### PR TITLE
Use latest dictionary content

### DIFF
--- a/CreeDictionary/res/test_dictionaries/crkeng.xml
+++ b/CreeDictionary/res/test_dictionaries/crkeng.xml
@@ -1,5 +1,24 @@
 <?xml version="1.0" ?>
 <r>
+	<source id="CW">
+		
+      
+		<title>Cree : Words / nēhiyawēwin : itwēwina</title>
+		
+   
+	</source>
+	
+   
+	<source id="MD">
+		
+      
+		<title>Maskwacîs Cree Dictionary</title>
+		
+   
+	</source>
+	
+
+
 	<e>
 		
    

--- a/CreeDictionary/res/test_dictionaries/crkeng.xml
+++ b/CreeDictionary/res/test_dictionaries/crkeng.xml
@@ -1,25 +1,5 @@
 <?xml version="1.0" ?>
 <r>
-	<source id="CW">
-		
-      
-		<title>Cree : Words / nēhiyawēwin : itwēwina</title>
-		
-   
-	</source>
-	
-   
-	<source id="MD">
-		
-      
-		<title>Maskwacîs Cree Dictionary</title>
-		
-   
-	</source>
-	
-
-
-
 	<e>
 		
    
@@ -45,16486 +25,6 @@
 				
        
 				<t pos="N" sources="MD CW">star</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">âcim</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Tell about him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">acimaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">A story is told about him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">âcimêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>âcim-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he tells about s.o., s/he talks about s.o.; s/he narrates about s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">âcimêwak</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">They are telling a story about him or them.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">âcimow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>âcimo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he tells, s/he tells a story; s/he tells news, s/he gives an account, s/he narrates; s/he tells his/her own story</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">âcimowak</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">They are telling stories.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">âcimowin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>âcimowin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A story. A news forecast.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">story, true story, account, report; news; what is being told</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">ahcahk</l>
