### PR TITLE
Change pixel font-size to ems.

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -890,6 +890,7 @@ a.menu-choice__label:active {
   font-size: var(--cite-text-font-size);
   font-style: normal;
   font-weight: var(--strong-font-weight);
+  vertical-align: middle;
 }
 
 /**

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -37,17 +37,17 @@
   --placeholder-text-color: #949494; /* The placeholder should be faint, but visible. */
 
   /* Font sizes */
-  --root-font-size:                 14px;
-  --branding-font-size:             24px; /* the title, e.g., "itwêwina" */
-  --branding-subtitle-font-size:    12px; /* the subtitle, e.g., "Plains Cree Dictionary" */
-  --definition-title-size:          28px;
-  --prominent-font-size:            24px; /* For text that should be prominent! */
-  --prose-heading-font-size:        18px;
-  --prose-section-title-font-size:  22px;
-  --search-result-font-size:        22px;
-  --footer-font-size:               12px;
-  --toggle-box-large-font-size:     16px;
-  --cite-text-font-size:            11px;
+  --root-font-size:                 1.00em;
+  --branding-font-size:             1.50em; /* the title, e.g., "itwêwina" */
+  --branding-subtitle-font-size:    0.75em; /* the subtitle, e.g., "Plains Cree Dictionary" */
+  --definition-title-size:          2.00em;
+  --prominent-font-size:            1.50em; /* For text that should be prominent! */
+  --prose-heading-font-size:        1.25em;
+  --prose-section-title-font-size:  1.33em;
+  --search-result-font-size:        1.33em;
+  --footer-font-size:               0.85em;
+  --toggle-box-large-font-size:     1.14em;
+  --cite-text-font-size:            0.50em;
   /* Font families */
   --heading-font-family: Raleway, Euphemia UCAS, sans-serif;
   --body-font-family: Open Sans, Euphemia UCAS, sans-serif;


### PR DESCRIPTION
According to some sources, pixel font-sizes are "inaccessible", since some browsers interpret them literally. Anecdotally, I think most browsers will allow you to scale pixels, but regardless, here I'm using an inherintly scalable unit (`em`) to explictly state that the font should scale with the users' preferences.