### PR TITLE
Add responsive CSS to reposition search based on desktop/mobile

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -15,7 +15,6 @@
 <body class="app">
   <a href="#start-of-content" tabindex="0" class="skip-to-content">Skip to content</a>
   {% include './components/header.html' %}
-  {% include './components/search.html' %}
 
 {% block content %}
 {% endblock %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -15,62 +15,7 @@
 <body class="app">
   <a href="#start-of-content" tabindex="0" class="skip-to-content">Skip to content</a>
   {% include './components/header.html' %}
-
-<nav class="search app__pane">
-    <form class="search__search-bar search-bar">
-      <label class="search-bar__label" for="search">Search</label>
-      <input id="search" class="search-bar__input" data-cy="search"
-             type="text" required name="q"
-             placeholder="Search in Cree or English"
-             autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false"
-             value="{{ query_string }}">
-      <button class="search-bar__button" type="submit">
-        <img src="{% static 'CreeDictionary/images/fa/search.svg' %}" alt="Search">
-      </button>
-    </form>
-    {% comment %}
-     TODO: Advanced search is disabled until the following issues are closed:
-     - https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/125
-     - https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/126
-    {% endcomment %}
-    <details style="display: none" class="search__advanced toggle-box toggle-box--large toggle-box--link-like">
-        <summary class="toggle-box__toggle">
-            Advanced search
-        </summary>
-        {# This HTML and the associated CSS is not ready yet :( #}
-        <div class="menu menu--wide toggle-box__menu">
-          <fieldset class="menu__category">
-            <legend class="menu__caption"> Dictionary Source</legend>
-            {# TODO: these sources must be generated from the database: #}
-            {# Blocked by: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/125 #}
-            <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
-              <div class="menu-choice__label"><h2> Include Cree : Words (<span class="cite-dict">CW</span>) </h2>
-                  <p class="reference"> Wolvengery, A. (2011). <i>Cree: Words.</i>
-                      Regina: University of Regina Press.
-                  </p></div>
-            </label>
-
-            <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
-              <div class="menu-choice__label">
-                <h2> Include Maskwacîs : Words (<span class="cite-dict">MD</span>)</h2>
-                <p class="reference"><i>Maskwacîs Dictionary of Cree
-                    Words/Nehiyaw Pîkiskweninisa.</i> (2009). Maskwacîs: Maskwachees
-                    Cultural College. </p>
-              </div>
-            </label>
-
-            <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
-              <div class="menu-choice__label"><h2> Include Alberta Elders' Cree Dictionary
-                 (<span class="cite-dict">EC</span>) </h2>
-                <p class="reference"> LeClaire, N., &amp; Cardinal, G. (2002).
-                    <i>Alberta Elders' Cree Dictionary/alperta ohci kehtehayak nehiyaw
-                        otwestamâkewasinahikan.</i> E. Waugh (Ed.). Edmonton: The
-                    University of Alberta Press.
-                </p></div>
-            </label></fieldset>
-        </div>
-    </details>
-</nav>
+  {% include './components/search.html' %}
 
 {% block content %}
 {% endblock %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/header.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/header.html
@@ -1,12 +1,12 @@
 <div class="top-bar app__header">
-  <header class="branding top-bar__heading "><a href="{% url 'cree-dictionary-index' %}">
+  <header class="branding top-bar__logo"><a href="{% url 'cree-dictionary-index' %}">
       <h1 class="branding__heading branding__title">
         <span lang="cr">itwêwina</span>
       </h1>
       <p class="branding__heading branding__subtitle">Plains Cree Dictionary</p>
   </a></header>
   {# TODO: The language and orthography selectors are not ready yet, so hide them: #}
-  <nav class="top-bar__nav" style="display: none">
+  <nav class="top-bar__nav">
     <details class="toggle-box toggle-box--with-menu">
       <summary id="language-selector__button" class="toggle-box__toggle" data-cy="language-selector"
                aria-haspopup="menu" role="button" tabindex="0"
@@ -19,5 +19,6 @@
       </div>
     </details>
   </nav>
+  {% include './search.html' %}
 </div>
 {# vim: set ft=htmldjango: et sw=t ts=2 sts=2 #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/header.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/header.html
@@ -6,7 +6,7 @@
       <p class="branding__heading branding__subtitle">Plains Cree Dictionary</p>
   </a></header>
   {# TODO: The language and orthography selectors are not ready yet, so hide them: #}
-  <nav class="top-bar__nav">
+  <nav class="top-bar__nav" style="visibility: hidden">
     <details class="toggle-box toggle-box--with-menu">
       <summary id="language-selector__button" class="toggle-box__toggle" data-cy="language-selector"
                aria-haspopup="menu" role="button" tabindex="0"

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
@@ -1,0 +1,57 @@
+{% load static %}
+<nav class="search app__pane">
+    <form class="search__search-bar search-bar">
+      <label class="search-bar__label" for="search">Search</label>
+      <input id="search" class="search-bar__input" data-cy="search"
+             type="text" required name="q"
+             placeholder="Search in Cree or English"
+             autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false"
+             value="{{ query_string }}">
+      <button class="search-bar__button" type="submit">
+        <img src="{% static 'CreeDictionary/images/fa/search.svg' %}" alt="Search">
+      </button>
+    </form>
+    {% comment %}
+     TODO: Advanced search is disabled until the following issues are closed:
+     - https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/125
+     - https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/126
+    {% endcomment %}
+    <details style="display: none" class="search__advanced toggle-box toggle-box--large toggle-box--link-like">
+        <summary class="toggle-box__toggle">
+            Advanced search
+        </summary>
+        {# This HTML and the associated CSS is not ready yet :( #}
+        <div class="menu menu--wide toggle-box__menu">
+          <fieldset class="menu__category">
+            <legend class="menu__caption"> Dictionary Source</legend>
+            {# TODO: these sources must be generated from the database: #}
+            {# Blocked by: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/125 #}
+            <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
+              <div class="menu-choice__label"><h2> Include Cree : Words (<span class="cite-dict">CW</span>) </h2>
+                  <p class="reference"> Wolvengery, A. (2011). <i>Cree: Words.</i>
+                      Regina: University of Regina Press.
+                  </p></div>
+            </label>
+
+            <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
+              <div class="menu-choice__label">
+                <h2> Include Maskwacîs : Words (<span class="cite-dict">MD</span>)</h2>
+                <p class="reference"><i>Maskwacîs Dictionary of Cree
+                    Words/Nehiyaw Pîkiskweninisa.</i> (2009). Maskwacîs: Maskwachees
+                    Cultural College. </p>
+              </div>
+            </label>
+
+            <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
+              <div class="menu-choice__label"><h2> Include Alberta Elders' Cree Dictionary
+                 (<span class="cite-dict">EC</span>) </h2>
+                <p class="reference"> LeClaire, N., &amp; Cardinal, G. (2002).
+                    <i>Alberta Elders' Cree Dictionary/alperta ohci kehtehayak nehiyaw
+                        otwestamâkewasinahikan.</i> E. Waugh (Ed.). Edmonton: The
+                    University of Alberta Press.
+                </p></div>
+            </label></fieldset>
+        </div>
+    </details>
+</nav>
+{# vim: set ft=htmldjango et sw=2 ts=2 sts=2: #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
@@ -12,46 +12,8 @@
     </button>
   </form>
   {% comment %}
-   TODO: Advanced search is disabled until the following issues are closed:
-   - https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/125
+   TODO: Advanced search cannot be implemented until the following issue is closed:
    - https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/126
   {% endcomment %}
-  <details style="display: none" class="search__advanced toggle-box toggle-box--large toggle-box--link-like">
-    <summary class="toggle-box__toggle">
-      Advanced search
-    </summary>
-    {# This HTML and the associated CSS is not ready yet :( #}
-    <div class="menu menu--wide toggle-box__menu">
-      <fieldset class="menu__category">
-        <legend class="menu__caption"> Dictionary Source</legend>
-        {# TODO: these sources must be generated from the database: #}
-        {# Blocked by: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/125 #}
-        <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
-          <div class="menu-choice__label"><h2> Include Cree : Words (<span class="cite-dict">CW</span>) </h2>
-            <p class="reference"> Wolvengery, A. (2011). <i>Cree: Words.</i>
-            Regina: University of Regina Press.
-            </p></div>
-        </label>
-
-        <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
-          <div class="menu-choice__label">
-            <h2> Include Maskwacîs : Words (<span class="cite-dict">MD</span>)</h2>
-            <p class="reference"><i>Maskwacîs Dictionary of Cree
-              Words/Nehiyaw Pîkiskweninisa.</i> (2009). Maskwacîs: Maskwachees
-            Cultural College. </p>
-          </div>
-        </label>
-
-        <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
-          <div class="menu-choice__label"><h2> Include Alberta Elders' Cree Dictionary
-              (<span class="cite-dict">EC</span>) </h2>
-            <p class="reference"> LeClaire, N., &amp; Cardinal, G. (2002).
-            <i>Alberta Elders' Cree Dictionary/alperta ohci kehtehayak nehiyaw
-              otwestamâkewasinahikan.</i> E. Waugh (Ed.). Edmonton: The
-            University of Alberta Press.
-            </p></div>
-        </label></fieldset>
-    </div>
-  </details>
 </nav>
 {# vim: set ft=htmldjango et sw=2 ts=2 sts=2: #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
@@ -1,6 +1,6 @@
 {% load static %}
 <nav class="search top-bar__search">
-  <form class="search__search-bar search-bar">
+  <form class="search-bar search__search-bar">
     <label class="search-bar__label" for="search">Search</label>
     <input id="search" class="search-bar__input" data-cy="search"
            type="text" required name="q"

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
@@ -1,5 +1,5 @@
 {% load static %}
-<nav class="search app__pane">
+<nav class="search app__pane--small-screen-only">
   <form class="search__search-bar search-bar">
     <label class="search-bar__label" for="search">Search</label>
     <input id="search" class="search-bar__input" data-cy="search"

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
@@ -1,5 +1,5 @@
 {% load static %}
-<nav class="search app__pane--small-screen-only">
+<nav class="search top-bar__search">
   <form class="search__search-bar search-bar">
     <label class="search-bar__label" for="search">Search</label>
     <input id="search" class="search-bar__input" data-cy="search"

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
@@ -1,57 +1,57 @@
 {% load static %}
 <nav class="search app__pane">
-    <form class="search__search-bar search-bar">
-      <label class="search-bar__label" for="search">Search</label>
-      <input id="search" class="search-bar__input" data-cy="search"
-             type="text" required name="q"
-             placeholder="Search in Cree or English"
-             autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false"
-             value="{{ query_string }}">
-      <button class="search-bar__button" type="submit">
-        <img src="{% static 'CreeDictionary/images/fa/search.svg' %}" alt="Search">
-      </button>
-    </form>
-    {% comment %}
-     TODO: Advanced search is disabled until the following issues are closed:
-     - https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/125
-     - https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/126
-    {% endcomment %}
-    <details style="display: none" class="search__advanced toggle-box toggle-box--large toggle-box--link-like">
-        <summary class="toggle-box__toggle">
-            Advanced search
-        </summary>
-        {# This HTML and the associated CSS is not ready yet :( #}
-        <div class="menu menu--wide toggle-box__menu">
-          <fieldset class="menu__category">
-            <legend class="menu__caption"> Dictionary Source</legend>
-            {# TODO: these sources must be generated from the database: #}
-            {# Blocked by: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/125 #}
-            <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
-              <div class="menu-choice__label"><h2> Include Cree : Words (<span class="cite-dict">CW</span>) </h2>
-                  <p class="reference"> Wolvengery, A. (2011). <i>Cree: Words.</i>
-                      Regina: University of Regina Press.
-                  </p></div>
-            </label>
+  <form class="search__search-bar search-bar">
+    <label class="search-bar__label" for="search">Search</label>
+    <input id="search" class="search-bar__input" data-cy="search"
+           type="text" required name="q"
+           placeholder="Search in Cree or English"
+           autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false"
+           value="{{ query_string }}">
+    <button class="search-bar__button" type="submit">
+      <img src="{% static 'CreeDictionary/images/fa/search.svg' %}" alt="Search">
+    </button>
+  </form>
+  {% comment %}
+   TODO: Advanced search is disabled until the following issues are closed:
+   - https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/125
+   - https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/126
+  {% endcomment %}
+  <details style="display: none" class="search__advanced toggle-box toggle-box--large toggle-box--link-like">
+    <summary class="toggle-box__toggle">
+      Advanced search
+    </summary>
+    {# This HTML and the associated CSS is not ready yet :( #}
+    <div class="menu menu--wide toggle-box__menu">
+      <fieldset class="menu__category">
+        <legend class="menu__caption"> Dictionary Source</legend>
+        {# TODO: these sources must be generated from the database: #}
+        {# Blocked by: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/125 #}
+        <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
+          <div class="menu-choice__label"><h2> Include Cree : Words (<span class="cite-dict">CW</span>) </h2>
+            <p class="reference"> Wolvengery, A. (2011). <i>Cree: Words.</i>
+            Regina: University of Regina Press.
+            </p></div>
+        </label>
 
-            <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
-              <div class="menu-choice__label">
-                <h2> Include Maskwacîs : Words (<span class="cite-dict">MD</span>)</h2>
-                <p class="reference"><i>Maskwacîs Dictionary of Cree
-                    Words/Nehiyaw Pîkiskweninisa.</i> (2009). Maskwacîs: Maskwachees
-                    Cultural College. </p>
-              </div>
-            </label>
+        <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
+          <div class="menu-choice__label">
+            <h2> Include Maskwacîs : Words (<span class="cite-dict">MD</span>)</h2>
+            <p class="reference"><i>Maskwacîs Dictionary of Cree
+              Words/Nehiyaw Pîkiskweninisa.</i> (2009). Maskwacîs: Maskwachees
+            Cultural College. </p>
+          </div>
+        </label>
 
-            <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
-              <div class="menu-choice__label"><h2> Include Alberta Elders' Cree Dictionary
-                 (<span class="cite-dict">EC</span>) </h2>
-                <p class="reference"> LeClaire, N., &amp; Cardinal, G. (2002).
-                    <i>Alberta Elders' Cree Dictionary/alperta ohci kehtehayak nehiyaw
-                        otwestamâkewasinahikan.</i> E. Waugh (Ed.). Edmonton: The
-                    University of Alberta Press.
-                </p></div>
-            </label></fieldset>
-        </div>
-    </details>
+        <label class="menu-choice"><input class="menu-choice__check" type="checkbox" name="lang" value="en" checked>
+          <div class="menu-choice__label"><h2> Include Alberta Elders' Cree Dictionary
+              (<span class="cite-dict">EC</span>) </h2>
+            <p class="reference"> LeClaire, N., &amp; Cardinal, G. (2002).
+            <i>Alberta Elders' Cree Dictionary/alperta ohci kehtehayak nehiyaw
+              otwestamâkewasinahikan.</i> E. Waugh (Ed.). Edmonton: The
+            University of Alberta Press.
+            </p></div>
+        </label></fieldset>
+    </div>
+  </details>
 </nav>
 {# vim: set ft=htmldjango et sw=2 ts=2 sts=2: #}

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -152,17 +152,17 @@ html {
   margin-right: var(--small-pad);
 }
 
+/**
+ * The top-bar collapses both the logo, the language picker, AND the search
+ * bar all into one long line.
+ */
 @media (min-width: 1366px) {
   .top-bar__title {
     flex: 0;
   }
 
   .top-bar__search {
-    flex: 1;
-    flex-basis: auto;
-
-    max-width: 800px; /* TODO: get from zeplin, make variable. */
-
+    flex: 1;  /* Make it WIDE! */
     order: 2;
   }
 
@@ -170,6 +170,8 @@ html {
     order: 3;
   }
 }
+
+
 
 /********************************* BRANDING *********************************/
 
@@ -252,8 +254,24 @@ html {
  * Contains the search bar.
  */
 .search__search-bar {
-  margin: var(--small-pad) auto;
+  margin: var(--gap) auto;
   max-width: calc(100vw - 2 * var(--page-gutter));
+}
+
+@media (min-width: 768px) {
+  .search__search-bar {
+    max-width: var(--tablet-search-bar-width);
+  }
+}
+
+/**
+ * The top-bar collapses both the logo, the language picker, AND the search
+ * bar all into one long line.
+ */
+@media (min-width: 1366px) {
+  .search__search-bar {
+    max-width: var(--desktop-search-bar-width);
+  }
 }
 
 /**

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -120,7 +120,7 @@ html {
   }
 }
 
-@media (min-width: 1366px) {
+@media (min-width: 960px) {
   .app__pane {
     width: var(--desktop-search-bar-width);
   }
@@ -174,7 +174,7 @@ html {
  * The top-bar collapses both the logo, the language picker, AND the search
  * bar all into one long line.
  */
-@media (min-width: 1366px) {
+@media (min-width: 960px) {
   .top-bar__logo {
     flex: 0 200px;
     order: 1;
@@ -288,7 +288,7 @@ html {
  * The top-bar collapses both the logo, the language picker, AND the search
  * bar all into one long line.
  */
-@media (min-width: 1366px) {
+@media (min-width: 960px) {
   .search__search-bar {
     max-width: var(--desktop-search-bar-width);
   }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -110,6 +110,22 @@ html {
   padding: 0 var(--page-gutter);
 }
 
+/* On larger screens, change to a margin: auto (to horizontally
+ * center)/max-width scheme. */
+@media (min-width: 768px) {
+  .app__pane {
+    padding: 0 0;
+    margin: auto;
+    width: var(--tablet-search-bar-width);
+  }
+}
+
+@media (min-width: 1366px) {
+  .app__pane {
+    width: var(--desktop-search-bar-width);
+  }
+}
+
 /********************************* TOP BAR *********************************/
 
 /**
@@ -121,16 +137,18 @@ html {
   display: flex;
   flex-flow: row wrap;
   justify-content: space-between;
+  align-content: flex-start;
   align-items: center;
 }
 
 /**
- * ELEMENT top-bar__title
+ * ELEMENT top-bar__logo
  *
  * Where the title (itwêwina -- Plains Cree Dictionary) goes.
  */
-.top-bar__title {
-  order: 1; /* The title should ALWAYS be the first thing! */
+.top-bar__logo {
+  order: -1; /* The title should ALWAYS be the first thing! */
+  align-self: flex-start;
 }
 
 /**
@@ -157,16 +175,18 @@ html {
  * bar all into one long line.
  */
 @media (min-width: 1366px) {
-  .top-bar__title {
-    flex: 0;
+  .top-bar__logo {
+    flex: 0 200px;
+    order: 1;
   }
 
   .top-bar__search {
-    flex: 1;  /* Make it WIDE! */
+    flex: 2 1 var(--desktop-search-bar-width);  /* Make it WIDE! */
     order: 2;
   }
 
   .top-bar__nav {
+    flex: 0 200px;
     order: 3;
   }
 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -141,8 +141,6 @@ html {
 .top-bar__search {
   /* Note: larger breakpoints mess around with the flex-basis: */
   flex: 1 100vw; /* Try to grow as much and have a basis of the full-width */
-
-  margin: var(--small-pad) var(--page-gutter);
 }
 
 /**
@@ -246,6 +244,17 @@ html {
  *
  * The main search panel.
  */
+
+
+/**
+ * BLOCK search__search-bar
+ *
+ * Contains the search bar.
+ */
+.search__search-bar {
+  margin: var(--small-pad) auto;
+  max-width: calc(100vw - 2 * var(--page-gutter));
+}
 
 /**
  * ELEMENT advanced search.

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -324,10 +324,10 @@ html {
 .search-bar__input {
   /* Display & Box Model */
   flex: 1;
-  min-width: 50vw; /* The max width actually was way too big before; make it relative to the viewport. */
   padding: var(--small-pad) 1rem;
-  padding-right: 1em;
+  padding-right: 1rem;
   border: solid 1px var(--search-border-color);
+  max-width: 100%;
 
   /* Text */
   text-overflow: ellipsis;

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -119,26 +119,41 @@ html {
  */
 .top-bar {
   display: flex;
-  flex-direction: row;
+  flex-flow: row wrap;
+  justify-content: space-between;
+  align-items: center;
 }
 
 /**
- * BLOCK top-bar
+ * ELEMENT top-bar__title
  *
- * Space within the top-bar in which site branding can appear.
+ * Where the title (itwêwina -- Plains Cree Dictionary) goes.
  */
-.top-bar__heading {
-  flex: 1;
-  padding: 0 var(--page-gutter);
-
-  background: transparent;  /* Fallback */
-  background: linear-gradient(to right, var(--header-stripe-color) 0%,
-                                        var(--header-stripe-color) var(--header-stripe-width),
-                                        rgba(0,0,0,0) var(--header-stripe-width),
-                                        rgba(0,0,0,0) 100%);
+.top-bar__title {
+  flex: 0;
+  order: 1;
 }
 
+/**
+ * ELEMENT top-bar__search
+ *
+ * Where the search bar.
+ */
+.top-bar__search {
+  flex: 1;
+  order: 2;
+
+  margin: 0 3rem;
+}
+
+/**
+ * ELEMENT top-bar__nav
+ *
+ * Where the navigation (e.g., language selector) goes.
+ */
 .top-bar__nav {
+  order: 3;
+
   margin-right: var(--small-pad);
 }
 
@@ -149,6 +164,15 @@ html {
  *
  * Displays the title and subtitle/tagline of the application.
  */
+.branding {
+  padding: 0 var(--page-gutter);
+
+  background: transparent;  /* Fallback */
+  background: linear-gradient(to right, var(--header-stripe-color) 0%,
+                                        var(--header-stripe-color) var(--header-stripe-width),
+                                        rgba(0,0,0,0) var(--header-stripe-width),
+                                        rgba(0,0,0,0) 100%);
+}
 
 /**
  * ELEMENT

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -130,8 +130,7 @@ html {
  * Where the title (itwêwina -- Plains Cree Dictionary) goes.
  */
 .top-bar__title {
-  flex: 0;
-  order: 1;
+  order: 1; /* The title should ALWAYS be the first thing! */
 }
 
 /**
@@ -140,10 +139,10 @@ html {
  * Where the search bar.
  */
 .top-bar__search {
-  flex: 1;
-  order: 2;
+  /* Note: larger breakpoints mess around with the flex-basis: */
+  flex: 1 100vw; /* Try to grow as much and have a basis of the full-width */
 
-  margin: 0 3rem;
+  margin: var(--small-pad) var(--page-gutter);
 }
 
 /**
@@ -152,9 +151,26 @@ html {
  * Where the navigation (e.g., language selector) goes.
  */
 .top-bar__nav {
-  order: 3;
-
   margin-right: var(--small-pad);
+}
+
+@media (min-width: 1366px) {
+  .top-bar__title {
+    flex: 0;
+  }
+
+  .top-bar__search {
+    flex: 1;
+    flex-basis: auto;
+
+    max-width: 800px; /* TODO: get from zeplin, make variable. */
+
+    order: 2;
+  }
+
+  .top-bar__nav {
+    order: 3;
+  }
 }
 
 /********************************* BRANDING *********************************/

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -10,8 +10,14 @@
   --header-stripe-width:        8px; /* Width of the "stripe" to the left of the title. */
   --small-pad:                  4px;
   --medium-gap:                 6px;
+  --gap:                        8px;
   --search-focus-outline-size:  4px; /* How far the focus colour should expand. */
   --footer-link-gap:           2rem; /* How far link sections in the footer should be. */
+
+  /* Responsive sizes */
+  /* Diane went to great effort to figure out these exact pixel values ¯\_(ツ)_/¯ */
+  --desktop-search-bar-width: 827px;
+  --tablet-search-bar-width:  561px;
 
   /* Colors */
   --app-bg-color:           #F7F7F7; /* Background color of the entire application. */


### PR DESCRIPTION
This adds a few responsive changes to the CSS. The most notable one is that the search bar collapses as part of the top bar when the width is sufficiently wide.

The second change is that the size of the content never goes beyond a certain width. That means that on super wide screens, the content remains in a tight, readable column.