### PR TITLE
Changed occurence of "Normatized" to "standardized"

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/cree-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/cree-entries.html
@@ -2,7 +2,7 @@
 
 {% load inflection_extras %}
 
-{% for analysis, normatized_cree, lemma_wordform in cree_results %}
+{% for analysis, standardized_cree, lemma_wordform in cree_results %}
 <li class="search-results__result" data-cy="search-results">
   <article class="definition box box--rounded" data-cy="search-result">
     <header class="definition__header">
@@ -16,7 +16,7 @@
               {# data- attributes are supported in HTML5 not in XHTML #}
               <span lang="cr">{{ lemma_wordform.text }}</span></a>
           {% else %}
-            <span lang="cr">{{ normatized_cree }}</span>
+            <span lang="cr">{{ standardized_cree }}</span>
           {% endif %}
 
               <span class="definition-title__pos">({{ lemma_wordform|presentational_pos }})</span>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/english-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/english-entries.html
@@ -2,7 +2,7 @@
 
 {% load inflection_extras %}
 
-{% for matched_english, normatized_cree, lemma_wordform in english_results %}
+{% for matched_english, standardized_cree, lemma_wordform in english_results %}
 <li class="search-results__result" data-cy="search-results">
   <article class="definition box box--rounded" data-cy="search-result">
     <header class="definition__header">
@@ -16,7 +16,7 @@
               {# data- attributes are supported in HTML5 not in XHTML #}
               <span lang="cr">{{ lemma_wordform.text }}</span></a>
           {% else %}
-              <span lang="cr">{{ normatized_cree }}</span>
+              <span lang="cr">{{ standardized_cree }}</span>
           {% endif %}
         </dfn>
 
@@ -25,7 +25,7 @@
     </header>
 
       {# Show the matched lemma (when this is NOT a lemma. #}
-      {% if normatized_cree != lemma_wordform.text %}
+      {% if standardized_cree != lemma_wordform.text %}
       <p class="definition-title__reference-to-lemma" data-cy="reference-to-lemma">
         Form of
         {# TODO: this link should go to the lemma search result, further down the page #}


### PR DESCRIPTION
What **are** English words:

- Normal
- Normalize
- Normative

What are **not**:
- Normatize 
- Normatized

![Screenshot from 2020-01-16 16-26-51](https://user-images.githubusercontent.com/44753941/72571513-0c7ff000-387d-11ea-9f29-37026581e259.png)


We do have a "normative_generator", I guess in that sense, we can say "normatize" means to "make some word normative". But I hate the fact that it's not in the dictionary. And even #100 uses the word "standardized" instead of "normatized" in the title. So here's me spending 10 minutes change all occurence of "normatize/normatized" to "standardize/standardized"