-			
-      
-			<lc>NA-3</lc>
-			
-      
-			<stem>ahcahkw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">soul, spirit</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">akocin</l>
-			
-      
-			<lc>VAI-n</lc>
-			
-      
-			<stem>akocin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he hangs, s/he is hanging, s/he is suspended</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">akohcin</l>
-			
-      
-			<lc>VAI-n</lc>
-			
-      
-			<stem>akohcin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he is in water</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">amisk</l>
-			
-      
-			<lc>NA-3</lc>
-			
-      
-			<stem>amiskw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">beaver</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">amiskwayân</l>
-			
-      
-			<lc>NA-1</lc>
-			
-      
-			<stem>amiskwayân-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">beaver-pelt</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">ana</l>
-			
-      
-			<lc>PrA</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD">That one, (him/her).</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">anihi</l>
-			
-      
-			<lc>PrA</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD">Those things, there. [Plural]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">aniki</l>
-			
-      
-			<lc>PrA</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD">Those people there. [Plural]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">anima</l>
-			
-      
-			<lc>PrI</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD">That thing, there.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">anohc</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">now, today</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">âpihtânîpin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">it is summer</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">âpihtâtipiskâw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">it is night, it is night time; it is dark</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">asawâpahtam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>asawâpaht-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is on the look-out for it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he waits and watches for s.t.; s/he looks out for s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">asawâpam</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Be on the look-out for him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">asawapamaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Someone is on the look-out for him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">asawâpamêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>asawâpam-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is on the look-out for him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he looks out for s.o., s/he waits and watches for s.o., s/he lies in watch for s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">asawâpi</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Be on the look-out. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">asawâpiwak</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">They are on the look-out.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">asawâpiwin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>asawâpiwin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A place designated as a look-out. E.g. A watchtower.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">hunting-blind; a place to watch from; look-out, lighthouse, watchtower; looking out</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">asawâpiwin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>asawâpiwin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A blind that is used by hunters, usually man-made, from trees shrubs or a hill, to watch for the enemy.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">hunting-blind; a place to watch from; look-out, lighthouse, watchtower; looking out</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">astamispihk</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Before that time. Before then and now. [Location]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">atâhk</l>
-			
-      
-			<lc>NA-3</lc>
-			
-      
-			<stem>atâhkw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A big bright star.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">star</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">atamiskaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Shake hands with him. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">atamiskawaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Someone shook hands with him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">atamiskawêw</l>
-			
-      
-			<lc>VTA-2</lc>
-			
-      
-			<stem>atamiskaw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He shook hands with him or them.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he greets s.o., s/he sends greetings to s.o.; s/he says hello to s.o.; s/he shakes hands with s.o.; s/he hugs s.o. in greeting, s/he kisses s.o. in greeting; s/he bids s.o. farewell</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">atamiskawêwak</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">They shook hands with all of them.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ati-tawahikêw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He clears the way or leaves a trail as he goes.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he slashes a path, s/he clears or marks a line, s/he clears the way of trees</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">atitawahikêw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He goes and his somebody or something as he is going.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he slashes a path, s/he clears or marks a line, s/he clears the way of trees</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">awa</l>
-			
-      
-			<lc>PrA</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD CW">this, this one</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">awasâpisk</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">beyond the rocks; beyond the Rocky Mountains</t>
-				
-       
-				<t pos="Ipc" sources="MD CW">British Columbia</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">awasâyihk</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">On the other side (of). E.g. A hill.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">beyond the place, beyond the bush</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">awasimê</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Above, more. Over and above the limit. More and more.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">further, beyond; more</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">awasita</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Over further. Also a command, meaning move over.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">awasitâkosîhk</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">day before yesterday</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">awasitê</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Further away. Beyond.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">go on; go away; on, to the further side (in time or space); beyond, further over there</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">awîna</l>
-			
-      
-			<lc>PrA</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD CW">who, whose</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">âyiman</l>
-			
-      
-			<lc>VII-n</lc>
-			
-      
-			<stem>âyiman-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">it is difficult</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ayimowew</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He asks for something to be done which is difficult to do.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">ayiwinis</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">article of clothing; [plural:] clothing, apparel</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">ayiwinisa</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>ayiwinis-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Clothes.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">clothes; clothing, apparel; [singular:] article of clothing</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ayocihaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is bothered or pestered by people for services.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">cacahkayow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A blackbird.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">cimihtawakêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>cimihtawakê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he has short ears</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ê-nawaswêt</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is in pursuit of him.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he gives chase, s/he chases game; s/he is in pursuit, s/he pursues</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ehatamiskahcik</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Somebody shakes hands with them.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">êhatamiskawacik</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">They shake hands with them.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ehkawacit</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is cold.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ehkawahak</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He knocks it down (it implies something standing).</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ehkawahikeht</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is knocking down (felling) trees. E.g. As a beaver.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ehkawahoht</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is knocked down (implies he was standing).</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ehkawamiht</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is knocked down by a bit or a biting attacker.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ehkimowahk</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">It is raining.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">êkwa</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">And also.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">and, also; then; now</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">êkwayâc</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Only now, for the first time.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">only now, for the first time, just then</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">ewako oci</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">That's the reason why.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">iskwapiw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">1. He sits higher or farther away. 2. He sits so high.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">itacimaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">What is said about him in a story.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">itâcimêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>itâcim-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">What he tells about him in a story.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he tells thus about s.o., s/he narrates thus about s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kakihcimow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">2. He talks intelligently for his age.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kakihcimow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">1. He boasts and brags.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">kakihcimowin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Cleaver, intelligent talk.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kâkîsimow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>kâkîsimo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is praying to the Creator.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he prays, s/he pleads, s/he chants</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kanawâpahta</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Keep looking at it.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he looks at s.t., s/he observes s.t.; s/he watches s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kanawâpahtam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>kanawâpaht-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He keeps looking at it.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he looks at s.t., s/he observes s.t.; s/he watches s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kanawâpam</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Keep looking at him. Keep an eye on him. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kanawapamaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is being watched.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kanawâpamêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>kanawâpam-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He watches him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he looks at s.o.; s/he looks after s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kaskipatam</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He shaves it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kaski-tipiskâw</l>
-			
-      
-			<lc>VII-v</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">The night is pitch black.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">it is night, it is night time; it is dark</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">katawasisihaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is made beautiful.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">katawasisîhêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>katawasisîh-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he makes s.o. beautiful, s/he beautifies s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">katawasisîhtâw</l>
-			
-      
-			<lc>VTI-2</lc>
-			
-      
-			<stem>katawasisîhtâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he beautifies s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">katawasisin</l>
-			
-      
-			<lc>VII-n</lc>
-			
-      
-			<stem>katawasisin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">it is beautiful</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">katawasisiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>katawasisi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is beautiful.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he is beautiful, s/he is good-looking</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">katawasisiwin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>katawasisiwin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">beauty</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kawacipayiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>kawacipayi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He gets a chill.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he gets chilled, s/he gets cold</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kawaciw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>kawaci-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is cold (from the weather).</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he is cold, s/he experiences cold, s/he suffers from cold</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">kawaciwin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>kawaciwin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">The state of being cold or chilled.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">coldness; of or pertaining to being cold</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kawaha</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Chop it down. Flatten it with a machine.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he chops s.t. down, s/he fells s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kawaham</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>kawah-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he chops s.t. down, s/he fells s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kawahikêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>kawahikê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He falls trees.</t>
-				
-       
-				<t pos="V" sources="MD">He knocks down something.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he chops down trees</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kawahtam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>kawaht-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he bites s.t. until it falls, s/he eats s.t. until it falls</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">kawâhtik</l>
-			
-      
-			<lc>NA-3</lc>
-			
-      
-			<stem>kawâhtikw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">fallen tree</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kawamêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>kawam-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">it gnaws s.o. down (e.g. a beaver to a tree)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kawatihtâw</l>
-			
-      
-			<lc>VTI-2</lc>
-			
-      
-			<stem>kawatihtâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He gets it cold.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he gets (it/him) chilled, s/he gets s.t. cold</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kayas oci</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">From a long ways back.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">kihci-niska</l>
-			
-      
-			<lc>NA-4</lc>
-			
-      
-			<stem>kihci-nisk-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">Canada goose</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kikamow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He flees with it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kikamow</l>
-			
-      
-			<lc>VII-v</lc>
-			
-      
-			<stem>kikamo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">It clings, it sticks.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">it clings, it sticks; it is fastened on</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kikawacin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">You are cold. Usually used in a question. E.g. kikawacin ci? Are you cold?</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kinohtawakêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>kinohtawakê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he has long ears</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">kîpit</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">tooth</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kisacimaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is persuaded to stay.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kisâcimêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>kisâcim-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He persuades him to stay.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he convinces s.o. to stay</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kiskinwahamâkosiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>kiskinwahamâkosi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is being taught. He is learning. He is going to school.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he learns; s/he is a student, s/he attends school; s/he is taught</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">kiskinwahamâkosiwin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>kiskinwahamâkosiwin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">The act of learning. Education.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">learning, being a student, attending school; schoolwork, homework</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">kiskisopayiwin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>kiskisopayiwin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">recollection</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kitâpahtam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>kitâpaht-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he looks at s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">kitocikan</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A piano.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kitocikeskow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He plays often on a musical instrument.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kitocikew</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He plays music.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">kîwâtêyimowin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>kîwâtêyimowin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">loneliness, depression</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">kiyânaw</l>
-			
-      
-			<lc>PrA</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD CW">we, us; we-and-you</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">kiyaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">body; corpse, dead body</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">kiyawâw</l>
-			
-      
-			<lc>PrA</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD CW">you</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kocipayihtâw</l>
-			
-      
-			<lc>VTI-2</lc>
-			
-      
-			<stem>kocipayihtâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He tries to make it work.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he tries s.t. (e.g. computer)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kocipayih</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Try running it (animate). As a car.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he tries s.o. (e.g. motorized vehicle)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kohcipayihtâ</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Swallow it. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kohcipayihtâw</l>
-			
-      
-			<lc>VTI-2</lc>
-			
-      
-			<stem>kohcipayihtâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he swallows s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">kôhkom</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Your grandmother.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">Your grandmother.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">kwahcimow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He gets carried away in talking.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mahkihtawakêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>mahkihtawakê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he has large ears</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mamihci</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">1. Please him. 2. Make him proud. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mamihcisiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>mamihcisi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he is proud</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">manâcim</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Talk respectfully to him.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he is careful how s/he speaks to s.o. out of respect; s/he avoids speaking to s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">manâcimêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>manâcim-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He has respect for him (language wise).</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he is careful how s/he speaks to s.o. out of respect; s/he avoids speaking to s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">maskosis</l>
-			
-      
-			<lc>NA-1</lc>
-			
-      
-			<stem>maskosis-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A bear cub.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">little bear, bear cub</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">maskwa</l>
-			
-      
-			<lc>NA-4w</lc>
-			
-      
-			<stem>maskw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A bear.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">bear, black bear</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">maskwacîs</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>maskwacîs-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A small bear's hill located in Hobbema.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">Hobbema, AB; literally: &quot;Little Bear Hills&quot;</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">maskwacîsihk</l>
-			
-      
-			<lc>INM</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">Hobbema, AB; literally: &quot;Little Bear Hills&quot;</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">maskwayân</l>
-			
-      
-			<lc>NA-1</lc>
-			
-      
-			<stem>maskwayân-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">bear skin</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mayacimaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">What is said of him is bad.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mâyâcimêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>mâyâcim-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He tells bad news of him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he speaks ill of s.o., s/he tells bad news of s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mâyâcimow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>mâyâcimo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he tells bad news</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">mâyâcimowin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>mâyâcimowin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">bad news</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mêkwâ-pimâtisiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>mêkwâ-pimâtisi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is living at the present time.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">while s/he lives, s/he is living presently, during his/her lifespan</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mêkwâ-nipâw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is sleeping right now.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he sleeps, s/he is asleep</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mêkwâtipiskâw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">It is night right now.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">it is night, it is night time; it is dark</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mîci</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Eat it. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mîciw</l>
-			
-      
-			<lc>VTI-3</lc>
-			
-      
-			<stem>mîci-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he eats s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">mîciwin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>mîciwin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Food.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">food, groceries; meal</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">mîciwina</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Lots of food or groceries.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">food, groceries; meal</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">mîciwinis</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>mîciwinis-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">bit of food</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">mihtawakay</l>
-			
-      
-			<lc>NDI-2</lc>
-			
-      
-			<stem>-htawakay-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">ear</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mikoskâcim</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Annoy him with disturbing talk.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he disturbs s.o., s/he annoys s.o. (by speech)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mikoskacimaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is annoyed by senseless talk.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mikoskâcimêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>mikoskâcim-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He annoys him by senseless talk.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he disturbs s.o., s/he annoys s.o. (by speech)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">minôsis</l>
-			
-      
-			<lc>NA-1</lc>
-			
-      
-			<stem>minôsis-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A kitten.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">kitten, little cat</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">mîpit</l>
-			
-      
-			<lc>NDI-1</lc>
-			
-      
-			<stem>-îpit-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">tooth</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">misihkêmow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>misihkêmo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He tattle tales.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he tattle, s/he tells on, s/he reveals the truth</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">misimowaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Lots of him is eaten. Animate.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mitsow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He eats.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">mitsowin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Eating. A meal.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">mitsowinis</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A lunch. Not a full meal.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">miyopayiwin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>miyopayiwin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Prosperity and good luck.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">good luck; welfare; prosperity; good heart</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">miyowatamowin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Merriment. Gaiety. Shared happiness.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">mohcihk</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">On the ground, or floor.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">on the bare ground; on the floor; to the ground</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">mohcihtak</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">The floor.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">on the floor, on the floorboards</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">môniyâsis</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A young white boy.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">White-Man; non-Indian; Canadian</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">môniyâskwêsis</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">A young white girl.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">môniyâskwêw</l>
-			
-      
-			<lc>NA-2</lc>
-			
-      
-			<stem>môniyâskwêw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">a White woman, Canadian woman</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">môniyâw</l>
-			
-      
-			<lc>NA-2</lc>
-			
-      
-			<stem>môniyâw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Any white man.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">White-Man; non-Indian; Canadian</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he eats s.o. (e.g. bread)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mowaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is eaten. Animate.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mowêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>mow-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he eats s.o. (e.g. bread)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">mowihk</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">All of you eat it. Animate. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">nâha</l>
-			
-      
-			<lc>PrA</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD">That one over there.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">naha</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Put him away to store. Store him away. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">namiskwêstawêw</l>
-			
-      
-			<lc>VTA-2</lc>
-			
-      
-			<stem>namiskwêstaw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he nods to s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">namiskwêyiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>namiskwêyi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He nods.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he puts his/her own head down</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nanamiskwêyiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>nanamiskwêyi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He nods his head.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he nods his/her own head, s/he shakes his/her own head</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nâpê-minôs</l>
-			
-      
-			<lc>NA-1</lc>
-			
-      
-			<stem>nâpê-minôs-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">tomcat</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">natawapiw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He looks around.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">nawac</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Preferably.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">by comparison; better, more; before; instead, rather, somewhat</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">nawac piko</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Rather. Somewhat.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawacî</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Cook it. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawacîw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>nawacî-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He cooks an item.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he roasts s.t., s/he cooks s.t. (i.e. in a wood stove or on a fire)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nawaciwin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Cooking.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawakapiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>nawakapi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he sits with his/her own head and body bent down</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawakî</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Bent down. (from the waist). [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawakiskwêpiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>nawakiskwêpi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he sits with his/her own head down</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawakiskwêyiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>nawakiskwêyi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He hangs his head down.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he hangs his/her own head down, s/he bends down his/her own head</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawakîw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>nawakî-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He stoops or bends down.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he bends over, s/he bends down, s/he bends forward; s/he stoops, s/he bends</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawasôn</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Choose among them. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawasôna</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Choose it. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawasônam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>nawasôn-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he chooses s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawasonaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is chosen.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawasônêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>nawasôn-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He chooses him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he chooses s.o.; s/he picks s.o. out</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawasônikêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>nawasônikê</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he chooses</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nawasônikêwin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>nawasônikêwin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">choosing</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawaswâs</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Chase him. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawaswasowew</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He chases others.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawaswâta</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Chas it. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawaswâtam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>nawaswât-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">he chases it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he chases after s.t., s/he pursues s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawaswataw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is being chased.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawaswâtêw</l>
-			
-      
-			<lc>VTA-4</lc>
-			
-      
-			<stem>nawaswât-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He chases him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he chases after s.o., s/he pursues s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawaswâtitowak</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>nawaswâtito-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">they chase one another</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawaswê</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Give chase after him. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawatâskitêw</l>
-			
-      
-			<lc>VII-v</lc>
-			
-      
-			<stem>nawatâskitê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">It caught on fire.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">it catches on fire, it is reached by flames, it catches fire</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawatin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Catch him. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawatina</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Catch it. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawatinam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>nawatin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He catches it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he grabs s.t., s/he seizes s.t.; s/he catches s.t. in his/her hand</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawatinaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is caught. E.g. From falling.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nawatinêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>nawatin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">he catches him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he grabs s.o., s/he seizes s.o.; s/he catches s.o. in his/her hand (e.g. a ball)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">nêhi</l>
-			
-      
-			<lc>PrI</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD">Those things. Inanimate.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">nêki</l>
-			
-      
-			<lc>PrA</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD">Those people over there (pointed at).</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">nêma</l>
-			
-      
-			<lc>PrI</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD">That thing over there.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nicimiw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He hold or grasps onto something.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nihtâ-kitohcikêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>nihtâ-kitohcikê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he plays music well</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nikî-nipân</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">I had slept.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ninawaswan</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">I chase him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ninawaswâtên</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">I chase it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ninîpawin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">I stand.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nipâ</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Sleep. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nipa</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Kill him. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">nipa</l>
-			
-      
-			<lc>IPV</lc>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Means, during the night.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nipâk</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">All of you sleep. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nipâtân</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Let's all sleep. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nipâw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>nipâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He sleeps.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he sleeps, s/he is asleep</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nipâwin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>nipâwin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Sleep.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">sleeping, sleep</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nîpin</l>
-			
-      
-			<lc>VII-n</lc>
-			
-      
-			<stem>nîpin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Summertime.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">it is summer</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nipinisow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He spends his summer there.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nipinisowin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">The summer one is having.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">nîpinohk</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">last summer</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nîpisîs</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>nîpisîs-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A willow branch used for discipline.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">willow branch, willow switch; little willow</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nîpit</l>
-			
-      
-			<lc>NDI-1</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">tooth</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nipiy</l>
-			
-      
-			<lc>NI-2</lc>
-			
-      
-			<stem>nipiy-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">water</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nîpiy</l>
-			
-      
-			<lc>NI-2</lc>
-			
-      
-			<stem>nîpiy-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A leaf.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">leaf; blade of grass</t>
-				
-       
-				<t pos="N" sources="CW">[plural:] leaves; salad</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">niska</l>
-			
-      
-			<lc>NA-4</lc>
-			
-      
-			<stem>nisk-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">goose</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">niskisis</l>
-			
-      
-			<lc>NA-1</lc>
-			
-      
-			<stem>niskisis-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">gosling</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">nisto</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">three</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nisto tipahikan</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Three o'clock.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nistohtâw</l>
-			
-      
-			<lc>VTI-2</lc>
-			
-      
-			<stem>nistohtâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he divides s.t. in three</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">nistomitanaw</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">thirty</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nistomitanaw nistosap</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Thirty-three.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">nistosâp</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">thirteen</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">nitaw</l>
-			
-      
-			<lc>IPV</lc>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Meaning, go and get, go and do or go and act. Also nitawi.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">niya</l>
-			
-      
-			<lc>PrA</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD CW">I, me, mine</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">niyahk</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">2. Beforehand. Ahead of time.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">niyahk</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">1. All of you go. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">niyânan</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">five</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">niyânaniwa</l>
-			
-      
-			<lc>VII-v</lc>
-			
-      
-			<stem>niyânani-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">they are five in number</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">niyânaniwak</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>niyânani-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">they are five in number</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">niyânanomitanaw</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">fifty</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">niyananomitanaw niyananosap</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Fifty five.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">niyânanosâp</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">fifteen</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">niyânanosâpwâw</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">fifteen times</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">niyaw</l>
-			
-      
-			<lc>NDI-1</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">body; corpse, dead body</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nôhkom</l>
-			
-      
-			<lc>NDA-1</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">My grandmother.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">my grandmother; [reference extended to all related females of grandmother's generation]; my respected female elder</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nohte mitsow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He wants to eat.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">nôkohcikêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>nôkohcikê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He shows something.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he shows things</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">nôsê-minôs</l>
-			
-      
-			<lc>NA-1</lc>
-			
-      
-			<stem>nôsê-minôs-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">female cat</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">ocêkatâhk</l>
-			
-      
-			<lc>NA-3</lc>
-			
-      
-			<stem>ocêkatâhkw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">the Big Dipper, the Great Bear (constellation)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ocipis</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Pull him. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ocipita</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Pull it. Inanimate. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ocipitam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>ocipit-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He pulls it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he pulls s.t., s/he pulls s.t. out, towards</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ocipitaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is pulled. Animate.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ocipitêw</l>
-			
-      
-			<lc>VTA-4</lc>
-			
-      
-			<stem>ocipit-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He pulls him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he pulls s.o., s/he pulls s.o. out, towards; s/he wins from s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ocipitikow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>ocipitiko-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He has cramps. He has a seizure.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he has a seizure, s/he has fits; s/he has cramps</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ociwâmiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>ociwâmi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He has a brother who is a cousin.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">he has a brother, he has a male parallel cousin</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">ohci</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">From, out of, for.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">from there, thence, out of; with, by means of; because of; for; from then; about</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohciciwan</l>
-			
-      
-			<lc>VII-n</lc>
-			
-      
-			<stem>ohciciwan-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">That's where it flows from.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">it flows thence, it flows from there</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohcikawâpiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>ohcikawâpi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He sheds tears.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he sheds tears; s/he has tears dropping</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">ohcikawapowin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">The shedding of tear drops.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohcikawihtâw</l>
-			
-      
-			<lc>VTI-2</lc>
-			
-      
-			<stem>ohcikawihtâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He makes it drip.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he makes s.t. drip, leak</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohcikawin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">It leaks. Inanimate.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohcikawiw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He leaks. Animate. It flows out. As a pail leaking.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohcimow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">1. That's where he scolds from. (A location). 2. He scolds about it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohcinas</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Hit him over it.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he fights s.o. over something; s/he fights s.o. on account of something</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohcinataw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is hit over it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohcinatêw</l>
-			
-      
-			<lc>VTA-4</lc>
-			
-      
-			<stem>ohcinat-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He hits him over it.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he fights s.o. over something; s/he fights s.o. on account of something</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohcipayin</l>
-			
-      
-			<lc>VII-n</lc>
-			
-      
-			<stem>ohcipayin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">That's where it comes from.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">it comes from there, it results from that</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohcipayiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>ohcipayi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">That's where he comes from, riding.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">it moves thence, it rides thence; it come from there</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">ohcitaw</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Deliberately. Something done on purpose.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">on purpose, purposely, deliberately; it has to be, it is necessary; as expected; without fail; by all means; expressly, specifically</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohci-wayawîw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>ohci-wayawî-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">That's where he goes out of.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he comes out of (there)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">ôhi</l>
-			
-      
-			<lc>PrI</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD">These things, here. (Inanimate).</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="CW">this one, these ones</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">ôhkoma</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">His grandmother.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">His grandmother.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">ohtawakay</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">ear</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">ohtêyihtamowin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>ohtêyihtamowin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Envy.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">jealousy, envy</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohtiskawapîstam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>ohtiskawapîst-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he sits in front of and facing s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohtiskawapîstaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Sit facing him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he sits in front of and facing s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohtiskawapîstawêw</l>
-			
-      
-			<lc>VTA-2</lc>
-			
-      
-			<stem>ohtiskawapîstaw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He sits facing him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he sits in front of and facing s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">ohtiskawapow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He sits facing an audience.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">okakihcimow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">One who can talk at great length intelligently.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">ôki</l>
-			
-      
-			<lc>PrA</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD">These animate items her. E.g. These cars here. Minosak oki.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="CW">these</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">okitohcikaniw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>okitohcikani-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he has musical instruments</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">okitohcikêw</l>
-			
-      
-			<lc>NA-2</lc>
-			
-      
-			<stem>okitohcikêw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A musician. He who plays music.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">musician; [pl:] orchestra</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">okitohcikêwak</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">An orchestra (they who play).</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">musician; [pl:] orchestra</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">ôma</l>
-			
-      
-			<lc>PrI</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD CW">it is this; the fact that; then; when; as it is, actually</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">opawahikêw</l>
-			
-      
-			<lc>NA-2</lc>
-			
-      
-			<stem>opawahikêw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A thresher. One who threshes grain.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">thresher, one who threshes grain, one who combines</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">opiminawasow</l>
-			
-      
-			<lc>NA-2</lc>
-			
-      
-			<stem>opiminawasow-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">chef; cook</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">oskan</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>oskan-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A bone.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">bone; his/her bone</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">otânisiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>otânisi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he has (s.o. as) a daughter</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">otatamow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He inhales.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">otatamowin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">The act of inhaling.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pâh-pasakwâpiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he closes his/her eyes</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pahpawaha</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Dust it. Inanimate. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pahpawaham</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>pahpawah-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He dusts it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he beats s.t., s/he shakes s.t. out by tool; s/he dusts s.t. off</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pahpawahwêw</l>
-			
-      
-			<lc>VTA-3</lc>
-			
-      
-			<stem>pahpawahw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He dusts him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he beats s.o., s/he shakes s.o. out by tool; s/he dusts s.o. off</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">pâkipayiwin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>pâkipayiwin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">a quick swelling on a body part.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">swelling</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">papâm-âcimêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He goes around telling news of him.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he tells about s.o., s/he talks about s.o.; s/he narrates about s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">papâmâmow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>papâmâmo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He flees about while getting chased.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he flees about</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">papâmitâcimow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>papâmitâcimo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he crawls around, about</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pasakwâpiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>pasakwâpi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He has his eyes shut.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he closes his/her eyes</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pawaham</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>pawah-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He threshes it.</t>
-				
-       
-				<t pos="V" sources="MD">He dust it.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he beats s.t., s/he shakes s.t. out, s/he brushes s.t. off by tool; s/he threshes s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">pawahikan</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>pawahikan-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A threshing machine.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">threshing-machine; combine</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pawahikêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>pawahikê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is threshing.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he threshes, s/he threshes grain, s/he combines</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pawahwaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is threshed. As grain.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pawahwêw</l>
-			
-      
-			<lc>VTA-3</lc>
-			
-      
-			<stem>pawahw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He threshes him. Animate.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he brushes s.o. off by tool; s/he threshes s.o. (e.g. grain)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">pe</l>
-			
-      
-			<lc>IPV</lc>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Meaning &quot;come and sit&quot;</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pê-nipâw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>nipâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he comes and sleeps</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">petacimow</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He comes bringing news.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêtâmow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>pêtâmo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He flees here for help.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he comes in flight, s/he flees here for shelter, s/he flees here for help</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêtatâmow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>pêtatâmo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">His breathing returns.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he blows hither, s/he breathes forth; s/he has his/her breathing return</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pê-wâpahta</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Come and see it. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pê-wâpahtam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He comes to see it.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he sees s.t., s/he witnesses s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pê-wâpam</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Come and see him. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">pêyak</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">One.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">one; alone, single; the only one</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">pêyak-pîsim</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">one moon, one month</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêyakohêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>pêyakoh-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He deals with him only.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he deals only with s.o., s/he deals with s.o. alone</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêyakohkam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>pêyakohk-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is the only one at it.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he tends s.t. alone</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">peyakohkawaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">There is more than one at him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêyakohkawêw</l>
-			
-      
-			<lc>VTA-2</lc>
-			
-      
-			<stem>pêyakohkaw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is the only one at him.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he tends s.o. alone</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêyakohkwâmiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>pêyakohkwâmi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he sleeps alone</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêyakohtâw</l>
-			
-      
-			<lc>VTI-2</lc>
-			
-      
-			<stem>pêyakohtâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He keeps to one area. He favors doing one thing only.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he keeps to one area</t>
-				
-       
-				<t pos="V" sources="CW">s/he makes one of s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">peyakokamik</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">One household.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêyakokâtêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>pêyakokâtê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He has one leg.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he has one leg, s/he is one-legged</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêyakokêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>pêyakokê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He lives alone. This term also used for when a girl becomes a woman.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he dwells alone, s/he lives alone</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêyakonêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>pêyakon-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He holds one alone.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he holds s.o. apart, alone</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêyakopiponwêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>pêyakopiponwê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he is one year old</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">pêyakosâp</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">eleven</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">pêyakosâpwâw</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">eleven times</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">pêyakôskân</l>
-			
-      
-			<lc>NA-1</lc>
-			
-      
-			<stem>pêyakôskân-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">One of a kind. One type. One select group.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">one family; one pair (at cards)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêyakôskânêsiwak</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>pêyakôskânêsi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">They are one group of them. E.g. Tribe or nation.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">they are one tribe, one nation</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêyakow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>pêyako-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is alone.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he is alone; s/he is the only one</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pêyakwan</l>
-			
-      
-			<lc>VII-n</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">It is by itself. As a reply, it means &quot;the same&quot;, after &quot;tansi?&quot;.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">same, the same, just the same; similar</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">pêyakwanohk</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">In one spot, place or area.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">in one place, the same spot</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">pêyakwâpisk</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">A silver dollar.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">one dollar, silver dollar</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">pêyakwâw</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Once. One more time.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">once, once more</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">pêyakwayak</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">At one place. In one location.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">in one place, in a certain place; in the same place; one way, one kind</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pîkiskâcimêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>pîkiskâcim-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he makes s.o. lonely (by speech)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">piminawas</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Cook for him. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">piminawasiw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He cooks.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">piminawaso</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Cook. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">piminawataw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">A meal is cooked for him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">piminawatêw</l>
-			
-      
-			<lc>VTA-4</lc>
-			
-      
-			<stem>piminawat-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">She cooks a meal for him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he cooks for s.o., s/he cooks a meal for s.o.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pimitâcimow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>pimitâcimo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He crawls.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he crawls about, s/he crawls around, s/he creeps</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">pimitâcimowin</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>pimitâcimowin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Crawling.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">crawling, creeping</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pohcipayihow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>pohcipayiho-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He wriggles into a hole.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he jumps into a hole</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pohcipayin</l>
-			
-      
-			<lc>VII-n</lc>
-			
-      
-			<stem>pohcipayin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">it falls into a hole</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pohcipayiw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He falls into a hole.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pohciwêpaham</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>pohciwêpah-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He sweeps it in with an object.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he shovels s.t. in</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pohciwêpinam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>pohciwêpin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He throws it in.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he throws s.t. into a hole</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pohciwepinaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He is thrown in.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">pohciwêpinêw</l>
-			
-      
-			<lc>VTA-1</lc>
-			
-      
-			<stem>pohciwêpin-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He throws him in. Animate.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he throws s.o. into a hole</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">poni</l>
-			
-      
-			<lc>IPV</lc>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Meaning stops, finishes.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="IPV">sa</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="IPV" sources="MD">Usually added to a verb to mean continuous action. [Reduplication]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">sâpwâpahtam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>sâpwâpaht-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He sees through it e.g. A microscope.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he sees through s.t., s/he takes a x-ray of s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">sôniyâhkêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>sôniyâhkê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">HE earns money. He makes money from it.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he earns money, s/he earns wages; s/he makes money, s/he creates money</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">sôniyâs</l>
-			
-      
-			<lc>NA-1</lc>
-			
-      
-			<stem>sôniyâs-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Money, in small quantities.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">money; change; [singular:] quarter dollar; a quarter, twenty-five cents</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">sôniyâw</l>
-			
-      
-			<lc>NA-2</lc>
-			
-      
-			<stem>sôniyâw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Money in large quantities.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">money, wages; gold, silver</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">sôniyâwasinahikan</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>sôniyâwasinahikan-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">cheque; money order</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">sôniyâwikamik</l>
-			
-      
-			<lc>NI-3</lc>
-			
-      
-			<stem>sôniyâwikamikw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">bank</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">sôniyâwikimâw</l>
-			
-      
-			<lc>NA-2</lc>
-			
-      
-			<stem>sôniyâwikimâw-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A bank manager.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">Indian Agent</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">tahkikamiw</l>
-			
-      
-			<lc>VII-v</lc>
-			
-      
-			<stem>tahkikami-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">it is cold water</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">tahkocikapawiw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He stands on the top of it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">tahkocikwaskohtiw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He jumps on the top of it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">tahteyihtamowin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">Relief from worry.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">tahto-tipiskâw</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">Every night; each night.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">it is night, it is night time; it is dark</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">tânisi</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">How are you?</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">how, in what way</t>
-				
-       
-				<t pos="Ipc" sources="CW">hello, how are you</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">tânispîhk</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD">When? At what time.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="CW">when</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">tâwaha</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Hit it on target with an object.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he hits s.t. with a missile; s/he hits s.t. (as a target), s/he hits the mark; s/he bumps into s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">tâwaham</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>tâwah-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He hits it on target. E.g. with a car.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he hits s.t. with a missile; s/he hits s.t. (as a target), s/he hits the mark; s/he bumps into s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">tawatinaw</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">His mouth is held open.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">tipinawaham</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>tipinawah-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He shelters it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he shelters s.t. from the wind</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">tipinawahikan</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>tipinawahikan-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A lean to. Anything use for shelter.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">shelter from wind</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">tipinawahikêw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>tipinawahikê-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He makes shelter.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he makes shelter from the wind</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Ipc">tipiskâki</l>
-			
-      
-			<lc>IPC</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Ipc" sources="MD CW">at night, tonight, when it's night; when it gets dark</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">tipiskâw</l>
-			
-      
-			<lc>VII-v</lc>
-			
-      
-			<stem>tipiskâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">Night time. V - It is night.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">it is night, it is night time; it is dark</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">wahkêmow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>wahkêmo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he cries easily</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">wahkemowin</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">The act of crying easily.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">waniskâhk</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">All of you wake up and rise. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">waniskâw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>waniskâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He rises out of bed.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he gets up, s/he arises from lying, s/he gets out of bed; s/he goes in, s/he comes in</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">wanitipiskâw</l>
-			
-      
-			<lc>VII-v</lc>
-			
-      
-			<stem>wanitipiskâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">It is a very dark night.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">it is a dark night, it is very dark</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">wâpahta</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">See it. [Command]</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">wâpahtam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>wâpaht-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He sees it.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he sees s.t., s/he witnesses s.t.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">wâpanacâhkos</l>
-			
-      
-			<lc>NA-1</lc>
-			
-      
-			<stem>wâpanacâhkos-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">morning star</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">wayawîtâcimow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>wayawîtâcimo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he crawls outside</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">wayawîtâpâtam</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>wayawîtâpât-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">s/he drags s.t. outside</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">wîpita</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">tooth</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">witokemiwew</l>
-			
-      
-			<lc/>
-			
-      
-			<stem>md_stem[nr]</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He lives with others.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">wiyâs</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>wiyâs-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">meat</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">wiyâsis</l>
-			
-      
-			<lc>NI-1</lc>
-			
-      
-			<stem>wiyâsis-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD CW">bit of meat, piece of meat</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="N">wiyaw</l>
-			
-      
-			<lc>NDI-1</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">His body.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="CW">body; corpse, dead body</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="Pron">wiyawâw</l>
-			
-      
-			<lc>PrA</lc>
-			
-      
-			<stem>-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="Pron" sources="MD CW">they, them, theirs</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">yahkîmow</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>yahkîmo-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He increases his family. He increases his weight.</t>
-				
-   
-			</tg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he grows; s/he has progeny; [plural:] they increase as a family</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
-			<l pos="V">yêkawan</l>
-			
-      
-			<lc>VII-n</lc>
-			
-      
-			<stem>yêkawan-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD CW">it is sandy</t>
 				
    
 			</tg>
@@ -16598,7 +98,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">Starblanket; literally: &quot;One who has Stars as a Blanket&quot;; name of Cree chief, signatory to Treaty 4</t>
+				<t pos="N" sources="CW">Starblanket; literally: One who has Stars as a Blanket; name of Cree chief, signatory to Treaty 4</t>
 				
    
 			</tg>
@@ -16673,6 +173,43 @@
 				
        
 				<t pos="V" sources="CW">s/he hangs with bottom up, it hangs with bottom up</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">ahcahk</l>
+			
+      
+			<lc>NA-3</lc>
+			
+      
+			<stem>ahcahkw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">soul, spirit</t>
 				
    
 			</tg>
@@ -17098,6 +635,58 @@
 		<lg>
 			
       
+			<l pos="V">akocin</l>
+			
+      
+			<lc>VAI-n</lc>
+			
+      
+			<stem>akocin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He hangs.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he hangs, s/he is hanging, s/he is suspended</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">akohcimêw</l>
 			
       
@@ -17117,6 +706,43 @@
 				
        
 				<t pos="V" sources="CW">s/he puts s.o. into water, s/he soaks s.o. in water, s/he immerses s.o. in water</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">akohcin</l>
+			
+      
+			<lc>VAI-n</lc>
+			
+      
+			<stem>akohcin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD CW">s/he is in water</t>
 				
    
 			</tg>
@@ -17209,6 +835,43 @@
 		<lg>
 			
       
+			<l pos="N">amisk</l>
+			
+      
+			<lc>NA-3</lc>
+			
+      
+			<stem>amiskw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">beaver</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">amisko-kipahikan</l>
 			
       
@@ -17264,7 +927,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">Amisk Lake, SK; literally: &quot;beaver lake&quot;</t>
+				<t pos="N" sources="CW">Amisk Lake, SK; literally: beaver lake</t>
 				
    
 			</tg>
@@ -17412,7 +1075,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">mint; literally: &quot;beaver-sweetgrass&quot;</t>
+				<t pos="N" sources="CW">mint; literally: beaver-sweetgrass</t>
 				
    
 			</tg>
@@ -17523,7 +1186,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">yellow blackberry; literally: &quot;beaver-berry&quot;</t>
+				<t pos="N" sources="CW">yellow blackberry; literally: beaver-berry</t>
 				
    
 			</tg>
@@ -17560,7 +1223,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">yellow blackberry tree; literally: &quot;beaver-berry bush&quot;</t>
+				<t pos="N" sources="CW">yellow blackberry tree; literally: beaver-berry bush</t>
 				
    
 			</tg>
@@ -17597,7 +1260,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">wood duck; literally: &quot;beaver duck&quot;</t>
+				<t pos="N" sources="CW">wood duck; literally: beaver duck</t>
 				
    
 			</tg>
@@ -17856,7 +1519,44 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">Edmonton, AB; Fort Edmonton; literally: &quot;Beaver Hills House&quot;</t>
+				<t pos="N" sources="CW">Edmonton, AB; Fort Edmonton; literally: Beaver Hills House</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">amiskwayân</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>amiskwayân-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">beaver-pelt</t>
 				
    
 			</tg>
@@ -17912,6 +1612,214 @@
 		<lg>
 			
       
+			<l pos="Pron">ana</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">That one, (him/her).</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">that</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">anihi</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">Those things, there.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">that; those</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">anihi</l>
+			
+      
+			<lc>PrI</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">Those things, there.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">those</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">aniki</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">Those people there.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">those</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">anikwacâsi-mîciwin</l>
 			
       
@@ -17931,6 +1839,43 @@
 				
        
 				<t pos="N" sources="CW">peanut butter</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">anohc</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">now, today</t>
 				
    
 			</tg>
@@ -18060,6 +2005,110 @@
 		<lg>
 			
       
+			<l pos="V">asawâpahtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>asawâpaht-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is on the look-out for it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he waits and watches for s.t.; s/he looks out for s.t.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">asawâpamêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>asawâpam-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is on the look-out for him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he looks out for s.o., s/he waits and watches for s.o., s/he lies in watch for s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">asawâpiw</l>
 			
       
@@ -18134,6 +2183,58 @@
 		<lg>
 			
       
+			<l pos="N">asawâpiwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>asawâpiwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">2. A blind that is used by hunters, usually man-made, from trees shrubs or a hill, to watch for the enemy.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">hunting-blind; a place to watch from; look-out, lighthouse, watchtower; looking out</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">asêtâcimow</l>
 			
       
@@ -18189,7 +2290,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">Smoothstone Lake, SK; literally: &quot;many stones lake&quot;</t>
+				<t pos="N" sources="CW">Smoothstone Lake, SK; literally: many stones lake</t>
 				
    
 			</tg>
@@ -18227,6 +2328,58 @@
 				
        
 				<t pos="N" sources="CW">Woods Cree, Woods Cree person; Rock Cree, Rock Cree person; [plural:] the Woods Cree people; the Rock Cree people</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">atamiskawêw</l>
+			
+      
+			<lc>VTA-2</lc>
+			
+      
+			<stem>atamiskaw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He shook hands with him or them.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he greets s.o., s/he sends greetings to s.o.; s/he says hello to s.o.; s/he shakes hands with s.o.; s/he hugs s.o. in greeting, s/he kisses s.o. in greeting; s/he bids s.o. farewell</t>
 				
    
 			</tg>
@@ -18412,6 +2565,58 @@
 				
        
 				<t pos="V" sources="CW">they greet one another</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">atâhk</l>
+			
+      
+			<lc>NA-3</lc>
+			
+      
+			<stem>atâhkw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A big bright star.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">star</t>
 				
    
 			</tg>
@@ -18618,6 +2823,58 @@
 		<lg>
 			
       
+			<l pos="Pron">awa</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">This one.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">this, this one</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">awahkâkan</l>
 			
       
@@ -18748,6 +3005,113 @@
 				
        
 				<t pos="Ipc" sources="CW">go on; go away; get out of my way</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">awasâpisk</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">Beyond the Rocky Mountains, B.C.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">beyond the rocks; beyond the Rocky Mountains</t>
+				
+       
+				<t pos="Ipc" sources="CW">British Columbia</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">awasâyihk</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">On the other side (of). E.g. A hill.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">beyond the place, beyond the bush</t>
 				
    
 			</tg>
@@ -19191,7 +3555,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="Ipc" sources="CW">United States; literally: &quot;beyond the border&quot;</t>
+				<t pos="Ipc" sources="CW">United States; literally: beyond the border</t>
 				
    
 			</tg>
@@ -19321,6 +3685,58 @@
 		<lg>
 			
       
+			<l pos="Ipc">awasimê</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">Above, more. Over and above the limit. More and more.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">further, beyond; more</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">awasita</l>
 			
       
@@ -19340,6 +3756,95 @@
 				
        
 				<t pos="Ipc" sources="CW">go on; go away; on, to the further side (in time or space); further on, beyond, more</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">awasitâkosîhk</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD CW">day before yesterday</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">awasitê</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">1. Further away. Beyond.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">go on; go away; on, to the further side (in time or space); beyond, further over there</t>
 				
    
 			</tg>
@@ -19598,7 +4103,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">family allowance; literally: &quot;child-money, small amount of money or change for a child&quot;</t>
+				<t pos="N" sources="CW">family allowance; literally: child-money, small amount of money or change for a child</t>
 				
    
 			</tg>
@@ -19673,6 +4178,43 @@
 				
        
 				<t pos="N" sources="CW">being a child, childhood</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">awîna</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD CW">who, whose</t>
 				
    
 			</tg>
@@ -19876,6 +4418,58 @@
 		<lg>
 			
       
+			<l pos="N">ayiwinisa</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>ayiwinis-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">Clothes.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">clothes; clothing, apparel; [singular:] article of clothing</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">ayiwinisi-akocikan</l>
 			
       
@@ -19987,6 +4581,162 @@
 		<lg>
 			
       
+			<l pos="V">âcimêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>âcim-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is telling a story about him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he tells about s.o., s/he talks about s.o.; s/he narrates about s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">âcimow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>âcimo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He told a story.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he tells, s/he tells a story; s/he tells news, s/he gives an account, s/he narrates; s/he tells his/her own story</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">âcimowin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>âcimowin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A story. A news forecast.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">story, true story, account, report; news; what is being told</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">âkawaskwêw</l>
 			
       
@@ -20079,7 +4829,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">cheese; literally: &quot;mouse food&quot;</t>
+				<t pos="N" sources="CW">cheese; literally: mouse food</t>
 				
    
 			</tg>
@@ -20153,7 +4903,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">lunch, dinner; literally: &quot;mid-day meal&quot;</t>
+				<t pos="N" sources="CW">lunch, dinner; literally: mid-day meal</t>
 				
    
 			</tg>
@@ -20227,7 +4977,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">noon meal, lunch, dinner; literally: &quot;mid-day meal&quot;</t>
+				<t pos="N" sources="CW">noon meal, lunch, dinner; literally: mid-day meal</t>
 				
    
 			</tg>
@@ -20542,6 +5292,43 @@
 		<lg>
 			
       
+			<l pos="V">cimihtawakêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>cimihtawakê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD CW">s/he has short ears</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">ciyêkwac</l>
 			
       
@@ -20727,6 +5514,58 @@
 		<lg>
 			
       
+			<l pos="Ipc">êkwa</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">And also.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">and, also; then; now</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">êkwa ani</l>
 			
       
@@ -20857,6 +5696,58 @@
 				
        
 				<t pos="Ipc" sources="CW">o.k. now, let's go</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">êkwayâc</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">Only now, for the first time.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">only now, for the first time, just then</t>
 				
    
 			</tg>
@@ -21208,43 +6099,6 @@
 		<lg>
 			
       
-			<l pos="V">iskwapiw</l>
-			
-      
-			<lc>VAI-v</lc>
-			
-      
-			<stem>iskwapi-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he has just so much left</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
 			<l pos="V">iskwâpiw</l>
 			
       
@@ -21301,6 +6155,58 @@
 				
        
 				<t pos="Ipc" sources="CW">when</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">itâcimêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>itâcim-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">What he tells about him in a story.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he tells thus about s.o., s/he narrates thus about s.o.</t>
 				
    
 			</tg>
@@ -21541,6 +6447,110 @@
 		<lg>
 			
       
+			<l pos="V">kanawâpahtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>kanawâpaht-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He keeps looking at it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he looks at s.t., s/he observes s.t.; s/he watches s.t.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kanawâpamêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>kanawâpam-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He watches him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he looks at s.o.; s/he looks after s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">kapê-nîpin</l>
 			
       
@@ -21689,6 +6699,58 @@
 		<lg>
 			
       
+			<l pos="V">kaski-tipiskâw</l>
+			
+      
+			<lc>VII-v</lc>
+			
+      
+			<stem>kaski-tipiskâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">The night is pitch black.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it is pitch-black night</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">katawa</l>
 			
       
@@ -21708,6 +6770,236 @@
 				
        
 				<t pos="Ipc" sources="CW">properly</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">katawasisin</l>
+			
+      
+			<lc>VII-n</lc>
+			
+      
+			<stem>katawasisin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD CW">it is beautiful</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">katawasisiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>katawasisi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is beautiful.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he is beautiful, s/he is good-looking</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">katawasisiwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>katawasisiwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">beauty</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">katawasisîhêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>katawasisîh-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He beautifies another.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he makes s.o. beautiful, s/he beautifies s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">katawasisîhtâw</l>
+			
+      
+			<lc>VTI-2</lc>
+			
+      
+			<stem>katawasisîhtâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He makes it beautiful.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he beautifies s.t.</t>
 				
    
 			</tg>
@@ -21763,6 +7055,162 @@
 		<lg>
 			
       
+			<l pos="V">kawacipayiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>kawacipayi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He gets a chill.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he gets chilled, s/he gets cold</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kawaciw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>kawaci-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is cold (from the weather).</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he is cold, s/he experiences cold, s/he suffers from cold</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">kawaciwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>kawaciwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">The state of being cold or chilled.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">coldness; of or pertaining to being cold</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">kawaciyawêpayiw</l>
 			
       
@@ -21782,6 +7230,162 @@
 				
        
 				<t pos="V" sources="CW">s/he has the chills</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kawaham</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>kawah-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He chops it down.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he chops s.t. down, s/he fells s.t.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kawahikêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>kawahikê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">1. He falls trees. 2. He knocks down something.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he chops down trees</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kawahtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>kawaht-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He bites or eats it until it falls.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he bites s.t. until it falls, s/he eats s.t. until it falls</t>
 				
    
 			</tg>
@@ -21837,6 +7441,58 @@
 		<lg>
 			
       
+			<l pos="V">kawamêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>kawam-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He gnaws him down. Him is an animate object.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it gnaws s.o. down (e.g. a beaver to a tree)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">kawatâpâwêw</l>
 			
       
@@ -21856,6 +7512,58 @@
 				
        
 				<t pos="V" sources="CW">s/he freezes immersed, s/he is wet to prostration</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kawatihtâw</l>
+			
+      
+			<lc>VTI-2</lc>
+			
+      
+			<stem>kawatihtâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He gets it cold.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he gets (it/him) chilled, s/he gets s.t. cold</t>
 				
    
 			</tg>
@@ -21967,6 +7675,43 @@
 				
        
 				<t pos="V" sources="CW">it is cold</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">kawâhtik</l>
+			
+      
+			<lc>NA-3</lc>
+			
+      
+			<stem>kawâhtikw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">fallen tree</t>
 				
    
 			</tg>
@@ -22152,6 +7897,58 @@
 				
        
 				<t pos="Ipc" sources="CW">back and forth; criss-crossed</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kâkîsimow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>kâkîsimo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is praying to the Creator.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he prays, s/he pleads, s/he chants</t>
 				
    
 			</tg>
@@ -22503,6 +8300,43 @@
 		<lg>
 			
       
+			<l pos="N">kihci-niska</l>
+			
+      
+			<lc>NA-4</lc>
+			
+      
+			<stem>kihci-nisk-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">Canada goose</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">kihci-sôniyâw</l>
 			
       
@@ -22522,6 +8356,162 @@
 				
        
 				<t pos="N" sources="CW">pound sterling (used in Treaty)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kikamow</l>
+			
+      
+			<lc>VII-v</lc>
+			
+      
+			<stem>kikamo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">It clings, it sticks.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it is attached</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kikamow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>kikamo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">It clings, it sticks.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it clings, it sticks; it is fastened on</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kinohtawakêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>kinohtawakê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He has long ears.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he has long ears</t>
 				
    
 			</tg>
@@ -22633,6 +8623,58 @@
 				
        
 				<t pos="V" sources="CW">s/he is unable to hear, s/he has a blockage of the ear</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kisâcimêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>kisâcim-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He persuades him to stay.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he convinces s.o. to stay</t>
 				
    
 			</tg>
@@ -22984,6 +9026,147 @@
 		<lg>
 			
       
+			<l pos="V">kiskinwahamâkosiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>kiskinwahamâkosi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is being taught. He's learning. He is going to school.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he learns; s/he is a student, s/he attends school; s/he is taught</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">kiskinwahamâkosiwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>kiskinwahamâkosiwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">The act of learning. Education.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">learning, being a student, attending school; schoolwork, homework</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">kiskisopayiwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>kiskisopayiwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">recollection</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">kistâpawacikêw</l>
 			
       
@@ -23114,6 +9297,58 @@
 				
        
 				<t pos="V" sources="CW">s/he washes him/herself</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kitâpahtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>kitâpaht-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He looks at it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he looks at s.t.</t>
 				
    
 			</tg>
@@ -23447,6 +9682,110 @@
 				
        
 				<t pos="V" sources="CW">s/he has itchy ears</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">kiyawâw</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">You all.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">you</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">kiyânaw</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">Us, we all.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">we, us; we-and-you</t>
 				
    
 			</tg>
@@ -23909,6 +10248,43 @@
 		<lg>
 			
       
+			<l pos="N">kîwâtêyimowin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>kîwâtêyimowin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">loneliness, depression</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">kîwêtinohk ohci</l>
 			
       
@@ -23965,6 +10341,58 @@
 				
        
 				<t pos="V" sources="CW">s/he tries s.o. (e.g. motorized vehicle)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kocipayihtâw</l>
+			
+      
+			<lc>VTI-2</lc>
+			
+      
+			<stem>kocipayihtâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He tries to make it work.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he tries s.t. (e.g. computer)</t>
 				
    
 			</tg>
@@ -24057,6 +10485,58 @@
 		<lg>
 			
       
+			<l pos="V">kohcipayihtâw</l>
+			
+      
+			<lc>VTI-2</lc>
+			
+      
+			<stem>kohcipayihtâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He swallows it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he swallows s.t.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">kôhkomipaninaw</l>
 			
       
@@ -24075,7 +10555,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">cucumber; literally: &quot;our deceased grandmother&quot;</t>
+				<t pos="N" sources="CW">cucumber; literally: our deceased grandmother</t>
 				
    
 			</tg>
@@ -24316,6 +10796,110 @@
 		<lg>
 			
       
+			<l pos="V">mahkihtawakêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>mahkihtawakê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He has large ears.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he has large ears</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">mamihcisiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>mamihcisi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is proud.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he is proud</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">manâcimâkan</l>
 			
       
@@ -24335,6 +10919,58 @@
 				
        
 				<t pos="N" sources="CW">parent-in-law; child-in-law; person to whom speech is avoided</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">manâcimêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>manâcim-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He has respect for him (language wise).</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he is careful how s/he speaks to s.o. out of respect; s/he avoids speaking to s.o.</t>
 				
    
 			</tg>
@@ -24501,6 +11137,58 @@
 		<lg>
 			
       
+			<l pos="N">maskosis</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>maskosis-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A bear cub.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">little bear, bear cub</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">maskosîs</l>
 			
       
@@ -24538,6 +11226,162 @@
 		<lg>
 			
       
+			<l pos="N">maskwa</l>
+			
+      
+			<lc>NA-4w</lc>
+			
+      
+			<stem>maskw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A bear.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">bear, black bear</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">maskwacîs</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>maskwacîs-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A small bear's hill located in Hobbema.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">Hobbema, AB; literally: Little Bear Hills</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">maskwacîsihk</l>
+			
+      
+			<lc>INM</lc>
+			
+      
+			<stem>maskwacîs- NI-1</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">Hobbema.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">Hobbema, AB; Plains Cree community; literally: at Little Bear Hills</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">maskwamiy</l>
 			
       
@@ -24557,6 +11401,43 @@
 				
        
 				<t pos="N" sources="CW">ice</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">maskwayân</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>maskwayân-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">bear skin</t>
 				
    
 			</tg>
@@ -25167,6 +12048,147 @@
 		<lg>
 			
       
+			<l pos="V">mâyâcimêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>mâyâcim-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He tells bad news of him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he speaks ill of s.o., s/he tells bad news of s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">mâyâcimow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>mâyâcimo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He tells bad news.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he tells bad news</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">mâyâcimowin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>mâyâcimowin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">bad news</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">mâyipayiwin</l>
 			
       
@@ -25334,6 +12356,58 @@
 				
        
 				<t pos="V" sources="CW">while it is daylight</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">mêkwâ-pimâtisiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>mêkwâ-pimâtisi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is living at the present time.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">while s/he lives, s/he is living presently, during his/her lifespan</t>
 				
    
 			</tg>
@@ -25537,6 +12611,95 @@
 		<lg>
 			
       
+			<l pos="N">mihtawakay</l>
+			
+      
+			<lc>NDI-2</lc>
+			
+      
+			<stem>-htawakay-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">ear</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">mikoskâcimêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>mikoskâcim-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He annoys him by senseless talk.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he disturbs s.o., s/he annoys s.o. (by speech)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">minôs</l>
 			
       
@@ -25574,6 +12737,58 @@
 		<lg>
 			
       
+			<l pos="N">minôsis</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>minôsis-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A kitten.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">kitten, little cat</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">misi-minôs</l>
 			
       
@@ -25593,6 +12808,58 @@
 				
        
 				<t pos="N" sources="CW">large cat</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">misihkêmow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>misihkêmo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He tattle tales.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he tattle, s/he tells on, s/he reveals the truth</t>
 				
    
 			</tg>
@@ -25926,6 +13193,58 @@
 				
        
 				<t pos="V" sources="CW">s/he has his/her property look nice, s/he has things look prosperous</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">miyopayiwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>miyopayiwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">Prosperity and good luck.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">good luck; welfare; prosperity; good heart</t>
 				
    
 			</tg>
@@ -26388,6 +13707,147 @@
 		<lg>
 			
       
+			<l pos="V">mîciw</l>
+			
+      
+			<lc>VTI-3</lc>
+			
+      
+			<stem>mîci-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He eats it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he eats s.t.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">mîciwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>mîciwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">Food.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">food, groceries; meal</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">mîciwinis</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>mîciwinis-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">bit of food</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">mîkisayiwinisa</l>
 			
       
@@ -26407,6 +13867,43 @@
 				
        
 				<t pos="N" sources="CW">beaded clothing</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">mîpit</l>
+			
+      
+			<lc>NDI-1</lc>
+			
+      
+			<stem>-îpit-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">tooth</t>
 				
    
 			</tg>
@@ -26610,6 +14107,110 @@
 		<lg>
 			
       
+			<l pos="Ipc">mohcihk</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">On the ground, or floor.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">on the bare ground; on the floor; to the ground</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">mohcihtak</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">The floor.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">on the floor, on the floorboards</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">mohcihtakâhk</l>
 			
       
@@ -26721,6 +14322,58 @@
 		<lg>
 			
       
+			<l pos="V">mowêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>mow-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He eats him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he eats s.o. (e.g. bread)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">mônisôniyâwêw</l>
 			
       
@@ -26814,6 +14467,110 @@
 				
        
 				<t pos="N" sources="CW">a White-Man, the Whites; little White-Man; Canadian</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">môniyâskwêw</l>
+			
+      
+			<lc>NA-2</lc>
+			
+      
+			<stem>môniyâskwêw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">Any white woman.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">a White woman, Canadian woman</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">môniyâw</l>
+			
+      
+			<lc>NA-2</lc>
+			
+      
+			<stem>môniyâw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">Any white man.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">White-Man; non-Indian; Canadian</t>
 				
    
 			</tg>
@@ -27165,6 +14922,110 @@
 		<lg>
 			
       
+			<l pos="V">namiskwêstawêw</l>
+			
+      
+			<lc>VTA-2</lc>
+			
+      
+			<stem>namiskwêstaw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He nods to him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he nods to s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">namiskwêyiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>namiskwêyi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He nods.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he puts his/her own head down</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">namôya êkwayikohk</l>
 			
       
@@ -27258,6 +15119,58 @@
 				
        
 				<t pos="V" sources="CW">s/he bows to s.o. (with the head only like a nod); s/he bows his/her own head to s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nanamiskwêyiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nanamiskwêyi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He nods his head.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he nods his/her own head, s/he shakes his/her own head</t>
 				
    
 			</tg>
@@ -27517,6 +15430,58 @@
 				
        
 				<t pos="N" sources="CW">scouting party (during tribal wars)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">nawac</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">Preferably.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">by comparison; better, more; before; instead, rather, somewhat</t>
 				
    
 			</tg>
@@ -27905,6 +15870,58 @@
 		<lg>
 			
       
+			<l pos="V">nawacîw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nawacî-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He cooks an item.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he roasts s.t., s/he cooks s.t. (i.e. in a wood stove or on a fire)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">nawacîwâtêw</l>
 			
       
@@ -27961,6 +15978,58 @@
 				
        
 				<t pos="N" sources="CW">roast</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nawakapiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nawakapi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He sits with his head and body bent down.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he sits with his/her own head and body bent down</t>
 				
    
 			</tg>
@@ -28090,6 +16159,110 @@
 		<lg>
 			
       
+			<l pos="V">nawakiskwêpiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nawakiskwêpi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He sits with his head down.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he sits with his/her own head down</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nawakiskwêyiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nawakiskwêyi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He hangs his head down.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he hangs his/her own head down, s/he bends down his/her own head</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">nawakîstawêw</l>
 			
       
@@ -28127,6 +16300,58 @@
 		<lg>
 			
       
+			<l pos="V">nawakîw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nawakî-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He stoops or bends down.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he bends over, s/he bends down, s/he bends forward; s/he stoops, s/he bends</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">nawasawâpamow</l>
 			
       
@@ -28146,6 +16371,58 @@
 				
        
 				<t pos="V" sources="CW">s/he makes his/her choice by sight</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nawasônam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>nawasôn-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He chooses it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he chooses s.t.</t>
 				
    
 			</tg>
@@ -28238,6 +16515,58 @@
 		<lg>
 			
       
+			<l pos="V">nawasônêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>nawasôn-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He chooses him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he chooses s.o.; s/he picks s.o. out</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">nawasônikan</l>
 			
       
@@ -28275,6 +16604,110 @@
 		<lg>
 			
       
+			<l pos="V">nawasônikêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nawasônikê</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He chooses.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he chooses</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">nawasônikêwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>nawasônikêwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">The act of choosing.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">choosing</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">nawaswâsiwêw</l>
 			
       
@@ -28294,6 +16727,147 @@
 				
        
 				<t pos="V" sources="CW">s/he chases after a person, people; s/he pursues a person, people</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nawaswâtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>nawaswât-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">he chases it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he chases after s.t., s/he pursues s.t.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nawaswâtêw</l>
+			
+      
+			<lc>VTA-4</lc>
+			
+      
+			<stem>nawaswât-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He chases him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he chases after s.o., s/he pursues s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nawaswâtitowak</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nawaswâtito-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD CW">they chase one another</t>
 				
    
 			</tg>
@@ -28460,6 +17034,110 @@
 		<lg>
 			
       
+			<l pos="V">nawatâskitêw</l>
+			
+      
+			<lc>VII-v</lc>
+			
+      
+			<stem>nawatâskitê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">It caught on fire.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it catches on fire, it is reached by flames, it catches fire</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nawatinam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>nawatin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He catches it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he grabs s.t., s/he seizes s.t.; s/he catches s.t. in his/her hand</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">nawatinamawêw</l>
 			
       
@@ -28479,6 +17157,58 @@
 				
        
 				<t pos="V" sources="CW">s/he takes hold of (it/him) for s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nawatinêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>nawatin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">he catches him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he grabs s.o., s/he seizes s.o.; s/he catches s.o. in his/her hand (e.g. a ball)</t>
 				
    
 			</tg>
@@ -28793,6 +17523,43 @@
 		<lg>
 			
       
+			<l pos="N">nâpê-minôs</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>nâpê-minôs-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">tomcat</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">nâtawâpahtam</l>
 			
       
@@ -28923,6 +17690,110 @@
 				
        
 				<t pos="V" sources="CW">s/he fetches money (e.g. get treaty money)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">nêhi</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">Those things. Inanimate.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">those yonder, that yonder</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">nêhi</l>
+			
+      
+			<lc>PrI</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">Those things. Inanimate.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">those yonder, that yonder</t>
 				
    
 			</tg>
@@ -29163,6 +18034,110 @@
 		<lg>
 			
       
+			<l pos="Pron">nêki</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">Those people over there (pointed at).</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">those yonder</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">nêma</l>
+			
+      
+			<lc>PrI</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">That thing over there.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">that yonder</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">nêtê ohci</l>
 			
       
@@ -29218,7 +18193,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">four dollars; [literally: &quot;four-pelt&quot;]</t>
+				<t pos="N" sources="CW">four dollars; [literally: four-pelt]</t>
 				
    
 			</tg>
@@ -29367,6 +18342,58 @@
 				
        
 				<t pos="N" sources="CW">my ear</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nihtâ-kitohcikêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nihtâ-kitohcikê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He plays music well.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he plays music well</t>
 				
    
 			</tg>
@@ -29570,6 +18597,110 @@
 		<lg>
 			
       
+			<l pos="V">nipâw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nipâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He sleeps.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he sleeps, s/he is asleep</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">nipâwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>nipâwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">Sleep.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">sleeping, sleep</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">nipêyakokosisân</l>
 			
       
@@ -29589,6 +18720,43 @@
 				
        
 				<t pos="N" sources="CW">my only son</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">nipiy</l>
+			
+      
+			<lc>NI-2</lc>
+			
+      
+			<stem>nipiy-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">water</t>
 				
    
 			</tg>
@@ -29718,6 +18886,43 @@
 		<lg>
 			
       
+			<l pos="N">niska</l>
+			
+      
+			<lc>NA-4</lc>
+			
+      
+			<stem>nisk-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">goose</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">niskan</l>
 			
       
@@ -29829,6 +19034,43 @@
 		<lg>
 			
       
+			<l pos="N">niskisis</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>niskisis-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">gosling</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">niskîsik</l>
 			
       
@@ -29848,6 +19090,43 @@
 				
        
 				<t pos="N" sources="CW">my eye</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">nisto</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD CW">three</t>
 				
    
 			</tg>
@@ -29995,7 +19274,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="V" sources="CW">it is Wednesday; literally: &quot;(it is) the third day&quot;</t>
+				<t pos="V" sources="CW">it is Wednesday; literally: (it is) the third day</t>
 				
    
 			</tg>
@@ -30144,6 +19423,58 @@
 				
        
 				<t pos="V" sources="CW">they sleep three in a bed</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nistohtâw</l>
+			
+      
+			<lc>VTI-2</lc>
+			
+      
+			<stem>nistohtâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He divides it into three.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he divides s.t. in three</t>
 				
    
 			</tg>
@@ -30384,6 +19715,43 @@
 		<lg>
 			
       
+			<l pos="Ipc">nistomitanaw</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD CW">thirty</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">nistomitanaw tahtwâpisk</l>
 			
       
@@ -30440,6 +19808,43 @@
 				
        
 				<t pos="V" sources="CW">s/he is three years old</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">nistosâp</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD CW">thirteen</t>
 				
    
 			</tg>
@@ -30976,6 +20381,43 @@
 		<lg>
 			
       
+			<l pos="Pron">niya</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">I, me, mine</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Pron">niyanân</l>
 			
       
@@ -31050,13 +20492,13 @@
 		<lg>
 			
       
-			<l pos="Ipc">niyâ</l>
+			<l pos="N">niyaw</l>
 			
       
-			<lc>IPJ</lc>
+			<lc>NDI-1</lc>
 			
       
-			<stem/>
+			<stem>-iyaw-</stem>
 			
    
 		</lg>
@@ -31068,7 +20510,22 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="Ipc" sources="CW">go ahead, go on, be off!</t>
+				<t pos="N" sources="MD">My body.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">my body</t>
 				
    
 			</tg>
@@ -31161,6 +20618,147 @@
 		<lg>
 			
       
+			<l pos="Ipc">niyânan</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD CW">five</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">niyânaniwa</l>
+			
+      
+			<lc>VII-v</lc>
+			
+      
+			<stem>niyânani-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">There are five of them. Inanimate.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">they are five in number</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">niyânaniwak</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>niyânani-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">There are five of them. Animate.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">they are five in number</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">niyânano-kîsikâw</l>
 			
       
@@ -31179,7 +20777,118 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="V" sources="CW">it is Friday; literally: &quot;(it is )the fifth day&quot;</t>
+				<t pos="V" sources="CW">it is Friday; literally: (it is )the fifth day</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">niyânanomitanaw</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD CW">fifty</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">niyânanosâp</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD CW">fifteen</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">niyânanosâpwâw</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD CW">fifteen times</t>
 				
    
 			</tg>
@@ -31328,6 +21037,58 @@
 				
        
 				<t pos="Ipc" sources="CW">next summer; in the (coming) summer, when it's summer</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nîpin</l>
+			
+      
+			<lc>VII-n</lc>
+			
+      
+			<stem>nîpin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">Summertime.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it is summer</t>
 				
    
 			</tg>
@@ -31549,7 +21310,188 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">stone boat; wagon; perhaps literally: &quot;summer sled&quot;</t>
+				<t pos="N" sources="CW">stone boat; wagon; perhaps literally: summer sled</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">nîpinohk</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD CW">last summer</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">nîpisîs</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>nîpisîs-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A willow branch used for discipline.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">willow branch, willow switch; little willow</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">nîpit</l>
+			
+      
+			<lc>NDI-1</lc>
+			
+      
+			<stem>-îpit-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">My tooth.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">my tooth</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">nîpiy</l>
+			
+      
+			<lc>NI-2</lc>
+			
+      
+			<stem>nîpiy-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">leaf; blade of grass</t>
+				
+       
+				<t pos="N" sources="CW">[plural:] leaves; salad</t>
 				
    
 			</tg>
@@ -31697,7 +21639,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="V" sources="CW">it is Tuesday night; literally: &quot;(it is) the second night&quot;</t>
+				<t pos="V" sources="CW">it is Tuesday night; literally: (it is) the second night</t>
 				
    
 			</tg>
@@ -31735,6 +21677,58 @@
 				
        
 				<t pos="Ipc" sources="CW">two nights</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">nôhkom</l>
+			
+      
+			<lc>NDA-1</lc>
+			
+      
+			<stem>-ohkom-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">My grandmother.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">my grandmother; [reference extended to all related females of grandmother's generation]; my respected female elder</t>
 				
    
 			</tg>
@@ -31901,6 +21895,58 @@
 		<lg>
 			
       
+			<l pos="V">nôkohcikêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nôkohcikê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He shows something.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he shows things</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">nômakês</l>
 			
       
@@ -31975,6 +22021,43 @@
 		<lg>
 			
       
+			<l pos="N">nôsê-minôs</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>nôsê-minôs-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">female cat</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">nôtamiskwêw</l>
 			
       
@@ -31994,6 +22077,58 @@
 				
        
 				<t pos="V" sources="CW">s/he hunts beavers</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">ocêkatâhk</l>
+			
+      
+			<lc>NA-3</lc>
+			
+      
+			<stem>ocêkatâhkw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">The Big Dipper.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">the Big Dipper, the Great Bear (constellation)</t>
 				
    
 			</tg>
@@ -32086,6 +22221,266 @@
 		<lg>
 			
       
+			<l pos="V">ocipitam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>ocipit-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He pulls it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he pulls s.t., s/he pulls s.t. out, towards</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ocipitêw</l>
+			
+      
+			<lc>VTA-4</lc>
+			
+      
+			<stem>ocipit-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He pulls him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he pulls s.o., s/he pulls s.o. out, towards; s/he wins from s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ocipitikow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>ocipitiko-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He has cramps. He has a seizure.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he has a seizure, s/he has fits; s/he has cramps</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ociwâmiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>ociwâmi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He has a brother who is a cousin.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">he has a brother, he has a male parallel cousin</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">ohci</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">From, out of, for.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">from there, thence, out of; with, by means of; because of; for; from then; about</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">ohci-kâhcitinam</l>
 			
       
@@ -32160,6 +22555,110 @@
 		<lg>
 			
       
+			<l pos="V">ohci-wayawîw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>ohci-wayawî-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">That's where he goes out of.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he comes out of (there)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ohciciwan</l>
+			
+      
+			<lc>VII-n</lc>
+			
+      
+			<stem>ohciciwan-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">That's where it flows from.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it flows thence, it flows from there</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">ohcihêw</l>
 			
       
@@ -32179,6 +22678,58 @@
 				
        
 				<t pos="V" sources="CW">s/he stops s.o., s/he holds s.o. away</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ohcikawâpiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>ohcikawâpi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He sheds tears.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he sheds tears; s/he has tears dropping</t>
 				
    
 			</tg>
@@ -32271,6 +22822,58 @@
 		<lg>
 			
       
+			<l pos="V">ohcikawihtâw</l>
+			
+      
+			<lc>VTI-2</lc>
+			
+      
+			<stem>ohcikawihtâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He makes it drip.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he makes s.t. drip, leak</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">ohcikawitêyikomêw</l>
 			
       
@@ -32308,13 +22911,13 @@
 		<lg>
 			
       
-			<l pos="V">ohcikawiw</l>
+			<l pos="V">ohcinatêw</l>
 			
       
-			<lc>VII-v</lc>
+			<lc>VTA-4</lc>
 			
       
-			<stem>ohcikawi-</stem>
+			<stem>ohcinat-</stem>
 			
    
 		</lg>
@@ -32326,7 +22929,22 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="V" sources="CW">it drips, it flows from there; it leaks</t>
+				<t pos="V" sources="MD">He hits him over it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he fights s.o. over something; s/he fights s.o. on account of something</t>
 				
    
 			</tg>
@@ -32475,6 +23093,162 @@
 				
        
 				<t pos="V" sources="CW">s/he runs from there</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ohcipayin</l>
+			
+      
+			<lc>VII-n</lc>
+			
+      
+			<stem>ohcipayin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">That's where it comes from.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it comes from there, it results from that</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ohcipayiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>ohcipayi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">That's where he comes from, riding.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he moves thence, s/he rides thence</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ohcipayiw</l>
+			
+      
+			<lc>VII-v</lc>
+			
+      
+			<stem>ohcipayi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">That's where he comes from, riding.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it moves thence, it rides thence; it come from there</t>
 				
    
 			</tg>
@@ -32752,6 +23526,58 @@
 		<lg>
 			
       
+			<l pos="Ipc">ohcitaw</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">Deliberately. Something done on purpose.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">on purpose, purposely, deliberately; it has to be, it is necessary; as expected; without fail; by all means; expressly, specifically</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">ohciyawêw</l>
 			
       
@@ -32974,6 +23800,58 @@
 		<lg>
 			
       
+			<l pos="N">ohtêyihtamowin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>ohtêyihtamowin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">Envy.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">jealousy, envy</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">ohtiskawapiw</l>
 			
       
@@ -32993,6 +23871,214 @@
 				
        
 				<t pos="V" sources="CW">s/he sits facing; s/he sits in front (facing an audience)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ohtiskawapîstam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>ohtiskawapîst-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He sits in front of it (facing it).</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he sits in front of and facing s.t.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ohtiskawapîstawêw</l>
+			
+      
+			<lc>VTA-2</lc>
+			
+      
+			<stem>ohtiskawapîstaw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He sits facing him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he sits in front of and facing s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">okitohcikaniw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>okitohcikani-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He has musical instruments.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he has musical instruments</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">okitohcikêw</l>
+			
+      
+			<lc>NA-2</lc>
+			
+      
+			<stem>okitohcikêw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A musician. He who plays music.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">musician; [pl:] orchestra</t>
 				
    
 			</tg>
@@ -33178,6 +24264,95 @@
 				
        
 				<t pos="V" sources="CW">s/he has a threshing machine, s/he has a combine</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">opawahikêw</l>
+			
+      
+			<lc>NA-2</lc>
+			
+      
+			<stem>opawahikêw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A thresher. One who threshes grain.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">thresher, one who threshes grain, one who combines</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">opiminawasow</l>
+			
+      
+			<lc>NA-2</lc>
+			
+      
+			<stem>opiminawasow-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">chef; cook</t>
 				
    
 			</tg>
@@ -33474,6 +24649,58 @@
 				
        
 				<t pos="V" sources="CW">it contains gold; it is made of gold</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">oskan</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>oskan-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A bone.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">bone; his/her bone</t>
 				
    
 			</tg>
@@ -33862,6 +25089,58 @@
 		<lg>
 			
       
+			<l pos="V">otânisiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>otânisi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He has a daughter.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he has (s.o. as) a daughter</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">otâpâtam</l>
 			
       
@@ -33918,6 +25197,162 @@
 				
        
 				<t pos="N" sources="CW">his/her innards (e.g. of an animal)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">ôhi</l>
+			
+      
+			<lc>PrI</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">These things, here. (Inanimate).</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">these ones</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">ôhi</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">These things, here. (Inanimate).</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">this one, these ones</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">ôki</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="MD">These animate items her. E.g. These cars here. Minosak oki.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">these</t>
 				
    
 			</tg>
@@ -34066,6 +25501,110 @@
 				
        
 				<t pos="V" sources="CW">s/he blinks, s/he closes his/her eyes</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pahpawaham</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>pahpawah-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He dusts it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he beats s.t., s/he shakes s.t. out by tool; s/he dusts s.t. off</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pahpawahwêw</l>
+			
+      
+			<lc>VTA-3</lc>
+			
+      
+			<stem>pahpawahw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He dusts him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he beats s.o., s/he shakes s.o. out by tool; s/he dusts s.o. off</t>
 				
    
 			</tg>
@@ -34306,6 +25845,214 @@
 		<lg>
 			
       
+			<l pos="V">papâm-âcimêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>papâm-âcim-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He goes around telling news of him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he goes around telling news of s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">papâmâmow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>papâmâmo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He flees about while getting chased.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he flees about</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">papâmitâcimow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>papâmitâcimo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He goes crawling around.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he crawls around, about</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pasakwâpiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>pasakwâpi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He has his eyes shut.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he closes his/her eyes</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">patamêw</l>
 			
       
@@ -34343,6 +26090,58 @@
 		<lg>
 			
       
+			<l pos="V">pawaham</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>pawah-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">1. He threshes it. 2. He dust it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he beats s.t., s/he shakes s.t. out, s/he brushes s.t. off by tool; s/he threshes s.t.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">pawahamawêw</l>
 			
       
@@ -34362,6 +26161,110 @@
 				
        
 				<t pos="V" sources="CW">s/he threshes (it/him) for s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">pawahikan</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>pawahikan-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A threshing machine.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">threshing-machine; combine</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pawahikêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>pawahikê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is threshing.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he threshes, s/he threshes grain, s/he combines</t>
 				
    
 			</tg>
@@ -34454,6 +26357,58 @@
 		<lg>
 			
       
+			<l pos="V">pawahwêw</l>
+			
+      
+			<lc>VTA-3</lc>
+			
+      
+			<stem>pawahw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He threshes him. Animate.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he brushes s.o. off by tool; s/he threshes s.o. (e.g. grain)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">payêkwac</l>
 			
       
@@ -34473,6 +26428,58 @@
 				
        
 				<t pos="Ipc" sources="CW">in solitude</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pâh-pasakwâpiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>pasakwâpi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He keeps shutting his eyes.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he opens and closes his/her eyes repeatedly, s/he blinks</t>
 				
    
 			</tg>
@@ -34713,6 +26720,58 @@
 		<lg>
 			
       
+			<l pos="N">pâkipayiwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>pâkipayiwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">a quick swelling on a body part.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">swelling</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">pê-</l>
 			
       
@@ -34769,6 +26828,95 @@
 				
        
 				<t pos="V" sources="CW">s/he comes and eats</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pê-nipâw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nipâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD CW">s/he comes and sleeps</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pê-wâpahtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>wâpaht-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He comes to see it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he comes and sees s.t.</t>
 				
    
 			</tg>
@@ -35009,6 +27157,58 @@
 		<lg>
 			
       
+			<l pos="V">pêtatâmow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>pêtatâmo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">His breathing returns.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he blows hither, s/he breathes forth; s/he has his/her breathing return</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">pêtâcimêw</l>
 			
       
@@ -35028,6 +27228,58 @@
 				
        
 				<t pos="V" sources="CW">s/he comes with news of s.o.; s/he tells news of s.o. coming</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pêtâmow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>pêtâmo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He flees here for help.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he comes in flight, s/he flees here for shelter, s/he flees here for help</t>
 				
    
 			</tg>
@@ -35102,6 +27354,58 @@
 				
        
 				<t pos="V" sources="CW">s/he arrives crying</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">pêyak</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">One.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">one; alone, single; the only one</t>
 				
    
 			</tg>
@@ -35342,6 +27646,43 @@
 		<lg>
 			
       
+			<l pos="Ipc">pêyak-pîsim</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD CW">one moon, one month</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">pêyak-sôniyâs</l>
 			
       
@@ -35471,7 +27812,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="V" sources="CW">it is Monday; literally: &quot;(it is) the first day&quot;</t>
+				<t pos="V" sources="CW">it is Monday; literally: (it is) the first day</t>
 				
    
 			</tg>
@@ -35675,6 +28016,269 @@
 		<lg>
 			
       
+			<l pos="V">pêyakohêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>pêyakoh-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He deals with him only.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he deals only with s.o., s/he deals with s.o. alone</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pêyakohkam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>pêyakohk-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is the only one at it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he tends s.t. alone</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pêyakohkawêw</l>
+			
+      
+			<lc>VTA-2</lc>
+			
+      
+			<stem>pêyakohkaw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is the only one at him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he tends s.o. alone</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pêyakohkwâmiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>pêyakohkwâmi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He sleeps alone.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he sleeps alone</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pêyakohtâw</l>
+			
+      
+			<lc>VTI-2</lc>
+			
+      
+			<stem>pêyakohtâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He keeps to one area. He favors doing one thing only.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he keeps to one area</t>
+				
+       
+				<t pos="V" sources="CW">s/he makes one of s.t.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">pêyakokamikosiw</l>
 			
       
@@ -35786,6 +28390,110 @@
 		<lg>
 			
       
+			<l pos="V">pêyakokâtêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>pêyakokâtê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He has one leg.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he has one leg, s/he is one-legged</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pêyakokêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>pêyakokê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He lives alone. This term also used forâ€¦when a girl becomes a woman.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he dwells alone, s/he lives alone</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">pêyakonêham</l>
 			
       
@@ -35842,6 +28550,58 @@
 				
        
 				<t pos="V" sources="CW">s/he brings alone</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pêyakonêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>pêyakon-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He holds one alone.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he holds s.o. apart, alone</t>
 				
    
 			</tg>
@@ -35953,6 +28713,132 @@
 				
        
 				<t pos="V" sources="CW">s/he plays cards</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pêyakopiponwêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>pêyakopiponwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is one year old.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he is one year old</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">pêyakosâp</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD CW">eleven</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">pêyakosâpwâw</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD CW">eleven times</t>
 				
    
 			</tg>
@@ -36159,6 +29045,58 @@
 		<lg>
 			
       
+			<l pos="V">pêyakow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>pêyako-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He is alone.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he is alone; s/he is the only one</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">pêyakowiw</l>
 			
       
@@ -36215,6 +29153,110 @@
 				
        
 				<t pos="V" sources="CW">s/he goes at s.o. single-handed</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">pêyakôskân</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>pêyakôskân-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">One of a kind. One type. One select group.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">one family; one pair (at cards)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pêyakôskânêsiwak</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>pêyakôskânêsi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">They are one group of them. E.g. Tribe or nation.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">they are one tribe, one nation</t>
 				
    
 			</tg>
@@ -36400,6 +29442,162 @@
 				
        
 				<t pos="N" sources="CW">one fur</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pêyakwan</l>
+			
+      
+			<lc>VII-n</lc>
+			
+      
+			<stem>pêyakwan-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">It is by itself. As a reply, it means the same, after tansi?.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it is one, it is the same</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">pêyakwan</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">It is by itself. As a reply, it means the same, after tansi?.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">same, the same, just the same; similar</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">pêyakwanohk</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">In one spot, place or area.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">in one place, the same spot</t>
 				
    
 			</tg>
@@ -36677,6 +29875,58 @@
 		<lg>
 			
       
+			<l pos="Ipc">pêyakwayak</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">At one place. In one location.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">in one place, in a certain place; in the same place; one way, one kind</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">pêyakwayiwinisa</l>
 			
       
@@ -36696,6 +29946,110 @@
 				
        
 				<t pos="N" sources="CW">suit, suit of clothing</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">pêyakwâpisk</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">A silver dollar.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">one dollar, silver dollar</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">pêyakwâw</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">Once. One more time.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">once, once more</t>
 				
    
 			</tg>
@@ -36973,6 +30327,58 @@
 		<lg>
 			
       
+			<l pos="V">piminawatêw</l>
+			
+      
+			<lc>VTA-4</lc>
+			
+      
+			<stem>piminawat-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">She cooks a meal for him.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he cooks for s.o., s/he cooks a meal for s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">pimitamow</l>
 			
       
@@ -36992,6 +30398,110 @@
 				
        
 				<t pos="V" sources="CW">it is a crosswise road, it lies crosswise</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pimitâcimow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>pimitâcimo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He crawls.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he crawls about, s/he crawls around, s/he creeps</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">pimitâcimowin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>pimitâcimowin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">Crawling.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">crawling, creeping</t>
 				
    
 			</tg>
@@ -37195,6 +30705,58 @@
 		<lg>
 			
       
+			<l pos="V">pîkiskâcimêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>pîkiskâcim-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He makes him lonely with his talk.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he makes s.o. lonely (by speech)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">pîmayiwinisêw</l>
 			
       
@@ -37269,13 +30831,13 @@
 		<lg>
 			
       
-			<l pos="V">pohcipayiw</l>
+			<l pos="V">pohcipayihow</l>
 			
       
-			<lc>VII-v</lc>
+			<lc>VAI-v</lc>
 			
       
-			<stem>pohcipayi-</stem>
+			<stem>pohcipayiho-</stem>
 			
    
 		</lg>
@@ -37287,7 +30849,111 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="V" sources="CW">it goes into a hole, it falls into a hole</t>
+				<t pos="V" sources="MD">He wriggles into a hole.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he jumps into a hole</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pohcipayin</l>
+			
+      
+			<lc>VII-n</lc>
+			
+      
+			<stem>pohcipayin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD CW">it falls into a hole</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pohciwêpaham</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>pohciwêpah-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He sweeps it in with an object.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he shovels s.t. in</t>
 				
    
 			</tg>
@@ -37325,6 +30991,110 @@
 				
        
 				<t pos="V" sources="CW">s/he shovels s.o. in</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pohciwêpinam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>pohciwêpin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He throws it in.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he throws s.t. into a hole</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pohciwêpinêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>pohciwêpin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He throws him in. Animate.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he throws s.o. into a hole</t>
 				
    
 			</tg>
@@ -37621,6 +31391,58 @@
 				
        
 				<t pos="V" sources="CW">s/he spreads (it/him) for s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">sâpwâpahtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>sâpwâpaht-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He sees through it e.g. A microscope.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he sees through s.t., s/he takes a x-ray of s.t.</t>
 				
    
 			</tg>
@@ -38120,6 +31942,110 @@
 		<lg>
 			
       
+			<l pos="V">sôniyâhkêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>sôniyâhkê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">HE earns money. He makes money from it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he earns money, s/he earns wages; s/he makes money, s/he creates money</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">sôniyâs</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>sôniyâs-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">Money, in small quantities.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">money; change; [singular:] quarter dollar; a quarter, twenty-five cents</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">sôniyâskâw</l>
 			
       
@@ -38139,6 +32065,58 @@
 				
        
 				<t pos="V" sources="CW">it is Treaty Day; there is an abundance of money</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">sôniyâw</l>
+			
+      
+			<lc>NA-2</lc>
+			
+      
+			<stem>sôniyâw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">Money in large quantities.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">money, wages; gold, silver</t>
 				
    
 			</tg>
@@ -38416,6 +32394,43 @@
 		<lg>
 			
       
+			<l pos="N">sôniyâwasinahikan</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>sôniyâwasinahikan-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">cheque; money order</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">sôniyâwâhkêsîs</l>
 			
       
@@ -38471,7 +32486,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">silver, gold, copper; literally: &quot;money-metal&quot;</t>
+				<t pos="N" sources="CW">silver, gold, copper; literally: money-metal</t>
 				
    
 			</tg>
@@ -38601,6 +32616,95 @@
 		<lg>
 			
       
+			<l pos="N">sôniyâwikamik</l>
+			
+      
+			<lc>NI-3</lc>
+			
+      
+			<stem>sôniyâwikamikw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">bank</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">sôniyâwikimâw</l>
+			
+      
+			<lc>NA-2</lc>
+			
+      
+			<stem>sôniyâwikimâw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A bank manager.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">Indian Agent</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">sôniyâwiw</l>
 			
       
@@ -38694,6 +32798,58 @@
 				
        
 				<t pos="N" sources="CW">cash box</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">tahkikamiw</l>
+			
+      
+			<lc>VII-v</lc>
+			
+      
+			<stem>tahkikami-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">It (a body of water) is cold.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it is cold water</t>
 				
    
 			</tg>
@@ -38879,6 +33035,58 @@
 				
        
 				<t pos="V" sources="CW">s/he lies on the top of something</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">tahto-tipiskâw</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">Every night; each night.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">each night; every night</t>
 				
    
 			</tg>
@@ -39230,43 +33438,6 @@
 		<lg>
 			
       
-			<l pos="V">tawaham</l>
-			
-      
-			<lc>VTI-1</lc>
-			
-      
-			<stem>tawah-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">s/he slashes s.t. open (as a path), s/he clears or marks s.t. (as a line)</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
 			<l pos="V">tawahcâw</l>
 			
       
@@ -39563,43 +33734,6 @@
 		<lg>
 			
       
-			<l pos="V">tawatinâw</l>
-			
-      
-			<lc>VII-v</lc>
-			
-      
-			<stem>tawatinâ-</stem>
-			
-   
-		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="CW">it is a valley</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-
-	</e>
-	
-
-
-	<e>
-		
-   
-		<lg>
-			
-      
 			<l pos="V">tawayâw</l>
 			
       
@@ -39656,6 +33790,61 @@
 				
        
 				<t pos="V" sources="CW">it is a week</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">tânisi</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">How are you?</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">how, in what way</t>
+				
+       
+				<t pos="Ipc" sources="CW">hello, how are you</t>
 				
    
 			</tg>
@@ -39785,6 +33974,58 @@
 		<lg>
 			
       
+			<l pos="Ipc">tânispîhk</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">When? At what time.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">when</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">tânita ohci</l>
 			
       
@@ -39841,6 +34082,43 @@
 				
        
 				<t pos="Ipc" sources="CW">how many nights</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">tâwaham</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>tâwah-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he hits s.t. with a missile; s/he hits s.t. (as a target), s/he hits the mark; s/he bumps into s.t.</t>
 				
    
 			</tg>
@@ -40118,6 +34396,58 @@
 		<lg>
 			
       
+			<l pos="V">tipinawaham</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>tipinawah-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He shelters it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he shelters s.t. from the wind</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">tipinawahamawêw</l>
 			
       
@@ -40137,6 +34467,214 @@
 				
        
 				<t pos="V" sources="CW">s/he makes a shelter from the wind over (it/him) for s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">tipinawahikan</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>tipinawahikan-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A lean to. Anything use for shelter.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">shelter from wind</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">tipinawahikêw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>tipinawahikê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He makes shelter.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he makes shelter from the wind</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">tipiskâki</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="MD">Tonight. When it gets dark.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Ipc" sources="CW">at night, tonight, when it's night; when it gets dark</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">tipiskâw</l>
+			
+      
+			<lc>VII-v</lc>
+			
+      
+			<stem>tipiskâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">Night time. V - It is night.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it is night, it is night time; it is dark</t>
 				
    
 			</tg>
@@ -40266,6 +34804,58 @@
 		<lg>
 			
       
+			<l pos="V">wahkêmow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>wahkêmo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He cries easily.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he cries easily</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">wanimow</l>
 			
       
@@ -40285,6 +34875,214 @@
 				
        
 				<t pos="V" sources="CW">s/he says the wrong thing; s/he loses his/her own train of thought while speaking</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">waniskâw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>waniskâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He rises out of bed.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he gets up, s/he arises from lying, s/he gets out of bed; s/he goes in, s/he comes in</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">wanitipiskâw</l>
+			
+      
+			<lc>VII-v</lc>
+			
+      
+			<stem>wanitipiskâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">It is a very dark night.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it is a dark night, it is very dark</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">wayawîtâcimow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>wayawîtâcimo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He crawls outside.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he crawls outside</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">wayawîtâpâtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>wayawîtâpât-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He drags it out.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he drags s.t. outside</t>
 				
    
 			</tg>
@@ -40414,6 +35212,58 @@
 		<lg>
 			
       
+			<l pos="V">wâpahtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>wâpaht-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He sees it.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he sees s.t., s/he witnesses s.t.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">wâpahtamawêw</l>
 			
       
@@ -40507,6 +35357,43 @@
 				
        
 				<t pos="V" sources="CW">s/he sees s.o., s/he witnesses s.o.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">wâpanacâhkos</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>wâpanacâhkos-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">morning star</t>
 				
    
 			</tg>
@@ -40861,6 +35748,58 @@
 		<lg>
 			
       
+			<l pos="N">wiyaw</l>
+			
+      
+			<lc>NDI-1</lc>
+			
+      
+			<stem>-iyaw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">His body.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">body; his/her body</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">wiyawihtam</l>
 			
       
@@ -40880,6 +35819,95 @@
 				
        
 				<t pos="V" sources="CW">s/he hears s.t. plainly</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">wiyâs</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>wiyâs-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD CW">meat</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">wiyâsis</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>wiyâsis-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="MD">A bit or piece of meat.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">bit of meat, piece of meat</t>
 				
    
 			</tg>
@@ -41027,7 +36055,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="CW">badger; literally: &quot;dirty ear&quot;</t>
+				<t pos="N" sources="CW">badger; literally: dirty ear</t>
 				
    
 			</tg>
@@ -41305,6 +36333,58 @@
 		<lg>
 			
       
+			<l pos="V">yahkîmow</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>yahkîmo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD">He increases his family. He increases his weight.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he grows; s/he has progeny; [plural:] they increase as a family</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="N">yahkîmowin</l>
 			
       
@@ -41398,6 +36478,43 @@
 				
        
 				<t pos="V" sources="CW">it is an area of sandhills</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">yêkawan</l>
+			
+      
+			<lc>VII-n</lc>
+			
+      
+			<stem>yêkawan-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="MD CW">it is sandy</t>
 				
    
 			</tg>
@@ -41551,6 +36668,3595 @@
 			</tg>
 			
    
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">anihi</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">it is (that) [focus maker]</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">anima</l>
+			
+      
+			<lc>PrI</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Pron" sources="CW">that, that one</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">anima</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">it is that; the fact that</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">anohc kâ-kîsikâk</l>
+			
+      
+			<lc>IPH</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">today</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ati-tipiskâw</l>
+			
+      
+			<lc>VII-2v</lc>
+			
+      
+			<stem>ati-tipiskâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">it is getting dark, night is approaching</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">awa</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">it is (this) [focus marker]</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">awasowi-kocawânâpiskos</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>awasowi-kocawânâpiskos-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">small warming-stove, heater</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">awaswâkan</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>awaswâkan-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">heater, warming stove</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ayiwâkimiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>ayiwâkimiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he makes false accusations against people</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">âhkwêhtawapiwak</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>âhkwêhtawapi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">they sit in layers on top of one another</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">âhkwêhtawastâw</l>
+			
+      
+			<lc>VTI-2</lc>
+			
+      
+			<stem>âhkwêhtawastâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he piles s.t. in layers on top of one another</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">âhkwêhtawastêwa</l>
+			
+      
+			<lc>VII-2v</lc>
+			
+      
+			<stem>âhkwêhtawastê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">they are piled in layers on top of one another; they are piled up, crosswise; they are laid on top of one another</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">âkawâskwêyâhk</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">in the shade of a dense forest or wood </t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">âkwâ-tipiskâw</l>
+			
+      
+			<lc>VII-1v</lc>
+			
+      
+			<stem>âkwâ-tipiskâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">it is well into the night, it is late in the evening</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">âyiman</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>âyiman-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">difficult thing</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">âyiman</l>
+			
+      
+			<lc>VII-2n</lc>
+			
+      
+			<stem>âyiman-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">it is difficult</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">âyîtamow</l>
+			
+      
+			<lc>VII-2v</lc>
+			
+      
+			<stem>âyîtamo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">it is stuck on tightly</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">âyîtawakâm</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">on both banks, on both sides of the river or lake, on each side of the water</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">âyîtawatinâw</l>
+			
+      
+			<lc>VII-2v</lc>
+			
+      
+			<stem>âyîtawatinâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">there are hills on each side, there are mountains on both sides</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">isi-wâpahtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>isi-wâpaht-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he sees s.t. thus, s/he witnesses s.t. thus, s/he has such a vision</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">iskwapiw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>iskwapi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he has just so much left</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kakihcimiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kakihcimiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he praises people, s/he speaks approvingly of people, s/he brags about people</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kakwâtakimiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kakwâtakimiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he speaks meanly to people, s/he nags people; s/he speaks poorly of people</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kakwâtakimow</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kakwâtakimo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he speaks meanly of him/herself, s/he speaks poorly of him/herself; s/he tells a hard luck story about him/herself</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kakwêcimiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kakwêcimiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he asks people</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kâkîcimiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kâkîcimiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he consoles people verbally, s/he speaks to console people</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">kâkîsimowin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>kâkîsimowin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">prayer, chant; praying, praying in a traditional manner, chanting prayers, supplication of the spirits</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kâskipâtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>kâskipât-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he shaves s.t.</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kipihcimiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kipihcimiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he stops people verbally, s/he convinces people to stop, s/he coaxes people to stop</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kisêwâtêyimiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kisêwâtêyimiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he thinks of people in a kindly way</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kisiwapiw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kisiwapi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he sits and sulks</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kisîmiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kisîmiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he angers people by speech</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">kisîpayiwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>kisîpayiwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">moving fast, travelling fast, driving fast</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kiskimiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kiskimiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he makes appointments with people</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">kiskimowin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>kiskimowin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">appointment, making an appointment</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">kiskinowâpamâkan</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>kiskinowâpamâkan-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">role model, one who is learned from through observation</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kitimâkimiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kitimâkimiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he belittles people, s/he slanders people</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">kitisimowin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>kitisimowin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">wanting to stay</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kîhkâtêyimiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kîhkâtêyimiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he holds people in high esteem, s/he respects people</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kîsowatâmow</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kîsowatâmo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he is kept warm by his/her own breath (e.g. by covering one's face with a blanket)</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kîsowiyawêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kîsowiyawê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he has a warm body</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kîwâtêyimiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kîwâtêyimiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he feels sorry for people, s/he finds people to be abandoned</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kotatâmow</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kotatâmo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he rehearses singing, s/he tries out her singing voice</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">kotatâmowin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>kotatâmowin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">singing rehearsal, singing practice</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kwayaskomiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kwayaskomiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he speaks forthrightly to people, s/he correctly informs people</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">kwâhcimow</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>kwâhcimo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he gets carried away in talking</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">mâcîpayiwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>mâcîpayiwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">hunting on horseback</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">mâyi-nawasônikêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>mâyi-nawasônikê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he choose badly, s/he makes a bad choice</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">mêkwâ-ayamihâw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>mêkwâ-ayamihâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he is at prayer presently</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">mêkwâ-kimiwan</l>
+			
+      
+			<lc>VII-1n</lc>
+			
+      
+			<stem>mêkwâ-kimiwan</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">it is currently raining, while it is raining</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">mêkwâ-mîcisow</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>mêkwâ-mîciso-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">while s/he eats, s/he is eating currently</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">mêkwâ-sakâhk</l>
+			
+      
+			<lc>INM</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">in the middle of the forest</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">mihkowatâmow</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>mihkowatâmo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he respirates blood, s/he has blood-scented breath</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">misi-mîciw</l>
+			
+      
+			<lc>VTA-3</lc>
+			
+      
+			<stem>misi-mîci-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he eats a lot of s.t., s/he eats much of s.t.</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">misiwanâcimiwêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>misiwanâcimiwê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he ruins people's reputations (verbally)</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">miskwâpahtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>miskwâpaht-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he notices s.t., s/he catches a glimpse of s.t.</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">miskwâpamêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>miskwâpam-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he sees s.o., s/he espies s.o., s/he notices s.o., s/he catches a glimpse of s.o.</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">miyo-sôniyâhkêw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>miyo-sôniyâhkê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he makes good money, s/he earns good wages</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="">môniyâw-kîkway</l>
+			
+      
+			<lc>PR</lc>
+			
+      
+			<stem>môniyâw-kîkway-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="" sources="CW">something White, White things</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">nahihtamowin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>nahihtamowin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">listening well; obedience; sharp hearing</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">nâha</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Pron" sources="CW">that one yonder, that further</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nêwo-tipiskâw</l>
+			
+      
+			<lc>VII-1v</lc>
+			
+      
+			<stem>nêwo-tipiskâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">it is the fourth night, it is four nights</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nimitawaham</l>
+			
+      
+			<lc>VAI-3</lc>
+			
+      
+			<stem>nimitawah-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he canoes to the open water; s/he canoes to the prairie, open country</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nimitâwaham</l>
+			
+      
+			<lc>VAI-3</lc>
+			
+      
+			<stem>nimitâwah-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he goes out to sea; s/he goes out into the lake</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">niskanis</l>
+			
+      
+			<lc>NDI-1</lc>
+			
+      
+			<stem>-skanis-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">my little bone</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">nisto-kîsikâw</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">three days, for three days</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">niyâ</l>
+			
+      
+			<lc>IPJ</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">go ahead, go on, be off!</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">ocipâson</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>ocipâson-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">knob, button (e.g. on a radio)</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ohcikawiw</l>
+			
+      
+			<lc>VII-2v</lc>
+			
+      
+			<stem>ohcikawi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">it drips, it leaks out, it trickles out (e.g. sap from tree); it flows from there</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">ohcimow</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>ohcimo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he scolds over something; s/he prevents improper action</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">ohtatâmowin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>ohtatâmowin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">inhalation, breathing in</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">okiskinowâpiw</l>
+			
+      
+			<lc>NA-2</lc>
+			
+      
+			<stem>okiskinowâpiw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">one who learns merely by watching; mere imitator, mimic</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">otâcimow</l>
+			
+      
+			<lc>NA-2</lc>
+			
+      
+			<stem>otâcimow-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">storyteller; narrator</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">ôki</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">it is (these) [focus marker]</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">ôma</l>
+			
+      
+			<lc>PrI</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Pron" sources="CW">this</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">ôma</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">it is this; the fact that; then; when; as it is, actually [focus marker]</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">pêyakokamik</l>
+			
+      
+			<lc>NI-2</lc>
+			
+      
+			<stem>pêyakokamikw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">lone lodge; single household</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">pêyakopêhikan</l>
+			
+      
+			<lc>NA-1</lc>
+			
+      
+			<stem>pêyakopêhikan-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">card, playing card; ace; [plural:] cards, deck of cards, game of cards</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">pêyakw-âya</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">a single team of horses, one team of horses</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">pêyakwahpitêw</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">one team (of two horses)</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">pohcipayiw</l>
+			
+      
+			<lc>VII-2v</lc>
+			
+      
+			<stem>pohcipayi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">it goes into a hole, it falls into a hole</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">saskaci-wâpahtam</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>saskaci-wâpaht-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he is tired of looking at s.t.</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">saskaci-wâpamêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>saskaci-wâpam-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he is tired of looking at s.o.</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">sôniyânâhk</l>
+			
+      
+			<lc>INM</lc>
+			
+      
+			<stem>sôniyâw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">at the bank</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">sôniyâw-okimânâhk</l>
+			
+      
+			<lc>INM</lc>
+			
+      
+			<stem>sôniyâw-okimâw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">agency; Indian Agency</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">tahto-nîpin</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">every summer, each summer</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">takahkatâmow</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>takahkatâmo-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he sings out beautifully</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">takahki-âcimêw</l>
+			
+      
+			<lc>VTA-1</lc>
+			
+      
+			<stem>takahki-âcim</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he tells a beautiful story about s.o.</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">tawaham</l>
+			
+      
+			<lc>VTI-1</lc>
+			
+      
+			<stem>tawah-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">s/he slashes s.t. open (as a path), s/he clears or marks s.t. (as a line)</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">tawatinâw</l>
+			
+      
+			<lc>VII-2v</lc>
+			
+      
+			<stem>tawatinâ-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">it is a valley</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">tâhkôcikâtêw</l>
+			
+      
+			<lc>VII-2v</lc>
+			
+      
+			<stem>tâhkôcikâtê-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">it is discussed</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">tânisi</l>
+			
+      
+			<lc>IPJ</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">hello, how are you</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">tipiskâw</l>
+			
+      
+			<lc>NI-2</lc>
+			
+      
+			<stem>tipiskâw-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">night; night sky</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">wahkêmowin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>wahkêmowin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="N" sources="CW">crying easily, being prone to crying</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">waniyaw</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">any, somebody; at random</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Ipc">wiyawâw</l>
+			
+      
+			<lc>IPC</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Ipc" sources="CW">by contrast</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="Pron">wiyawâw</l>
+			
+      
+			<lc>PrA</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="Pron" sources="CW">they, them, theirs; themselves</t>
+				
+   
+			</tg>
+			
+ 
 		</mg>
 		
 

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -4,8 +4,8 @@ import pytest
 from hypothesis import assume, given
 
 from API.models import Wordform, filter_cw_wordforms
-from CreeDictionary import settings
 from constants import Language
+from CreeDictionary import settings
 from tests.conftest import random_lemmas
 
 
@@ -174,14 +174,18 @@ def test_search_space_characters_in_matched_term(term):
     assert len(cree_results) > 0
 
 
+@pytest.mark.skip
 @pytest.mark.django_db
 def test_filter_cw_content():
+    # TODO: what is this actually testing??!??!?!?!
+
     # test 1
     # assumptions
     mowew_queryset = Wordform.objects.filter(text="mowêw", is_lemma=True)
     assert mowew_queryset.count() == 1
     assert {
         ("s/he eats s.o. (e.g. bread)", "CW"),
+        # XXX: this is not the definition in MD!!!!!!
         ("s/he eats s.o. (e.g. bread)", "MD"),
     } == {
         tuple(definition_dict.values())

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -174,40 +174,6 @@ def test_search_space_characters_in_matched_term(term):
     assert len(cree_results) > 0
 
 
-@pytest.mark.skip
-@pytest.mark.django_db
-def test_filter_cw_content():
-    # TODO: what is this actually testing??!??!?!?!
-
-    # test 1
-    # assumptions
-    mowew_queryset = Wordform.objects.filter(text="mowêw", is_lemma=True)
-    assert mowew_queryset.count() == 1
-    assert {
-        ("s/he eats s.o. (e.g. bread)", "CW"),
-        # XXX: this is not the definition in MD!!!!!!
-        ("s/he eats s.o. (e.g. bread)", "MD"),
-    } == {
-        tuple(definition_dict.values())
-        for definition_dict in mowew_queryset.get()
-        .definitions.all()
-        .values("text", "citations")
-    }
-
-    # test 2
-    # assumption
-    nipa_queryset = Wordform.objects.filter(text="nipa-", full_lc="IPV")
-    assert (
-        nipa_queryset.count() == 1
-    )  # there should only be one preverb meaning "during the night", it's from MD
-
-    # test
-    filtered = filter_cw_wordforms(nipa_queryset)
-    assert (
-        len(list(filtered)) == 0
-    )  # nipa should no longer be there because the preverb nipa is a MD only word
-
-
 @pytest.mark.django_db
 def test_paradigm():
     def deep_contain(container: Iterable, testee):


### PR DESCRIPTION
Now that #274 is fixed, we can use the latest dictionary content in our tests!

Note: I marked a test as `skip` since it relies on exact dictionary content, and I have no idea what its purpose is.