### PR TITLE
Corrected, maintainable modified-lev-dist

### DIFF
--- a/CreeDictionary/tests/utils_tests/test_cree_lev_dist.py
+++ b/CreeDictionary/tests/utils_tests/test_cree_lev_dist.py
@@ -2,13 +2,15 @@ from string import ascii_letters
 
 import pytest
 from Levenshtein import distance
-from hypothesis import given, assume
+from hypothesis import given, assume, example
 from hypothesis.strategies import text
 
 from utils import get_modified_distance
 
 
 @given(text(alphabet=ascii_letters), text(alphabet=ascii_letters))
+@example("", "")
+@example("some_word", "")
 def test_get_distance_basic_lev(spelling: str, normal_form: str):
     """
     make sure the modified distance gets basic lev distance right

--- a/CreeDictionary/tests/utils_tests/test_cree_lev_dist.py
+++ b/CreeDictionary/tests/utils_tests/test_cree_lev_dist.py
@@ -32,10 +32,15 @@ def test_get_distance_basic_lev(spelling: str, normal_form: str):
 @pytest.mark.parametrize(
     ("spelling", "normal_form", "expected_distance"),
     (
-        ["a", "ab", 1],  # plain lev distance
-        ["a", "ah", 0.5],  # an 'h' in a rime is not added
-        ["ah", "a", 0.5],  # an 'h' in a rime is added
-        ["a", "ā", 0.5],  # a macron is not added
+        ["atâk", "atâhk", 0.5],  # an 'h' in a rime is not added
+        ["ah", "a", 0.5],  # an extra 'h' in a rime is added
+        ["atahk", "atâhk", 0.5],  # a circumflex is not added
+        ["atak", "atâhk", 1],  # both circumflex and h in a rime is not added
+        [
+            "adak",
+            "atâhk",
+            2,
+        ],  # both circumflex and h in a rime is not added and spelling error t -> d
     ),
 )
 def test_get_distance(spelling: str, normal_form: str, expected_distance):

--- a/CreeDictionary/tests/utils_tests/test_cree_lev_dist.py
+++ b/CreeDictionary/tests/utils_tests/test_cree_lev_dist.py
@@ -2,18 +2,10 @@ from string import ascii_letters
 
 import pytest
 from Levenshtein import distance
-from Levenshtein import editops
 from hypothesis import given, assume
 from hypothesis.strategies import text
 
 from utils import get_modified_distance
-from utils.cree_lev_dist import EditOp
-
-
-@given(text(alphabet=ascii_letters), text(alphabet=ascii_letters))
-def test_apply_ops(s: str, t: str):
-    ops = editops(s, t)
-    assert EditOp.apply_ops(ops, s, t) == t
 
 
 @given(text(alphabet=ascii_letters), text(alphabet=ascii_letters))
@@ -28,13 +20,13 @@ def test_get_distance_basic_lev(spelling: str, normal_form: str):
     )
 
 
-# todo: use real world spelling examples here
 @pytest.mark.parametrize(
     ("spelling", "normal_form", "expected_distance"),
     (
         ["atâk", "atâhk", 0.5],  # an 'h' in a rime is not added
         ["ah", "a", 0.5],  # an extra 'h' in a rime is added
         ["atahk", "atâhk", 0.5],  # a circumflex is not added
+        ["wâpamew", "wâpamêw", 0],  # a circumflex on 'e' is omitted, don't punish
         ["atak", "atâhk", 1],  # both circumflex and h in a rime is not added
         [
             "adak",

--- a/CreeDictionary/utils/cree_lev_dist.py
+++ b/CreeDictionary/utils/cree_lev_dist.py
@@ -16,12 +16,18 @@ def remove_cree_diacritics(input_str) -> str:
 
 
 def del_dist(string, i):
+    """
+    custom distance for deleting a character at index i from string
+    """
     if i > 0 and remove_cree_diacritics(string[i - 1]) in VOWELS and string[i] == "h":
         return 0.5
     return 1
 
 
 def sub_dist(string, new_char, i):
+    """
+    custom distance for substituting a character at index i for a new character
+    """
     if new_char == string[i]:
         return 0
     elif remove_cree_diacritics(string[i]) == remove_cree_diacritics(new_char):
@@ -34,6 +40,9 @@ def sub_dist(string, new_char, i):
 
 
 def ins_dist(string, char, i):
+    """
+    custom distance for inserting a character at index i
+    """
     if string == "":
         return 1
     elif (

--- a/CreeDictionary/utils/cree_lev_dist.py
+++ b/CreeDictionary/utils/cree_lev_dist.py
@@ -60,7 +60,9 @@ def get_modified_distance(spelling: str, normal_form: str) -> float:
 
     A substitution should have a distance of 1: e.g., ekwa vs. ikwa
 
-    A vowel lengths change incur a distance of ½
+    A vowel diacritics on {a i o} change incur a distance of ½
+
+    A vowel diacritics change on "e" should be treated as distance 0
 
     An addition or deletion of an 'h' in a rime should incur a distance of ½
 
@@ -138,8 +140,15 @@ def get_modified_distance(spelling: str, normal_form: str) -> float:
 
         if op_name == "replace":
             n_char = normal_form[n_index]
-            if remove_cree_diacritics(n_char) == remove_cree_diacritics(o_char):
-                dist += 0.5
+            stripped_n_char, stripped_o_char = (
+                remove_cree_diacritics(n_char),
+                remove_cree_diacritics(o_char),
+            )
+            if stripped_n_char == stripped_o_char:
+                if stripped_n_char == "e":
+                    pass
+                else:
+                    dist += 0.5
             else:
                 dist += 1
 

--- a/CreeDictionary/utils/cree_lev_dist.py
+++ b/CreeDictionary/utils/cree_lev_dist.py
@@ -17,7 +17,8 @@ def remove_cree_diacritics(input_str) -> str:
 
 def del_dist(string, i):
     """
