### PR TITLE
Add curl --fail to notify when redeployment fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,4 +54,4 @@ jobs:
       install: sudo apt-get -y install curl
       script:
         - openssl aes-256-cbc -K $encrypted_49b37942e026_key -iv $encrypted_49b37942e026_iv -in cree-dictionary.key.enc -out cree-dictionary.key -d
-        - curl -XPOST -dsecret=$(sudo cat cree-dictionary.key) sapir.artsrn.ualberta.ca/redeploy/cree-dictionary
+        - curl --fail -XPOST -dsecret=$(sudo cat cree-dictionary.key) sapir.artsrn.ualberta.ca/redeploy/cree-dictionary


### PR DESCRIPTION
The `--fail` flag will give an error exit code when the server returns a 4xx, or 5xx error.

This will let us know if something is amiss during deployment. At least, theoretically!

e.g.,

```ssh
$ curl --fail sapir.artsrn.ualberta.ca/redeploy/cree-dictionary
curl: (22) The requested URL returned error: 405 Method Not Allowed
$ echo $?
22
$ curl sapir.artsrn.ualberta.ca/redeploy/cree-dictionary

Status: 405 Method Not Allowed
Invalid invocation. You must make a POST request with the secret.

    curl -XPOST -dsecret=XXXXXX sapir.artsrn.ualberta.ca/redeploy/cree-dictionary
$ echo $?
0
```