### PR TITLE
Use CSS grid for layout instead of janky flexbox

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -134,11 +134,12 @@ html {
  * A bar that runs across the top of the application.
  */
 .top-bar {
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: space-between;
-  align-content: flex-start;
-  align-items: center;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto;
+  grid-template-areas:
+   "logo nav"
+   "search search";
 }
 
 /**
@@ -147,8 +148,7 @@ html {
  * Where the title (itwêwina -- Plains Cree Dictionary) goes.
  */
 .top-bar__logo {
-  order: -1; /* The title should ALWAYS be the first thing! */
-  align-self: flex-start;
+  grid-area: logo;
 }
 
 /**
@@ -157,8 +157,7 @@ html {
  * Where the search bar.
  */
 .top-bar__search {
-  /* Note: larger breakpoints mess around with the flex-basis: */
-  flex: 1 100vw; /* Try to grow as much and have a basis of the full-width */
+  grid-area: search;
 }
 
 /**
@@ -167,6 +166,10 @@ html {
  * Where the navigation (e.g., language selector) goes.
  */
 .top-bar__nav {
+  grid-area: nav;
+
+  text-align: right; /* So that it's flush with the right side of the page. */
+
   margin-right: var(--small-pad);
 }
 
@@ -175,19 +178,9 @@ html {
  * bar all into one long line.
  */
 @media (min-width: 960px) {
-  .top-bar__logo {
-    flex: 0 200px;
-    order: 1;
-  }
-
-  .top-bar__search {
-    flex: 2 1 var(--desktop-search-bar-width);  /* Make it WIDE! */
-    order: 2;
-  }
-
-  .top-bar__nav {
-    flex: 0 200px;
-    order: 3;
+  .top-bar {
+    grid-template-columns: 200px auto 200px;
+    grid-template-areas: "logo search nav";
   }
 }
 


### PR DESCRIPTION
This updates yesterday's HTML/CSS using grid instead of flexbox, because it is way easier and less janky to do the same with flexbox. It does this:

![Screen Recording 2019-12-12 at 12 48 38 PM 2019-12-12 12_52_27](https://user-images.githubusercontent.com/2294397/70744100-4e49d380-1cde-11ea-9fd7-bcb9545dd0e9.gif)

Responsive web design!
