### PR TITLE
preverb search

### DIFF
--- a/CreeDictionary/API/apps.py
+++ b/CreeDictionary/API/apps.py
@@ -9,7 +9,9 @@ class APIConfig(AppConfig):
 
     def ready(self):
         """
-        initialize fuzzy search (build the data structure)
+        This function is called prior to app start.
+        It initializes fuzzy search (build the data structure).
+        It also hashes preverbs for faster preverb matching.
         """
         # todo: fuzzy search is for now not used. Use it in the future
         # # without the guard


### PR DESCRIPTION
# faster preverb match (supposedly)

The preverb search is faster by hashing all the preverbs prior to the start of the app.
I tested this new method on the real database. Actually It's not significantly faster (I wouldn't say even 10%). As  @eddieantonio discovers, one of the time consuming part is `fst-lookup` and one being the use of wrong indexes.

