### PR TITLE
Make sure about and index have start-of-content anchors

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/about.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/about.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block content %}
-<main class="app__content app__pane">
+<main id="start-of-content" class="app__content app__pane">
   <section id="source-materials" class="prose box box--spaced">
     <h2 class="prose__section-title">Source Materials</h2>
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -18,6 +18,14 @@
   {% include './components/header.html' %}
 
 {% block content %}
+{% comment %}
+N.B.: Make sure whatever is placed here has is a <main> or has role=main and
+has id="start-of-content"
+{% endcomment %}
+  <main id="start-of-content">
+    <strong> Placeholder content! </strong> If you're seeing this, something
+    went wrong.
+  </main>
 {% endblock %}
 
 <footer class="app-footer">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
@@ -3,9 +3,7 @@
 {% load static %}
 
 {% block content %}
-
-    <main class="app__content app__pane">
-
+    <main id="start-of-content" class="app__content app__pane">
           <article class="prose box" id="introduction-text" {% if search_results or lemma_id %}style="display:none;"{% endif %}>
             <h1 class="prose__heading"><span lang="cr">tânisi!</span></h1>
             <p><span lang="cr">itwêwina</span> is a Plains Cree Dictionary.</p>
@@ -37,7 +35,6 @@
                 {% endif %}
             </ol>
         </section>
-
 
         {% if lemma_id %}
             {% include 'CreeDictionary/paradigm.html' %}


### PR DESCRIPTION
I had a link for a11y the jumps to start of content (press tab within Chrome and you'll see it). Problem is, none of the pages had the corresponding anchor!