### PR TITLE
Preverb breakdown popups, popup responsiveness

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -21,15 +21,22 @@
                         {% endif %}
                         <span class="definition-title__pos">({{ result.lemma_wordform|presentational_pos }})</span>
                         {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
-                            <div class="definition-title__tooltip">
-                                <img class="definition-title__question-mark"
-                                     src="{% static 'CreeDictionary/images/fa/question-circle-solid.svg' %}"
-                                     alt="linguistic breakdown" data-cy="question-mark">
-                                <span class="definition-title__tooltip-text"
-                                      data-cy="linguistic-breakdown">{% if result.linguistic_breakdown_head %}
+
+
+                            <div tabindex="0" class="definition-title__tooltip-icon" aria-describedby="tooltip">
+                                <img
+                                        src="{% static 'CreeDictionary/images/fa/question-circle-solid.svg' %}"
+                                        alt="linguistic breakdown" data-cy="question-mark">
+                            </div>
+
+
+                            <div class="tooltip" role="tooltip">
+                                <span
+                                        data-cy="linguistic-breakdown">{% if result.linguistic_breakdown_head %}
                                     {{ result.linguistic_breakdown_head|join:" + " }}
                                     + {% endif %}
                                     <strong>{{ result.lemma_wordform.text }}</strong> + {{ result.linguistic_breakdown_tail|join:" + " }}</span>
+                                <div class="arrow" data-popper-arrow></div>
                             </div>
                         {% endif %}
                     </dfn>
@@ -59,12 +66,34 @@
             </ol>
 
             {# show preverb breakdown #}
-            <ol class="">
-                {% for preverb_text, optional_id in result.preverbs %}
-                    <li class="">
-                        <p>Preverb: {% if optional_id %}
-                            <a href="{% url 'cree-dictionary-index-with-lemma' optional_id %}">{{ preverb_text }}</a>{% else %}
-                            {{ preverb_text }}{% endif %}</p>
+            <ol class="preverb-breakdown">
+                {% for preverb in result.preverbs %}
+                    <li>
+                        <span>Preverb: {% if preverb.id %}
+                            <a href="{% url 'cree-dictionary-index-with-lemma' preverb.id %}">{{ preverb.text }}</a>{% else %}
+                            {{ preverb.text }}{% endif %}
+                        </span>
+
+                        {% if preverb.id %} {# we know the preverb in the database #}
+
+
+
+                            <div tabindex="0" class="preverb-breakdown__tooltip-icon" aria-describedby="tooltip">
+
+
+                                <img
+                                        src="{% static 'CreeDictionary/images/fa/question-circle-solid.svg' %}"
+                                        alt="preverb breakdown" data-cy="preverb-question-mark">
+                            </div>
+
+                            <div class="tooltip" role="tooltip">
+                                {% for definition in preverb.definitions %}
+                                    <p class="preverb-breakdown__preverb-definition">{{ definition }}</p>
+                                {% endfor %}
+                                <div class="arrow" data-popper-arrow></div>
+                            </div>
+
+                        {% endif %}
                     </li>
                 {% endfor %}
             </ol>

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -113,6 +113,17 @@ def test_search_for_english() -> None:
 
 
 @pytest.mark.django_db
+def test_search_for_pronoun() -> None:
+    """
+    Search for a common pronoun "ôma". Make sure "oma" returns at least one
+    result that says "ôma"
+    """
+
+    search_results = Wordform.search("oma")
+    assert "ôma" in {res.matched_cree for res in search_results}
+
+
+@pytest.mark.django_db
 def test_search_for_stored_non_lemma():
     """
     A "stored non-lemma" is a wordform in the database that is NOT a lemma.

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,11 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@popperjs/core": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.0.5.tgz",
+      "integrity": "sha512-YOV1TitTNzJDXe/14sDJO/M/aL12Jhind0EkQRnqTX2167fqJsAICJfi0vsDdapPI1WaYsheyYYgy6PO02Nqqg=="
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -2200,7 +2205,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2221,12 +2227,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2241,17 +2249,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2368,7 +2379,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2380,6 +2392,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2394,6 +2407,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2401,12 +2415,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2425,6 +2441,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2505,7 +2522,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2517,6 +2535,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2602,7 +2621,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2638,6 +2658,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2657,6 +2678,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2700,12 +2722,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "wait-on": "^3.3.0"
   },
   "dependencies": {
+    "@popperjs/core": "^2.0.5",
     "jquery": "^3.4.1"
   }
 }

--- a/src/css/_tooltip.css
+++ b/src/css/_tooltip.css
@@ -1,0 +1,55 @@
+/* adapted from https://popper.js.org/docs/v2/tutorial/ */
+
+/* how to use: Create `icon` element and `popup` element in html
+
+`popup` needs to be the direct next sibling of `icon` and has class tooltip
+
+.tooltip class in this file decides how the popup looks like
+
+tooltip.js attaches all the event handlers
+
+*/
+
+.tooltip {
+    background: #333;
+    color: white;
+    font-weight: bold;
+    padding: 4px 8px;
+    font-size: 13px;
+    border-radius: 4px;
+    display: none;
+}
+
+.tooltip[data-show] {
+    display: block;
+}
+
+.arrow,
+.arrow::before {
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    z-index: -1;
+}
+
+.arrow::before {
+    content: '';
+    transform: rotate(45deg);
+    background: #333;
+}
+
+.tooltip[data-popper-placement^='top'] > .arrow {
+    bottom: -4px;
+}
+
+.tooltip[data-popper-placement^='bottom'] > .arrow {
+    top: -4px;
+}
+
+.tooltip[data-popper-placement^='left'] > .arrow {
+    right: -4px;
+}
+
+.tooltip[data-popper-placement^='right'] > .arrow {
+    left: -4px;
+}

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -2,6 +2,7 @@
 
 @import "./vendor/normalize.css";
 @import "./variables.css";
+@import "./_tooltip.css";
 
 /**
  * Preliminary styles for the application.
@@ -436,39 +437,24 @@ html {
   font-weight: normal;
 }
 
-.definition-title__question-mark{
-  width: calc(var(--definition-title-size) / 2);
+.definition-title__tooltip-icon{
+  display: inline;
+  position: relative;
+}
+
+
+.definition-title__tooltip-icon > img {
+  width: var(--tooltip-icon-size);
+
   /* vertically center the question mark*/
   position: absolute;
   top:0;
   bottom: 0;
   margin: auto;
   /* end vertical centering */
+
   left:0.2em;  /* space out the question mark */
-  filter: var(--blue-filter);
-}
-
-.definition-title__tooltip{
-  display: inline;
-  position: relative;
-}
-
-.definition-title__tooltip-text{
-  display: none;
-  white-space: nowrap;
-  background-color: black;
-  color: #fff;
-  text-align: center;
-  border-radius: 6px;
-  padding: 5px 10px;
-  position: absolute;
-  z-index: 1;
-  top: 100%;
-  left: 50%;
-}
-
-.definition-title__question-mark:hover + .definition-title__tooltip-text {
-  display: block;
+  filter: var(--blue-filter); /* blue color */
 }
 
 .definition-title__reference-to-lemma{
@@ -499,6 +485,32 @@ html {
   /* Text */
   font-size: var(--search-result-font-size);
 }
+
+.preverb-breakdown {
+  padding: 0;
+  list-style: none;
+  font-size: var(--preverb-breakdown-size);
+}
+
+.preverb-breakdown__tooltip-icon {
+  display: inline;
+  position: relative;
+}
+.preverb-breakdown__tooltip-icon > img {
+  width: var(--tooltip-icon-size);
+
+  /* vertically center the question mark*/
+  position: absolute;
+  top:0;
+  bottom: 0;
+  margin: auto;
+  /* end vertical centering */
+
+  left:0.2em;  /* space out the question mark */
+  filter: var(--blue-filter); /* blue color */
+}
+
+
 
 /********************************* PARADIGM *********************************/
 

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -51,7 +51,9 @@
   --branding-font-size:             1.50em; /* the title, e.g., "itwêwina" */
   --branding-subtitle-font-size:    0.75em; /* the subtitle, e.g., "Plains Cree Dictionary" */
   --definition-title-size:          2.00em;
-  --reference-to-lemma-size:        1.5em;
+  --tooltip-icon-size:              2rem; /* size of the question mark or the exclamation mark. Kept the same across the app */
+  --reference-to-lemma-size:        1.50em;
+  --preverb-breakdown-size:         1.50em;
   --prominent-font-size:            1.50em; /* For text that should be prominent! */
   --prose-heading-font-size:        1.25em;
   --prose-section-title-font-size:  1.33em;

--- a/src/index.js
+++ b/src/index.js
@@ -142,11 +142,12 @@ function loadResults($input) {
           })
 
 
-
+          // attach handlers for tooltip icon at preverb breakdown
           $searchResultList.find('.definition-title__tooltip-icon').each(function (){
             createTooltip($(this), $(this).next('.tooltip'))
           })
 
+          // attach handlers for tooltip icon at preverb breakdown
           $searchResultList.find('.preverb-breakdown__tooltip-icon').each(function (){
             createTooltip($(this), $(this).next('.tooltip'))
           })

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import $ from 'jquery'
 // Process CSS with PostCSS automatically. See rollup.config.js for more
 // details.
 import './css/styles.css';
+import {createTooltip} from "./tooltip";
 
 /**
  * request server-end rendered paradigm and plunk it in place
@@ -139,6 +140,17 @@ function loadResults($input) {
           $searchResultList.find('.definition-title__link').on('click', function () {
             loadParadigm($(this).data('lemma-id'))
           })
+
+
+
+          $searchResultList.find('.definition-title__tooltip-icon').each(function (){
+            createTooltip($(this), $(this).next('.tooltip'))
+          })
+
+          $searchResultList.find('.preverb-breakdown__tooltip-icon').each(function (){
+            createTooltip($(this), $(this).next('.tooltip'))
+          })
+
 
         } else { // changed. Do nothing
         }

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -1,0 +1,52 @@
+// adapted from poppers.js tutorial https://popper.js.org/docs/v2/tutorial/
+import {createPopper} from "@popperjs/core/dist/esm/popper";
+
+
+let popperInstance = null
+
+function create(icon, popup) {
+  popperInstance = createPopper(icon.get(0), popup.get(0), {
+    modifiers: [
+      {
+        name: 'offset',
+        options: {
+          offset: [0, 8],
+        },
+      },
+    ],
+  })
+}
+
+function destroy() {
+  if (popperInstance) {
+    popperInstance.destroy()
+    popperInstance = null
+  }
+}
+
+const showEvents = ['mouseenter', 'focus']
+const hideEvents = ['mouseleave', 'blur']
+
+/**
+ * prepare the popup and the icon. Attach relevant handlers
+ *
+ * @param icon {jQuery}: icon that triggers the popup on hover/click/focus
+ * @param popup {jQuery}: the popup that shows up
+ */
+export function createTooltip(icon, popup) {
+  console.log(icon)
+  showEvents.forEach(event => {
+    icon.on(event, () => {
+      popup.attr('data-show', '')
+      create(icon, popup)
+    })
+  })
+
+  hideEvents.forEach(event => {
+    icon.on(event, () => {
+      popup.removeAttr('data-show')
+      destroy()
+    })
+  })
+}
+


### PR DESCRIPTION
# Splendid

- preverbs get tooltips now

![Screenshot from 2020-02-08 04-41-44](https://user-images.githubusercontent.com/44753941/74084574-ad516d80-4a2d-11ea-95d0-ca84faa38ead.png)

- popups are intelligent now

    They wrap. They adapt, they don't do crap.

![Screenshot from 2020-02-08 04-41-37](https://user-images.githubusercontent.com/44753941/74084618-028d7f00-4a2e-11ea-93c6-b81c8cddc1c3.png)


@kobexamoh also I'm not trying to steal yo job. I worked on preverb breakdown and found `poppers.js` is easily adapted to all other tooltips. You can really work futher based on the current CSS! 