-    custom distance for deleting a character at index i from string
+    custom distance for deleting a character at index i from string.
+    The string is guaranteed non-empty and i is not out of bound
     """
     if i > 0 and remove_cree_diacritics(string[i - 1]) in VOWELS and string[i] == "h":
         return 0.5
@@ -26,7 +27,8 @@ def del_dist(string, i):
 
 def sub_dist(string, new_char, i):
     """
-    custom distance for substituting a character at index i for a new character
+    custom distance for substituting a character at index i for a new character.
+    Note the string is guaranteed non-empty and i is not out-of-bound
     """
     if new_char == string[i]:
         return 0
@@ -41,12 +43,11 @@ def sub_dist(string, new_char, i):
 
 def ins_dist(string, char, i):
     """
-    custom distance for inserting a character at index i
+    custom distance for inserting a character at index i to a non-empty string
+    Note the string is guaranteed non-empty and  0 <= i <= len(string)
     """
-    if string == "":
-        return 1
-    elif (
-        remove_cree_diacritics(string[min(i - 1, len(string) - 1)]) in VOWELS
+    if (
+        remove_cree_diacritics(string[min(i, len(string)) - 1]) in VOWELS
         and char == "h"
     ):
         return 0.5

--- a/CreeDictionary/utils/cree_lev_dist.py
+++ b/CreeDictionary/utils/cree_lev_dist.py
@@ -1,17 +1,10 @@
-from enum import Enum
-from typing import List, Tuple, Optional, NamedTuple
-
-from attr import attrs
-from Levenshtein import editops
 import unicodedata
 
 VOWELS = {"a", "e", "i", "o"}
-CIRCUMFLEX_VOWELS = {"â", "ê", "î", "ô"}
-MACRON_VOWELS = {"ā", "ē", "ī", "ō"}
 
 
 def remove_cree_diacritics(input_str) -> str:
-    """    
+    """
     >>> remove_cree_diacritics('ā')
     'a'
     >>> remove_cree_diacritics('â')
@@ -22,32 +15,34 @@ def remove_cree_diacritics(input_str) -> str:
     return only_ascii
 
 
-class EditOp(NamedTuple):
-    op_name: str
-    source_index: int
-    """The original index of the character in the original string"""
-    target_index: int
-    """the index of the character in the target string"""
+def del_dist(string, i):
+    if i > 0 and remove_cree_diacritics(string[i - 1]) in VOWELS and string[i] == "h":
+        return 0.5
+    return 1
 
-    @staticmethod
-    def apply_ops(ops: List["EditOp"], s: str, t: str) -> str:
-        """This function exists to show how to interpret of EditOps obtained from `Levenshtein.editops()`"""
-        s_list = list(s)
-        insertion_buffers = ["" for _ in range(len(s) + 1)]
 
-        for op_name, s_i, t_i in ops:
-            if op_name == "insert":
-                insertion_buffers[s_i] += t[t_i]
-            elif op_name == "replace":
-                s_list[s_i] = t[t_i]
-            else:  # delete
-                s_list[s_i] = ""
+def sub_dist(string, new_char, i):
+    if new_char == string[i]:
+        return 0
+    elif remove_cree_diacritics(string[i]) == remove_cree_diacritics(new_char):
+        if remove_cree_diacritics(new_char) == "e":
+            return 0
+        else:
+            return 0.5
+    else:
+        return 1
 
-        result = ""
-        for a, b in zip([""] + s_list, insertion_buffers):
-            result += a + b
 
-        return result
+def ins_dist(string, char, i):
+    if string == "":
+        return 1
+    elif (
+        remove_cree_diacritics(string[min(i - 1, len(string) - 1)]) in VOWELS
+        and char == "h"
+    ):
+        return 0.5
+    else:
+        return 1
 
 
 def get_modified_distance(spelling: str, normal_form: str) -> float:
@@ -72,101 +67,22 @@ def get_modified_distance(spelling: str, normal_form: str) -> float:
     :param normal_form:
     :return: Our own metric of edit distance
     """
