### PR TITLE
Server side rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ DatabaseManager.log*
 *.log
 local_settings.py
 db.sqlite3
+db.sqlite3.bak
 *.sqlite3-journal
 
 # pyenv

--- a/.idea/dictionaries/matt.xml
+++ b/.idea/dictionaries/matt.xml
@@ -16,6 +16,7 @@
       <w>mîpit</w>
       <w>nehiyawewin</w>
       <w>nipiy</w>
+      <w>nitawi</w>
       <w>niya</w>
       <w>normatized</w>
       <w>nîpin</w>

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -449,7 +449,7 @@ class Wordform(models.Model):
         if " " not in user_query:  # a whole word
 
             # this requires database to be changed as currently EnglishKeyword are associated with lemmas
-            lemma_ids = EnglishKeyword.objects.filter(text__iexact=user_query).values(
+            lemma_ids = EnglishKeyword.objects.filter(text__exact=user_query).values(
                 "lemma__id"
             )
             for wordform in Wordform.objects.filter(id__in=lemma_ids, as_is=False):

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -1,5 +1,6 @@
 import logging
 import unicodedata
+from collections import defaultdict
 from functools import cmp_to_key, partial
 from typing import (
     Any,
@@ -72,34 +73,6 @@ def replace_user_friendly_tags(fst_tags: List[FSTTag]) -> List[Label]:
 WordformID = NewType("WordformID", int)  # the id of an wordform object in the database
 
 
-def fetch_preverbs(user_query: str) -> Set["CreeResult"]:
-    """
-    exhaustively search for preverbs (with index)
-
-    :param user_query: unicode normalized, to_lower-ed
-    """
-
-    if not user_query.endswith("-"):
-        user_query += "-"
-    user_query = remove_cree_diacritics(user_query)
-    # for preverbs
-    # An all inclusive filtering mechanism is full_lc=IPV OR pos="IPV". Don't rely on a single one
-    # due to the inconsistent labelling in the source crkeng.xml.
-    # e.g. for preverb "pe", the source gives pos=Ipc lc=IPV.
-    # For "sa", the source gives pos=IPV lc="" (unspecified)
-
-    wordform_to_cree_results: Dict[Wordform, CreeResult] = dict()
-    for preverb_wordform in Wordform.objects.filter(Q(full_lc="IPV") | Q(pos="IPV")):
-        if user_query == remove_cree_diacritics(preverb_wordform.text):
-            wordform_to_cree_results[preverb_wordform] = CreeResult(
-                Analysis(preverb_wordform.analysis),
-                preverb_wordform,
-                Lemma(preverb_wordform),
-            )
-    cw_preverbs = filter_cw_wordforms(wordform_to_cree_results)
-    return {wordform_to_cree_results[wf] for wf in cw_preverbs}
-
-
 class Preverb(NamedTuple):
     """
     Contains information about a preverb, should be used inside templates
@@ -108,6 +81,35 @@ class Preverb(NamedTuple):
     id: Optional[int]  # might be not in our database
     text: str
     definitions: Tuple[str, ...]  # might be not in our database, so might be empty
+
+
+def fetch_preverbs(
+    user_query: str, serialize: bool = False
+) -> Set[Union[Preverb, "Wordform"]]:
+    """
+    exhaustively search for preverbs (with index) in the database. MD only contents are filtered out.
+    circumflex and dash character relaxation is used
+
+    :param serialize: if set to True, will return a named tuple Preverb instead of Wordform instance
+    :param user_query: unicode normalized, to_lower-ed
+    """
+
+    if user_query.endswith("-"):
+        user_query = user_query[:-1]
+    user_query = remove_cree_diacritics(user_query)
+
+    if serialize:
+        return {
+            Preverb(
+                id=preverb_wordform.id,
+                text=preverb_wordform.text,
+                definitions=tuple(preverb_wordform.definitions.all()),
+            )
+            for preverb_wordform in Wordform.PREVERB_ASCII_LOOKUP[user_query]
+        }
+
+    else:
+        return Wordform.PREVERB_ASCII_LOOKUP[user_query]
 
 
 @attrs(auto_attribs=True, frozen=True)  # frozen makes it hashable
@@ -163,6 +165,22 @@ MatchedEnglish = NewType("MatchedEnglish", str)
 
 class Wordform(models.Model):
     _cree_fuzzy_searcher = None
+
+    # this is initialized upon app ready.
+    # this helps speed up preverb match
+    # will look like: {"pe": {...}, "e": {...}, "nitawi": {...}}
+    # pure MD content won't be included
+    PREVERB_ASCII_LOOKUP: Dict[str, Set["Wordform"]] = defaultdict(set)
+
+    @property
+    def md_only(self) -> bool:
+        """
+        check if the wordform instance has only definition from the MD source
+        """
+        for definition in self.definitions.all():
+            if set(definition.source_ids) - {"MD"}:
+                return False
+        return True
 
     @classmethod
     def init_fuzzy_searcher(cls):
@@ -412,7 +430,12 @@ class Wordform(models.Model):
         # preverbs should be presented
         # exhaustively search preverbs here (since we can't use fst on preverbs.)
 
-        cree_results |= fetch_preverbs(user_query)
+        for preverb_wf in fetch_preverbs(user_query, serialize=False):
+            cree_results.add(
+                CreeResult(
+                    Analysis(preverb_wf.analysis), preverb_wf, Lemma(preverb_wf),
+                )
+            )
 
         # Words/phrases with spaces in CW dictionary can not be analyzed by fst and are labeled "as_is".
         # However we do want to show them. We trust CW dictionary here and filter those lemmas that has any definition
@@ -471,37 +494,23 @@ class Wordform(models.Model):
                         LabelFriendliness.LINGUISTIC_SHORT
                     )
                     if ling_short is not None and ling_short != "":
-                        # looks like: "âpihci-"
-                        preverb_text_with_dash = ling_short[len("Preverb: ") :]
-                        preverb_results = fetch_preverbs(preverb_text_with_dash)
+                        # looks like: "âpihci"
+                        normative_preverb_text = ling_short[len("Preverb: ") : -1]
+                        preverb_results: Set[Preverb] = fetch_preverbs(
+                            normative_preverb_text, serialize=True
+                        )
 
                         # find the one that looks the most similar
                         if preverb_results:
-                            preverb_cree_result = min(
+                            result = min(
                                 preverb_results,
                                 key=lambda pr: get_modified_distance(
-                                    preverb_text_with_dash.strip("-"),
-                                    pr.normatized_cree_text.strip("-"),
+                                    normative_preverb_text, pr.text.strip("-"),
                                 ),
                             )
 
-                            assert isinstance(
-                                preverb_cree_result.normatized_cree, Wordform
-                            )  # normatized_cree has to be a Wordform in the database. Because we match preverbs by
-                            #   exhaustive search in the database
-
-                            result_wf = preverb_cree_result.normatized_cree
-                            defintion_strings: Tuple[str, ...] = tuple(
-                                preverb_cree_result.normatized_cree.definitions.all()
-                            )
-                            result = Preverb(
-                                result_wf.id,
-                                preverb_cree_result.normatized_cree_text,
-                                defintion_strings,
-                            )
-
                         else:  # can't find a match for the preverb in the database
-                            result = Preverb(None, preverb_text_with_dash, tuple())
+                            result = Preverb(None, normative_preverb_text, tuple())
 
                 if result is not None:
                     results.append(result)

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     "API.apps.APIConfig",
     "CreeDictionary.apps.CreeDictionaryConfig",
     "django_js_reverse",
+    "debug_toolbar",
 ]
 
 # sapir uses `wsgi_express` that requires mod_wsgi
@@ -63,6 +64,11 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+if DEBUG:
+    MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
+
+INTERNAL_IPS = ["127.0.0.1"]
 
 ROOT_URLCONF = "CreeDictionary.urls"
 

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -68,6 +68,12 @@ MIDDLEWARE = [
 if DEBUG:
     MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
 
+# works with django-debug-toolbar app
+DEBUG_TOOLBAR_CONFIG = {
+    # Toolbar options
+    "SHOW_COLLAPSED": True,
+}
+
 INTERNAL_IPS = ["127.0.0.1"]
 
 ROOT_URLCONF = "CreeDictionary.urls"

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
@@ -6,28 +6,33 @@
     {# tell javascript to display initial lemma #}
     <data id="initial-lemma-id" value="{{ lemma_id|default:"" }}"></data>
     <main class="app__content app__pane">
-
-        <article class="prose box" id="introduction-text"><h1 class="prose__heading"><span lang="cr">tânisi!</span></h1>
-            <p><span lang="cr">itwêwina</span> is a Plains Cree Dictionary.</p>
-            <p>Type any Cree word to find its English translation. You can search for
-                short Cree words (e.g., <span lang="cr">atim</span>) or very long Cree words
-                (e.g., <span lang="cr">ê-mâh-misi-nâh-nôcihikocik</span>). Or you can type an
-                English word and find its possible Cree translations. You can write words
-                in Cree using standard Roman orthography (SRO) (like
-                <span lang="cr">acimosis</span>) or using syllabics (e.g.,
-                <span lang="cr">ᐊᒋᒧᓯᐢ</span>).</p>
-            <p><span lang="cr">itwêwina</span> was made by the University of Alberta ALTLab,
-                in collaboration with the First Nations University and Maskwacîs Education
-                Schools Commission (MESC). The dictionary entries are courtesy of Dr.
-                Arok Wolvengrey and MESC.</p></article>
+        {% if not search_results %}
+            <article class="prose box" id="introduction-text"><h1 class="prose__heading"><span lang="cr">tânisi!</span></h1>
+                <p><span lang="cr">itwêwina</span> is a Plains Cree Dictionary.</p>
+                <p>Type any Cree word to find its English translation. You can search for
+                    short Cree words (e.g., <span lang="cr">atim</span>) or very long Cree words
+                    (e.g., <span lang="cr">ê-mâh-misi-nâh-nôcihikocik</span>). Or you can type an
+                    English word and find its possible Cree translations. You can write words
+                    in Cree using standard Roman orthography (SRO) (like
+                    <span lang="cr">acimosis</span>) or using syllabics (e.g.,
+                    <span lang="cr">ᐊᒋᒧᓯᐢ</span>).</p>
+                <p><span lang="cr">itwêwina</span> was made by the University of Alberta ALTLab,
+                    in collaboration with the First Nations University and Maskwacîs Education
+                    Schools Commission (MESC). The dictionary entries are courtesy of Dr.
+                    Arok Wolvengrey and MESC.</p></article>
+        {% endif %}
 
         <section class="search-results">
             {% comment %}
-        JavaScript adds the class .search-progress--loading or
-        .search-progress-error, and changes the value:
-      {% endcomment %}
+                JavaScript adds the class .search-progress--loading or
+                .search-progress-error, and changes the value:
+            {% endcomment %}
             <progress id="loading-indicator" class="search-progress" data-cy="loading-indicator" max="1"></progress>
-            <ol class="search-results__results" id="search-result-list"></ol>
+            <ol class="search-results__results" id="search-result-list">
+                {% if search_results %}
+                    {% include "CreeDictionary/word-entries.html" %}
+                {% endif %}
+            </ol>
         </section>
     </main>
 {% endblock %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
@@ -6,8 +6,8 @@
     {# tell javascript to display initial lemma #}
     <data id="initial-lemma-id" value="{{ lemma_id|default:"" }}"></data>
     <main class="app__content app__pane">
-        {% if not search_results and not lemma_id %}
-            <article class="prose box" id="introduction-text"><h1 class="prose__heading"><span lang="cr">tânisi!</span></h1>
+
+            <article class="prose box" id="introduction-text" {% if search_results or lemma_id %}style="display:none;"{% endif %}><h1 class="prose__heading"><span lang="cr">tânisi!</span></h1>
                 <p><span lang="cr">itwêwina</span> is a Plains Cree Dictionary.</p>
                 <p>Type any Cree word to find its English translation. You can search for
                     short Cree words (e.g., <span lang="cr">atim</span>) or very long Cree words
@@ -20,7 +20,7 @@
                     in collaboration with the First Nations University and Maskwacîs Education
                     Schools Commission (MESC). The dictionary entries are courtesy of Dr.
                     Arok Wolvengrey and MESC.</p></article>
-        {% endif %}
+
 
         <section class="search-results">
             {% comment %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
@@ -6,7 +6,7 @@
     {# tell javascript to display initial lemma #}
     <data id="initial-lemma-id" value="{{ lemma_id|default:"" }}"></data>
     <main class="app__content app__pane">
-        {% if not search_results %}
+        {% if not search_results and not lemma_id %}
             <article class="prose box" id="introduction-text"><h1 class="prose__heading"><span lang="cr">tânisi!</span></h1>
                 <p><span lang="cr">itwêwina</span> is a Plains Cree Dictionary.</p>
                 <p>Type any Cree word to find its English translation. You can search for
@@ -34,6 +34,11 @@
                 {% endif %}
             </ol>
         </section>
+
+
+        {% if lemma_id %}
+            {% include 'CreeDictionary/paradigm.html' %}
+        {% endif %}
     </main>
 {% endblock %}
 {# vim: set ft=htmldjango et ts=2 sw=2 sts=2 : #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/paradigm.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/paradigm.html
@@ -23,9 +23,9 @@
         </ol>
     </section>
 
-    {% if tables %}{# TODO: split this up into its own file? #}
+    {% if paradigm_tables %}{# TODO: split this up into its own file? #}
         <section class="definition__paradigm paradigm" data-cy="paradigm">
-            {% for table in tables %}
+            {% for table in paradigm_tables %}
                 <table class="paradigm__table">
                     {% for row in table %}
                         {% if row.is_title %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -8,12 +8,8 @@
                 <h2 class="definition-title definition-title--search-result">
 
                     <dfn class="definition-title__word" data-cy="definition-title">
-                        {# upon loaded, this <a> will be attached to onclick handler that loads #}
-                        {# detailed lemma page. <a> is used for accessible styling #}
                         {% if result.is_lemma %}
-                            <a class="definition-title__link" href="javascript:void(0)"
-                               data-lemma-id="{{ result.lemma_wordform.id }}">
-                                {# data- attributes are supported in HTML5 not in XHTML #}
+                            <a class="definition-title__link" href="{% url 'cree-dictionary-index-with-lemma' result.lemma_wordform.id %}">
                                 <span lang="cr">{{ result.lemma_wordform.text }}</span></a>
                         {% else %}
                             <span lang="cr">{{ result.matched_cree }}</span>
@@ -47,8 +43,8 @@
             {% if result.is_inflection %}
                 <p class="definition-title__reference-to-lemma" data-cy="reference-to-lemma">
                     Form of
-                    <a class="definition-title__link" href="javascript:void(0)"
-                       data-lemma-id="{{ result.lemma_wordform.id }}">{{ result.lemma_wordform.text }}</a>
+                    <a class="definition-title__link" href="{% url 'cree-dictionary-index-with-lemma' result.lemma_wordform.id %}"
+                       >{{ result.lemma_wordform.text }}</a>
                 </p>
             {% endif %}
 
@@ -107,10 +103,8 @@
                     <h2 class="definition-title definition-title--search-result">
 
                         <dfn class="definition-title__word" data-cy="definition-title">
-                            {# upon loaded, this <a> will be attached to onclick handler that loads #}
-                            {# detailed lemma page. <a> is used for accessible styling #}
-                            <a class="definition-title__link" href="javascript:void(0)"
-                               data-lemma-id="{{ result.lemma_wordform.id }}">
+                            <a class="definition-title__link" href="{% url 'cree-dictionary-index-with-lemma' result.lemma_wordform.id %}"
+                               >
                                 {# data- attributes are supported in HTML5 not in XHTML #}
                                 <span lang="cr">{{ result.lemma_wordform.text }}</span></a>
                         </dfn>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -1,7 +1,7 @@
 {% load inflection_extras %}
 {% load static %}
 
-{% for result in results %}
+{% for result in search_results %}
     <li class="search-results__result" data-cy="search-results">
         <article class="definition box box--rounded" data-cy="search-result">
             <header class="definition__header">

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -6,7 +6,7 @@ from django.conf.urls import url
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from django.urls import path
+from django.urls import path, include
 from django_js_reverse.views import urls_js
 
 import API.views as api_views
@@ -68,4 +68,7 @@ for route, view, name in _urlpatterns:
 urlpatterns.append(url(fr"^{prefix}jsreverse/$", urls_js, name="js_reverse"))
 
 if settings.DEBUG:
+    import debug_toolbar
+
     urlpatterns += staticfiles_urlpatterns()
+    urlpatterns.append(path("__debug__/", include(debug_toolbar.urls)))

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -13,13 +13,14 @@ def index(request, query_string=None, lemma_id=None):
     homepage with optional initial query or initial lemma. query_string and lemma_id can not both be given
 
     :param request:
-    :param query_string: initial search results o display
-    :param lemma_id: initial paradigm page to display
+    :param query_string: optional initial search results to display
+    :param lemma_id: optional initial paradigm page to display
     :return:
     """
     context = {
         "word_search_form": WordSearchForm(),
         "query_string": query_string,
+        "search_results": Wordform.search(query_string) if query_string else set(),
         "lemma_id": lemma_id,
     }
     return HttpResponse(render(request, "CreeDictionary/index.html", context))
@@ -29,9 +30,10 @@ def search_results(request, query_string: str):
     """
     returns rendered boxes of search results according to user query
     """
-    # todo: show user query analysis (Preverb, reduplication, IC ...)
     results = Wordform.search(query_string)
-    return render(request, "CreeDictionary/word-entries.html", {"results": results})
+    return render(
+        request, "CreeDictionary/word-entries.html", {"search_results": results}
+    )
 
 
 # todo: allow different paradigm size

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -19,8 +19,10 @@ def index(request, query_string=None, lemma_id=None):
     lemma = Wordform.objects.get(id=lemma_id) if lemma_id else None
     context = {
         "word_search_form": WordSearchForm(),
+        # when we have initial query word to search and display
         "query_string": query_string,
         "search_results": Wordform.search(query_string) if query_string else set(),
+        # when we have initial paradigm to show
         "lemma_id": lemma_id,
         "lemma": lemma,
         "paradigm_size": ParadigmSize.BASIC.display_form,

--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,7 @@ pysnooper = "*"
 gitdir = "*"
 tqdm = "~=4.40"
 python-levenshtein = "*"
+django-debug-toolbar = "~=2.2"
 
 [packages]
 colorama = "~=0.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "55a2a3240066c154ccd8ff69637c144a6770918e6669b3a33c75b8eb66205795"
+            "sha256": "de8408dfe35078c268e07dfa5fe355b107b0784385216c89d09853a343a3943b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -337,6 +337,14 @@
             ],
             "index": "pypi",
             "version": "==2.2.10"
+        },
+        "django-debug-toolbar": {
+            "hashes": [
+                "sha256:eabbefe89881bbe4ca7c980ff102e3c35c8e8ad6eb725041f538988f2f39a943",
+                "sha256:ff94725e7aae74b133d0599b9bf89bd4eb8f5d2c964106e61d11750228c8774c"
+            ],
+            "index": "pypi",
+            "version": "==2.2"
         },
         "gitdir": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "de8408dfe35078c268e07dfa5fe355b107b0784385216c89d09853a343a3943b"
+            "sha256": "06b5c98517047037a8cbf7bffcb9cd35f9728817823bd94bd3467a7ab181b8f6"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -8,6 +8,8 @@ context('Searching', () => {
 
       // not visible at the start
       cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
+        .and('contain', 'wâpamêw') // lemma
+        .and('contain', 'Action word') // verb
 
       cy.get('[data-cy=information-mark]').first().focus()
 
@@ -26,6 +28,8 @@ context('Searching', () => {
       cy.get('[data-cy=information-mark]').first().click({force:true})
 
       cy.get('[data-cy=linguistic-breakdown]').should('be.visible')
+        .and('contain', 'wâpamêw') // lemma
+        .and('contain', 'Action word') // verb
     })
 
   }

--- a/src/index.js
+++ b/src/index.js
@@ -9,38 +9,6 @@ import $ from 'jquery'
 import './css/styles.css'
 import {createTooltip} from './tooltip'
 
-/**
- * request server-end rendered paradigm and plunk it in place
- *
- * @param lemmaID {number} the id of the lemma in database
- */
-function loadParadigm(lemmaID) {
-  let xhttp = new XMLHttpRequest()
-
-  xhttp.onloadstart = function () {
-    // Show the loading indicator:
-    indicateLoading()
-  }
-
-  xhttp.onload = function () {
-    if (xhttp.status === 200) {
-      window.history.pushState('', document.title, Urls['cree-dictionary-index-with-lemma'](lemmaID))
-      hideInstruction()
-      emptySearchResultList()
-      $('main').append(xhttp.responseText)
-
-      indicateLoadedSuccessfully()
-    } else {
-      indicateLoadingFailure()
-    }
-  }
-
-  xhttp.onerror = function () {
-  }
-
-  xhttp.open('GET', Urls['cree-dictionary-lemma-detail'](lemmaID), true)
-  xhttp.send()
-}
 
 const ERROR_CLASS = 'search-progress--error'
 const LOADING_CLASS = 'search-progress--loading'
@@ -76,12 +44,6 @@ function hideLoadingIndicator() {
   progress.classList.remove(LOADING_CLASS, ERROR_CLASS)
 }
 
-/**
- * clean search results (boxed shaped entries)
- */
-function emptySearchResultList() {
-  $('#search-result-list').html('')
-}
 
 /**
  * clean paradigm details
@@ -154,7 +116,6 @@ function loadResults($input) {
           indicateLoadedSuccessfully()
           cleanParadigm()
           $searchResultList.html(xhttp.responseText)
-
           prepareTooltips()
 
 
@@ -212,12 +173,8 @@ $(() => {
   } else if (route === '/about') {
     // About page
     setSubtitle('About')
-  } else if (route.match(/^[/]lemma[/].+/)) {
-
   } else if (route.match(/^[/]search[/].+/)) {
     prepareTooltips()
-  } else {
-    console.assert('not sure what page this is: ' + route)
   }
 
   $input.on('input', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -102,23 +102,18 @@ function hideInstruction() {
 }
 
 /**
- * find #search-result-list element on the page to add onclick handler to lemma links and attach relevant handlers to
- * the tooltip icons
+ * find #search-result-list element on the page to attach relevant handlers to the tooltip icons
  */
-function prepareTooltipAndLemmaLink(){
+function prepareTooltips() {
   const $searchResultList = $('#search-result-list')
-  $searchResultList.find('.definition-title__link').on('click', function () {
-    loadParadigm($(this).data('lemma-id'))
-  })
-
 
   // attach handlers for tooltip icon at preverb breakdown
-  $searchResultList.find('.definition-title__tooltip-icon').each(function (){
+  $searchResultList.find('.definition-title__tooltip-icon').each(function () {
     createTooltip($(this), $(this).next('.tooltip'))
   })
 
   // attach handlers for tooltip icon at preverb breakdown
-  $searchResultList.find('.preverb-breakdown__tooltip-icon').each(function (){
+  $searchResultList.find('.preverb-breakdown__tooltip-icon').each(function () {
     createTooltip($(this), $(this).next('.tooltip'))
   })
 }
@@ -159,7 +154,8 @@ function loadResults($input) {
           indicateLoadedSuccessfully()
           cleanParadigm()
           $searchResultList.html(xhttp.responseText)
-          prepareTooltipAndLemmaLink()
+
+          prepareTooltips()
 
 
         } else { // changed. Do nothing
@@ -217,10 +213,9 @@ $(() => {
     // About page
     setSubtitle('About')
   } else if (route.match(/^[/]lemma[/].+/)) {
-    let initialLemmaID = $('#initial-lemma-id').val()
-    loadParadigm(parseInt(initialLemmaID))
+
   } else if (route.match(/^[/]search[/].+/)) {
-    prepareTooltipAndLemmaLink()
+    prepareTooltips()
   } else {
     console.assert('not sure what page this is: ' + route)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,28 @@ function hideInstruction() {
 }
 
 /**
+ * find #search-result-list element on the page to add onclick handler to lemma links and attach relevant handlers to
+ * the tooltip icons
+ */
+function prepareTooltipAndLemmaLink(){
+  const $searchResultList = $('#search-result-list')
+  $searchResultList.find('.definition-title__link').on('click', function () {
+    loadParadigm($(this).data('lemma-id'))
+  })
+
+
+  // attach handlers for tooltip icon at preverb breakdown
+  $searchResultList.find('.definition-title__tooltip-icon').each(function (){
+    createTooltip($(this), $(this).next('.tooltip'))
+  })
+
+  // attach handlers for tooltip icon at preverb breakdown
+  $searchResultList.find('.preverb-breakdown__tooltip-icon').each(function (){
+    createTooltip($(this), $(this).next('.tooltip'))
+  })
+}
+
+/**
  * use xhttp to load search results in place
  *
  * @param {jQuery} $input
@@ -137,20 +159,7 @@ function loadResults($input) {
           indicateLoadedSuccessfully()
           cleanParadigm()
           $searchResultList.html(xhttp.responseText)
-          $searchResultList.find('.definition-title__link').on('click', function () {
-            loadParadigm($(this).data('lemma-id'))
-          })
-
-
-          // attach handlers for tooltip icon at preverb breakdown
-          $searchResultList.find('.definition-title__tooltip-icon').each(function (){
-            createTooltip($(this), $(this).next('.tooltip'))
-          })
-
-          // attach handlers for tooltip icon at preverb breakdown
-          $searchResultList.find('.preverb-breakdown__tooltip-icon').each(function (){
-            createTooltip($(this), $(this).next('.tooltip'))
-          })
+          prepareTooltipAndLemmaLink()
 
 
         } else { // changed. Do nothing
@@ -211,7 +220,7 @@ $(() => {
     let initialLemmaID = $('#initial-lemma-id').val()
     loadParadigm(parseInt(initialLemmaID))
   } else if (route.match(/^[/]search[/].+/)) {
-    loadResults($input)
+    prepareTooltipAndLemmaLink()
   } else {
     console.assert('not sure what page this is: ' + route)
   }

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -34,7 +34,6 @@ const hideEvents = ['mouseleave', 'blur']
  * @param popup {jQuery}: the popup that shows up
  */
 export function createTooltip(icon, popup) {
-  console.log(icon)
   showEvents.forEach(event => {
     icon.on(event, () => {
       popup.attr('data-show', '')


### PR DESCRIPTION
# Main Change

now `/search/blah` and `/lemma/blah` will render everything on the server-side. fixes #211, fixes #210

Dynamic searching is not imparied in any sense.

# Side thing

Preverb search is optimized. But there's not much improvement speed-wise cuz preverb search doesn't seem like to be the culprit. I haven't looked into the real cause of the slow-down yet.

# Important thing

We are officially using this magic in development: `django-debug-toolbar`.

It shows as a green icon hovering on the right side of the screen. It is majestic. Everybody is obliged to learn and use it.


![Screenshot from 2020-02-14 16-25-23](https://user-images.githubusercontent.com/44753941/74576059-9f787c80-4f46-11ea-96f5-3aa2db1da5fc.png)

![Screenshot from 2020-02-14 16-25-46](https://user-images.githubusercontent.com/44753941/74576074-ae5f2f00-4f46-11ea-83d6-55e1220e2f52.png)


it's majestic in the following ways:

- You can drag it around
- You can expand and collapse it
- shows varaibles in settings.py, shows context variables used in the rendering of each template
- shows SQL qeuries and their time taken (I'll use this to dubug performance issues)
- shows logging messages
- shows everything
- does profiling and code tracing
- highly configurable
- majestic