+    # see these slides for "weighted min edit distance"
+    # https://web.stanford.edu/class/cs124/lec/med.pdf
     spelling = spelling.lower()
     normal_form = normal_form.lower()
+    n, m = len(spelling), len(normal_form)
+    d = [[0] * (m + 1) for _ in range(n + 1)]
+    for i in range(1, n + 1):
+        d[i][0] = d[i - 1][0] + del_dist(spelling, i - 1)
+    for j in range(1, m + 1):
+        d[0][j] = d[0][j - 1] + ins_dist(normal_form, normal_form[j - 1], j - 1)
 
-    ops: List[EditOp] = editops(spelling, normal_form)
-    dist = 0.0
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            _del_dist = d[i - 1][j] + del_dist(spelling, i - 1)
+            _ins_dist = d[i][j - 1] + ins_dist(normal_form, normal_form[j - 1], j - 1)
+            _sub_dist = d[i - 1][j - 1] + sub_dist(spelling, normal_form[j - 1], i - 1)
+            d[i][j] = min((_del_dist, _ins_dist, _sub_dist))
 
-    spelling_list = list(spelling)
-    insertion_buffers = ["" for _ in range(len(spelling) + 1)]
-
-    for op_name, s_i, t_i in ops:
-        if op_name == "insert":
-            insertion_buffers[s_i] += normal_form[t_i]
-        elif op_name == "replace":
-            spelling_list[s_i] = normal_form[t_i]
-        else:  # delete
-            spelling_list[s_i] = ""
-
-    ops_and_new_indexes: List[
-        Tuple[str, int]
-    ] = []  # new indexes and what happened to original characters
-
-    result = ""
-    new_index_counter = 0
-    for i, (mutated_char, insertions) in enumerate(
-        zip([""] + spelling_list, insertion_buffers)
-    ):
-        if i > 0:
-            original_char = spelling[i - 1]
-            if mutated_char != "":
-                if mutated_char == original_char:
-                    ops_and_new_indexes.append(("equal", new_index_counter))
-                else:
-                    ops_and_new_indexes.append(("replace", new_index_counter))
-            else:
-                # a deletion happened
-                ops_and_new_indexes.append(("delete", new_index_counter))
-
-        if result != "":
-            last_char = result[-1]
-        else:
-            last_char = ""
-
-        result += mutated_char + insertions
-
-        for x, new_char in enumerate(insertions):
-            if x == 0:
-                if mutated_char != "":
-                    last_char = mutated_char
-            else:
-                last_char = insertions[x - 1]
-
-            if last_char != "":
-                # h in a rime is inserted
-                if remove_cree_diacritics(last_char) in VOWELS and new_char == "h":
-                    dist += 0.5
-                else:
-                    dist += 1
-            else:
-                # insertion at the beginning
-                dist += 1
-
-        new_index_counter += len(mutated_char + insertions)
-
-    for o_index, (op_name, n_index) in enumerate(ops_and_new_indexes):
-        o_char = spelling[o_index]
-
-        if op_name == "replace":
-            n_char = normal_form[n_index]
-            stripped_n_char, stripped_o_char = (
-                remove_cree_diacritics(n_char),
-                remove_cree_diacritics(o_char),
-            )
-            if stripped_n_char == stripped_o_char:
-                if stripped_n_char == "e":
-                    pass
-                else:
-                    dist += 0.5
-            else:
-                dist += 1
-
-        elif op_name == "delete":
-            if n_index == 0:
-                # deleted from the start
-                dist += 1
-            else:
-                new_char_in_front = normal_form[n_index - 1]
-                if o_char == "h":
-                    if remove_cree_diacritics(new_char_in_front) in VOWELS:
-                        # the h is in a rime
-                        dist += 0.5
-                    else:
-                        dist += 1
-                else:
-                    dist += 1
-        else:  # equal
-            pass
-
-    return dist
+    return d[-1][-1]

--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ paramiko = "~=2.6"
 pysnooper = "*"
 gitdir = "*"
 tqdm = "~=4.40"
+python-levenshtein = "*"
 
 [packages]
 colorama = "~=0.4"
@@ -31,7 +32,6 @@ typing-extensions = "~=3.7"
 attrs = "~=19.1"
 django-js-reverse = "~=0.9"
 fst-lookup = "*"
-python-levenshtein = "*"
 
 [scripts]
 # look stuff up

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9dfe4d2d234e112b801c8da5aabeec7f6988fa8ec4ee967554a3716bcff3b181"
+            "sha256": "dbe333739e76bc8b243741d812e15e3436dbd09e48199357a13d342ab487728e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -84,11 +84,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:a4ad4f6f9c6a4b7af7e2deec8d0cbff28501852e5010d6c2dc695d3d1fae7ca0",
-                "sha256:fa98ec9cc9bf5d72a08ebf3654a9452e761fbb8566e3f80de199cbc15477e891"
+                "sha256:662a1ff78792e3fd77f16f71b1f31149489434de4b62a74895bd5d6534e635a5",
+                "sha256:687c37153486cf26c3fdcbdd177ef16de38dc3463f094b5f9c9955d91f277b14"
             ],
             "index": "pypi",
-            "version": "==2.2.8"
+            "version": "==2.2.9"
         },
         "django-js-reverse": {
             "hashes": [
@@ -112,13 +112,6 @@
             ],
             "index": "pypi",
             "version": "==1.2.10"
-        },
-        "python-levenshtein": {
-            "hashes": [
-                "sha256:033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1"
-            ],
-            "index": "pypi",
-            "version": "==0.12.0"
         },
         "pytz": {
             "hashes": [
@@ -348,29 +341,29 @@
         },
         "django": {
             "hashes": [
-                "sha256:a4ad4f6f9c6a4b7af7e2deec8d0cbff28501852e5010d6c2dc695d3d1fae7ca0",
-                "sha256:fa98ec9cc9bf5d72a08ebf3654a9452e761fbb8566e3f80de199cbc15477e891"
+                "sha256:662a1ff78792e3fd77f16f71b1f31149489434de4b62a74895bd5d6534e635a5",
+                "sha256:687c37153486cf26c3fdcbdd177ef16de38dc3463f094b5f9c9955d91f277b14"
             ],
             "index": "pypi",
-            "version": "==2.2.8"
+            "version": "==2.2.9"
         },
         "gitdir": {
             "hashes": [
-                "sha256:f1b78f077a0d0717592d5c6088266698228b2d3b02c5833b73185defea274465"
+                "sha256:269f4f940a28c21a6cb79a5ff11e06067222309f79b0abd5ac7619af05f935a0"
             ],
             "index": "pypi",
-            "version": "==1.1.6"
+            "version": "==1.1.8"
         },
         "hypothesis": {
             "extras": [
                 "django"
             ],
             "hashes": [
-                "sha256:24d4b7d455308e205e0be1e597bbaceb7acf3f2712971c59c2e93ee8ebffff55",
-                "sha256:32b411baa28620fd0d8dfe755e021871f4310bd99bad31a4cb2a36f0defece77"
+                "sha256:554a91e9cde0635fcf6a3ebe995a182b97717bf374b9d649ddba57717509745a",
+                "sha256:9bf5b44ac4c6d9ec81f4128ed17ef9754a5a975ebbd0383389d7c1c001d53ef1"
             ],
             "index": "pypi",
-            "version": "==4.53.3"
+            "version": "==4.56.3"
         },
         "idna": {
             "hashes": [
@@ -396,23 +389,23 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:02d9bdd3398b636723ecb6c5cfe9773025a9ab7f34612c1cde5c7f2292e2d768",
-                "sha256:088f758a50af31cf8b42688118077292370c90c89232c783ba7979f39ea16646",
-                "sha256:28e9fbc96d13397a7ddb7fad7b14f373f91b5cff538e0772e77c270468df083c",
-                "sha256:30e123b24931f02c5d99307406658ac8f9cd6746f0d45a3dcac2fe5fbdd60939",
-                "sha256:3294821b5840d51a3cd7a2bb63b40fc3f901f6a3cfb3c6046570749c4c7ef279",
-                "sha256:41696a7d912ce16fdc7c141d87e8db5144d4be664a0c699a2b417d393994b0c2",
-                "sha256:4f42675fa278f3913340bb8c3371d191319704437758d7c4a8440346c293ecb2",
-                "sha256:54d205ccce6ed930a8a2ccf48404896d456e8b87812e491cb907a355b1a9c640",
-                "sha256:6992133c95a2847d309b4b0c899d7054adc60481df6f6b52bb7dee3d5fd157f7",
-                "sha256:6ecbd0e8e371333027abca0922b0c2c632a5b4739a0c61ffbd0733391e39144c",
-                "sha256:83fa87f556e60782c0fc3df1b37b7b4a840314ba1ac27f3e1a1e10cb37c89c17",
-                "sha256:c87ac7233c629f305602f563db07f5221950fe34fe30af072ac838fa85395f78",
-                "sha256:de9ec8dba773b78c49e7bec9a35c9b6fc5235682ad1fc2105752ae7c22f4b931",
-                "sha256:f385a0accf353ca1bca4bbf473b9d83ed18d923fdb809d3a70a385da23e25b6a"
+                "sha256:0a9a45157e532da06fe56adcfef8a74629566b607fa2c1ac0122d1ff995c748a",
+                "sha256:2c35cae79ceb20d47facfad51f952df16c2ae9f45db6cb38405a3da1cf8fc0a7",
+                "sha256:4b9365ade157794cef9685791032521233729cb00ce76b0ddc78749abea463d2",
+                "sha256:53ea810ae3f83f9c9b452582261ea859828a9ed666f2e1ca840300b69322c474",
+                "sha256:634aef60b4ff0f650d3e59d4374626ca6153fcaff96ec075b215b568e6ee3cb0",
+                "sha256:7e396ce53cacd5596ff6d191b47ab0ea18f8e0ec04e15d69728d530e86d4c217",
+                "sha256:7eadc91af8270455e0d73565b8964da1642fe226665dd5c9560067cd64d56749",
+                "sha256:7f672d02fffcbace4db2b05369142e0506cdcde20cea0e07c7c2171c4fd11dd6",
+                "sha256:85baab8d74ec601e86134afe2bcccd87820f79d2f8d5798c889507d1088287bf",
+                "sha256:87c556fb85d709dacd4b4cb6167eecc5bbb4f0a9864b69136a0d4640fdc76a36",
+                "sha256:a6bd44efee4dc8c3324c13785a9dc3519b3ee3a92cada42d2b57762b7053b49b",
+                "sha256:c6d27bd20c3ba60d5b02f20bd28e20091d6286a699174dfad515636cb09b5a72",
+                "sha256:e2bb577d10d09a2d8822a042a23b8d62bc3b269667c9eb8e60a6edfa000211b1",
+                "sha256:f97a605d7c8bc2c6d1172c2f0d5a65b24142e11a58de689046e62c2d632ca8c1"
             ],
             "markers": "python_version >= '3.5' and python_version < '3.8'",
-            "version": "==0.750"
+            "version": "==0.761"
         },
         "mypy-extensions": {
             "hashes": [
@@ -543,6 +536,13 @@
             "index": "pypi",
             "version": "==0.4.2"
         },
+        "python-levenshtein": {
+            "hashes": [
+                "sha256:033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1"
+            ],
+            "index": "pypi",
+            "version": "==0.12.0"
+        },
         "pytz": {
             "hashes": [
                 "sha256:26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32",
@@ -553,19 +553,29 @@
         },
         "regex": {
             "hashes": [
-                "sha256:3dbd8333fd2ebd50977ac8747385a73aa1f546eb6b16fcd83d274470fe11f243",
-                "sha256:40b7d1291a56897927e08bb973f8c186c2feb14c7f708bfe7aaee09483e85a20",
-                "sha256:719978a9145d59fc78509ea1d1bb74243f93583ef2a34dcc5623cf8118ae9726",
-                "sha256:75cf3796f89f75f83207a5c6a6e14eaf57e0369ef0ffff8e22bf36bbcfa0f1de",
-                "sha256:77396cf80be8b2a35db863cca4c1a902d88ceeb183adab328b81184e71a5eafe",
-                "sha256:77a3799152951d6d14ae5720ca162c97c64f85d4755da585418eac216b736cad",
-                "sha256:91235c98283d2bddf1a588f0fbc2da8afa37959294bbd18b76297bdf316ba4d6",
-                "sha256:aaffd68c4c1ed891366d5c390081f4bf6337595e76a157baf453603d8e53fbcb",
-                "sha256:ad9e3c7260809c0d1ded100269f78ea0217c0704f1eaaf40a382008461848b45",
-                "sha256:c203c9ee755e9656d0af8fab82754d5a664ebaf707b3f883c7eff6a3dd5151cf",
-                "sha256:e865bc508e316a3a09d36c8621596e6599a203bc54f1cd41020a127ccdac468a"
+                "sha256:032fdcc03406e1a6485ec09b826eac78732943840c4b29e503b789716f051d8d",
+                "sha256:0e6cf1e747f383f52a0964452658c04300a9a01e8a89c55ea22813931b580aa8",
+                "sha256:106e25a841921d8259dcef2a42786caae35bc750fb996f830065b3dfaa67b77e",
+                "sha256:1768cf42a78a11dae63152685e7a1d90af7a8d71d2d4f6d2387edea53a9e0588",
+                "sha256:27d1bd20d334f50b7ef078eba0f0756a640fd25f5f1708d3b5bed18a5d6bced9",
+                "sha256:29b20f66f2e044aafba86ecf10a84e611b4667643c42baa004247f5dfef4f90b",
+                "sha256:4850c78b53acf664a6578bba0e9ebeaf2807bb476c14ec7e0f936f2015133cae",
+                "sha256:57eacd38a5ec40ed7b19a968a9d01c0d977bda55664210be713e750dd7b33540",
+                "sha256:724eb24b92fc5fdc1501a1b4df44a68b9c1dda171c8ef8736799e903fb100f63",
+                "sha256:77ae8d926f38700432807ba293d768ba9e7652df0cbe76df2843b12f80f68885",
+                "sha256:78b3712ec529b2a71731fbb10b907b54d9c53a17ca589b42a578bc1e9a2c82ea",
+                "sha256:7bbbdbada3078dc360d4692a9b28479f569db7fc7f304b668787afc9feb38ec8",
+                "sha256:8d9ef7f6c403e35e73b7fc3cde9f6decdc43b1cb2ff8d058c53b9084bfcb553e",
+                "sha256:a83049eb717ae828ced9cf607845929efcb086a001fc8af93ff15c50012a5716",
+                "sha256:adc35d38952e688535980ae2109cad3a109520033642e759f987cf47fe278aa1",
+                "sha256:c29a77ad4463f71a506515d9ec3a899ed026b4b015bf43245c919ff36275444b",
+                "sha256:cfd31b3300fefa5eecb2fe596c6dee1b91b3a05ece9d5cfd2631afebf6c6fadd",
+                "sha256:d3ee0b035816e0520fac928de31b6572106f0d75597f6fa3206969a02baba06f",
+                "sha256:d508875793efdf6bab3d47850df8f40d4040ae9928d9d80864c1768d6aeaf8e3",
+                "sha256:ef0b828a7e22e58e06a1cceddba7b4665c6af8afeb22a0d8083001330572c147",
+                "sha256:faad39fdbe2c2ccda9846cd21581063086330efafa47d87afea4073a08128656"
             ],
-            "version": "==2019.12.9"
+            "version": "==2019.12.20"
         },
         "requests": {
             "hashes": [
@@ -588,6 +598,13 @@
             ],
             "index": "pypi",
             "version": "==2.0.1"
+        },
+        "sortedcontainers": {
+            "hashes": [
+                "sha256:974e9a32f56b17c1bac2aebd9dcf197f3eb9cd30553c5852a3187ad162e1a03a",
+                "sha256:d9e96492dd51fae31e60837736b38fe42a187b5404c16606ff7ee7cd582d4c60"
+            ],
+            "version": "==2.1.0"
         },
         "sqlparse": {
             "hashes": [
@@ -617,11 +634,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:7543892c59720e36e4212180274d8f58dde36803bc1f6370fd09afa20b8f5892",
-                "sha256:f0ab01cf3ae5673d18f918700c0165e5fad0f26b5ebe4b34f62ead92686b5340"
+                "sha256:166a82cdea964ae45528e0cc89436255ff2be73dc848bdf239f13c501cae5dc7",
+                "sha256:9036904496bd2afacf836a6f206c5a766ce11d3e9319d54a4e794c0f34b111dc"
             ],
             "index": "pypi",
-            "version": "==4.40.2"
+            "version": "==4.41.0"
         },
         "typed-ast": {
             "hashes": [


### PR DESCRIPTION
`cree_lev_dist.py` is now corrected and rewritten.
The previous version would calculate wrong distance in some of the new test cases.

Also It's now super maintainable. @eddieantonio you should be able to understand and edit it in munites.
The "custom distance" part is split to three functions: `ins_dist` `sub_dist`, and `del_dist`, in which further rules can be added very easily to further customize.