### PR TITLE
Orthography selection menu

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/header.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/header.html
@@ -6,15 +6,14 @@
       <p class="branding__heading branding__subtitle">Plains Cree Dictionary</p>
   </a></header>
   {# TODO: The language and orthography selectors are not ready yet, so hide them: #}
-  <nav class="top-bar__nav" style="visibility: hidden; overflow: hidden">
+  <nav class="top-bar__nav">
     <details class="toggle-box toggle-box--with-menu">
       <summary id="language-selector__button" class="toggle-box__toggle" data-cy="language-selector"
                aria-haspopup="menu" role="button" tabindex="0"
                aria-label="Select language and writing system">
-        English (êîôâ)
+        SRO (êîôâ)
       </summary>
       <div class="menu toggle-box__menu" aria-labelledby="language-selector__button">
-        {% include './language-selector__language.html' %}
         {% include './language-selector__orthography.html' %}
       </div>
     </details>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/language-selector__orthography.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/language-selector__orthography.html
@@ -2,13 +2,13 @@
   <h2 class="menu__caption" id="language-selector__orthography"> Show Cree words in </h2>
   <ul class="menu__choices" data-cy="orthography-choices">
     <li class="menu-choice menu-choice--selected">
-      <a href="?o=Latn" class="menu-choice__label">SRO (êîôû)</a>
+      <button data-orth-switch="Latn" value="Latn" class="menu-choice__label">SRO (êîôû)</button>
     </li>
     <li class="menu-choice">
-      <a href="?o=Latn-x-macron" class="menu-choice__label">SRO (ēīōū)</a>
+      <button data-orth-switch="Latn-x-macron" value="Latn-x-macron" class="menu-choice__label">SRO (ēīōū)</button>
     </li>
     <li class="menu-choice">
-      <a href="?o=Cans" class="menu-choice__label">Syllabics (ᒐᐦᑭᐯᐦᐃᑲᓇ)</a>
+      <button data-orth-switch="Cans" value="Cans" class="menu-choice__label">Syllabics (ᒐᐦᑭᐯᐦᐃᑲᓇ)</button>
     </li>
   </ul>
 </section>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/language-selector__orthography.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/language-selector__orthography.html
@@ -2,13 +2,13 @@
   <h2 class="menu__caption" id="language-selector__orthography"> Show Cree words in </h2>
   <ul class="menu__choices" data-cy="orthography-choices">
     <li class="menu-choice menu-choice--selected">
-      <button data-orth-switch value="Latn" class="menu-choice__label">SRO (êîôû)</button>
+      <button data-orth-switch value="Latn" class="menu-choice__label unbutton">SRO (êîôû)</button>
     </li>
     <li class="menu-choice">
-      <button data-orth-switch value="Latn-x-macron" class="menu-choice__label">SRO (ēīōū)</button>
+      <button data-orth-switch value="LatnXMacron" class="menu-choice__label unbutton">SRO (ēīōū)</button>
     </li>
     <li class="menu-choice">
-      <button data-orth-switch value="Cans" class="menu-choice__label">Syllabics (ᒐᐦᑭᐯᐦᐃᑲᓇ)</button>
+      <button data-orth-switch value="Cans" class="menu-choice__label unbutton">Syllabics (ᒐᐦᑭᐯᐦᐃᑲᓇ)</button>
     </li>
   </ul>
 </section>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/language-selector__orthography.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/language-selector__orthography.html
@@ -2,13 +2,13 @@
   <h2 class="menu__caption" id="language-selector__orthography"> Show Cree words in </h2>
   <ul class="menu__choices" data-cy="orthography-choices">
     <li class="menu-choice menu-choice--selected">
-      <button data-orth-switch="Latn" value="Latn" class="menu-choice__label">SRO (êîôû)</button>
+      <button data-orth-switch value="Latn" class="menu-choice__label">SRO (êîôû)</button>
     </li>
     <li class="menu-choice">
-      <button data-orth-switch="Latn-x-macron" value="Latn-x-macron" class="menu-choice__label">SRO (ēīōū)</button>
+      <button data-orth-switch value="Latn-x-macron" class="menu-choice__label">SRO (ēīōū)</button>
     </li>
     <li class="menu-choice">
-      <button data-orth-switch="Cans" value="Cans" class="menu-choice__label">Syllabics (ᒐᐦᑭᐯᐦᐃᑲᓇ)</button>
+      <button data-orth-switch value="Cans" class="menu-choice__label">Syllabics (ᒐᐦᑭᐯᐦᐃᑲᓇ)</button>
     </li>
   </ul>
 </section>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/language-selector__orthography.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/language-selector__orthography.html
@@ -2,10 +2,10 @@
   <h2 class="menu__caption" id="language-selector__orthography"> Show Cree words in </h2>
   <ul class="menu__choices" data-cy="orthography-choices">
     <li class="menu-choice menu-choice--selected">
-      <button data-orth-switch value="Latn" class="menu-choice__label unbutton">SRO (êîôû)</button>
+      <button data-orth-switch value="Latn" class="menu-choice__label unbutton">SRO (êîôâ)</button>
     </li>
     <li class="menu-choice">
-      <button data-orth-switch value="LatnXMacron" class="menu-choice__label unbutton">SRO (ēīōū)</button>
+      <button data-orth-switch value="LatnXMacron" class="menu-choice__label unbutton">SRO (ēīōā)</button>
     </li>
     <li class="menu-choice">
       <button data-orth-switch value="Cans" class="menu-choice__label unbutton">Syllabics</button>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/language-selector__orthography.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/language-selector__orthography.html
@@ -8,7 +8,7 @@
       <button data-orth-switch value="LatnXMacron" class="menu-choice__label unbutton">SRO (ēīōū)</button>
     </li>
     <li class="menu-choice">
-      <button data-orth-switch value="Cans" class="menu-choice__label unbutton">Syllabics (ᒐᐦᑭᐯᐦᐃᑲᓇ)</button>
+      <button data-orth-switch value="Cans" class="menu-choice__label unbutton">Syllabics</button>
     </li>
   </ul>
 </section>

--- a/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
+++ b/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
@@ -27,7 +27,10 @@ def orth(sro_original: str):
 
     Yields:
 
-        <span lang="cr" data-orth-latn="wâpamêw" data-orth-latn="wāpamēw" data-orth-cans="ᐚᐸᒣᐤ">wâpamêw</span>
+        <span lang="cr" data-orth
+              data-orth-latn="wâpamêw"
+              data-orth-latn="wāpamēw"
+              data-orth-cans="ᐚᐸᒣᐤ">wâpamêw</span>
     """
 
     sro_circumflex = conditional_escape(sro_original)
@@ -35,7 +38,7 @@ def orth(sro_original: str):
     syllabics = conditional_escape(sro2syllabics(sro_original))
 
     return mark_safe(
-        '<span lang="cr" '
+        '<span lang="cr" data-orth '
         f'data-orth-Latn="{sro_circumflex}" '
         f'data-orth-Latn-x-macron="{sro_macrons}"'
         f'data-orth-Cans="{syllabics}">{sro_circumflex}</span>'

--- a/CreeDictionary/tests/CreeDictionary_tests/creedictionary_templatetags_test.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/creedictionary_templatetags_test.py
@@ -23,7 +23,7 @@ def test_produces_correct_markup():
     assert 'data-orth-Cans="ᐚᐸᒣᐤ"' in rendered
     assertInHTML(
         """
-        <span lang="cr" data-orth-Latn="wâpamêw" data-orth-latn-x-macron="wāpamēw" data-orth-Cans="ᐚᐸᒣᐤ">wâpamêw</span>
+        <span lang="cr" data-orth data-orth-Latn="wâpamêw" data-orth-latn-x-macron="wāpamēw" data-orth-Cans="ᐚᐸᒣᐤ">wâpamêw</span>
         """,
         rendered,
     )

--- a/cypress/integration/orthography.spec.js
+++ b/cypress/integration/orthography.spec.js
@@ -8,9 +8,10 @@ describe('Orthography selection', function () {
         .as('greeting')
 
       // Switch to syllabics
-      cy.get('[data-orthography-selector]')
-        .as('menu')
+      cy.get('[data-cy=language-selector]')
         .click()
+        .parent('details')
+        .as('menu')
       cy.get('@menu')
         .contains('Syllabics')
         .should('be.visible')

--- a/cypress/integration/orthography.spec.js
+++ b/cypress/integration/orthography.spec.js
@@ -23,13 +23,23 @@ describe('Orthography selection', function () {
       cy.get('@greeting')
         .contains('ᑖᓂᓯ!')
 
+      // We should not see the menu
+      cy.get('@option')
+        .should('not.be.visible')
+
       // It should say so on the button
       cy.get('[data-cy=language-selector]')
         .contains('Syllabics')
+        .click()
 
-      // We should no longer be able to see options
-      cy.get('@option')
-        .should('not.be.visible')
+      // Opening the menu, we should find that syllabics is highligted, and
+      // SRO is not:
+      cy.get('@menu')
+        .contains('li', 'SRO (êîôâ)')
+        .should('not.have.class', 'menu-choice--selected')
+      cy.get('@menu')
+        .contains('li', 'Syllabics')
+        .should('have.class', 'menu-choice--selected')
     })
   })
 })

--- a/cypress/integration/orthography.spec.js
+++ b/cypress/integration/orthography.spec.js
@@ -1,0 +1,24 @@
+describe('Orthography selection', function () {
+  describe('switching orthography', function () {
+    it('should switch to syllabics when I click on the menu', function () {
+      cy.visit('/')
+
+      // Get the introduction: it should be in SRO
+      cy.contains('h1', 'tânisi!')
+        .as('greeting')
+
+      // Switch to syllabics
+      cy.get('[data-orthography-selector]')
+        .as('menu')
+        .click()
+      cy.get('@menu')
+        .contains('Syllabics')
+        .should('be.visible')
+        .click()
+
+      // Now it should be in syllabics!
+      cy.get('@greeting')
+        .contains('ᑖᓂᓯ!')
+    })
+  })
+})

--- a/cypress/integration/orthography.spec.js
+++ b/cypress/integration/orthography.spec.js
@@ -9,17 +9,27 @@ describe('Orthography selection', function () {
 
       // Switch to syllabics
       cy.get('[data-cy=language-selector]')
+        .contains('SRO (êîôâ)')
         .click()
         .parent('details')
         .as('menu')
       cy.get('@menu')
         .contains('Syllabics')
+        .as('option')
         .should('be.visible')
         .click()
 
       // Now it should be in syllabics!
       cy.get('@greeting')
         .contains('ᑖᓂᓯ!')
+
+      // It should say so on the button
+      cy.get('[data-cy=language-selector]')
+        .contains('Syllabics')
+
+      // We should no longer be able to see options
+      cy.get('@option')
+        .should('not.be.visible')
     })
   })
 })

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -172,7 +172,7 @@ html {
 
   text-align: right; /* So that it's flush with the right side of the page. */
 
-  margin-right: var(--small-pad);
+  padding-right: var(--small-pad);
 }
 
 /**
@@ -831,6 +831,7 @@ html {
 
   /* Other */
   cursor: pointer;
+  overflow: hidden; /* Don't affect the layout if the toggle icon overflows its box. */
 }
 
 .toggle-box__toggle::-webkit-details-marker {
@@ -841,15 +842,17 @@ html {
   content: url("img/fa/chevron-circle-down.svg");
 
   display: inline-block;
-  width: 11px;
+  width: 0.75rem;
   margin-left: var(--small-pad);
+
+  vertical-align: middle;
 
   transition: transform .25s;
   transform: rotate(-90deg);
 }
 
 .toggle-box[open] > .toggle-box__toggle::after {
-  transform: rotate(0deg);
+  transform: rotate(0);
 }
 
 /**
@@ -883,6 +886,8 @@ html {
   right: 0;
   z-index: 100;
 }
+
+.top-bar > * { outline: solid 1px magenta } .top-bar > * > * { outline: solid 1px lime }
 
 /**
  * Creates an area behind the menu pop-up that, when clicked/touched, will

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -887,8 +887,6 @@ html {
   z-index: 100;
 }
 
-.top-bar > * { outline: solid 1px magenta } .top-bar > * > * { outline: solid 1px lime }
-
 /**
  * Creates an area behind the menu pop-up that, when clicked/touched, will
  * inadvertently toggle the menu away.

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -474,7 +474,7 @@ html {
 
 /**
  * ELEMENT play-button
- * 
+ *
  * Should be a button that looks like a link.
  */
 .definition-title__play-button {
@@ -953,8 +953,8 @@ html {
 }
 
 .menu-choice:hover {
-  color: #fff;
-  background-color: #0072C8;
+  color: var(--menu-hover-color);
+  background-color: var(--menu-hover-bg-color);
 }
 
 a.menu-choice__label:link,

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -473,8 +473,9 @@ html {
 }
 
 /**
- * The button to play a recording is intended to be a <button> element that
- * looks like a link.
+ * ELEMENT play-button
+ * 
+ * Should be a button that looks like a link.
  */
 .definition-title__play-button {
   /* Reset the button appearance: */
@@ -951,6 +952,11 @@ html {
   padding: 9px;
 }
 
+.menu-choice:hover {
+  color: #fff;
+  background-color: #0072C8;
+}
+
 a.menu-choice__label:link,
 a.menu-choice__label:visited,
 a.menu-choice__label:hover,
@@ -1119,4 +1125,18 @@ a.menu-choice__label:active {
   -webkit-clip-path: inset(1px 1px 1px 1px);
   clip-path: inset(1px 1px 1px 1px);
   pointer-events: none;
+}
+
+/**
+ * Makes a <button> look like a link.
+ */
+.unbutton {
+  border: 0;
+
+  text-align: inherit;
+
+  color: inherit;
+  background: transparent;
+
+  cursor: pointer;
 }

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -43,6 +43,8 @@
   --placeholder-text-color: #949494; /* The placeholder should be faint, but visible. */
   --play-button-color:      #286995; /* The play button in a head (definition-title). */
   --soft-hr-color:          #CCCCCC; /* Make the <hr> less harsh */
+  --menu-hover-color:       var(--box-bg-color); /* An inverted colour scheme */
+  --menu-hover-bg-color:    #0072C8; /* A dark background to contrast highlighted menu items. */
 
   /* special way of changing svg fill color when svg is embedded in <img> */
   /* to change the color. Generate a "filter" attribute with the desired color code*/

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import $ from 'jquery'
 import './css/styles.css'
 import {createTooltip} from './tooltip'
 import {fetchFirstRecordingURL} from './recordings.js'
+import * as orthography from './orthography.js'
 
 const ERROR_CLASS = 'search-progress--error'
 const LOADING_CLASS = 'search-progress--loading'
@@ -204,6 +205,7 @@ $(() => {
   })
 
   setupAudioOnPageLoad()
+  orthography.registerEventListener()
 
   let route = window.location.pathname
   let $input = $('#search')

--- a/src/orthography.js
+++ b/src/orthography.js
@@ -9,14 +9,38 @@ const AVAILABLE_ORTHOGRAPHIES = new Set(['Cans', 'Latn', 'LatnXMacron'])
  * have the data-orth-switch.
  */
 export function registerEventListener() {
+  // Try to handle a click on ANYTHING.
+  // This way, if new elements appear on the page dynamically, we never
+  // need to register new event listeners: this one will work for all of them.
   document.body.addEventListener('click', function (evt) {
     let target = evt.target
+    // Determine that this is a orthography changing button.
     if (target.dataset.orthSwitch === undefined) {
       return
     }
 
+    // target is a <button data-orth-swith value="ORTHOGRAPHY">
     let orth = target.value
     changeOrth(orth)
+
+    // Update the UI appropriately
+
+    // Climb up the DOM tree to find the <details> and its <summary> that contains the title.
+    let detailsElement = target.closest('details')
+    if (!detailsElement) {
+      // there absolutely should be a <de
+      throw new Error('Could not find relevant <details> element!')
+    }
+    let summaryElement = detailsElement.querySelector('summary')
+    if (!summaryElement) {
+      throw new Error('Could not find relevant <summary> element!')
+    }
+
+    // Change the title appropriately and close the menu
+    summaryElement.innerText = target.innerText
+    detailsElement.open = false
+
+    // TODO: set the active class on the button!
   })
 }
 

--- a/src/orthography.js
+++ b/src/orthography.js
@@ -40,7 +40,12 @@ export function registerEventListener() {
     summaryElement.innerText = target.innerText
     detailsElement.open = false
 
-    // TODO: set the active class on the button!
+    // Clear the selected class from all options
+    for (let el of detailsElement.querySelectorAll('[data-orth-switch]')) {
+      let li = el.closest('.menu-choice')
+      li.classList.remove('menu-choice--selected')
+    }
+    target.closest('.menu-choice').classList.add('menu-choice--selected')
   })
 }
 

--- a/src/orthography.js
+++ b/src/orthography.js
@@ -11,7 +11,7 @@ const AVAILABLE_ORTHOGRAPHIES = new Set(['Cans', 'Latn', 'LatnXMacron'])
 export function registerEventListener() {
   document.body.addEventListener('click', function (evt) {
     let target = evt.target
-    if (!target.dataset.orthSwitch) {
+    if (target.dataset.orthSwitch === undefined) {
       return
     }
 

--- a/src/orthography.js
+++ b/src/orthography.js
@@ -12,41 +12,7 @@ export function registerEventListener() {
   // Try to handle a click on ANYTHING.
   // This way, if new elements appear on the page dynamically, we never
   // need to register new event listeners: this one will work for all of them.
-  document.body.addEventListener('click', function (evt) {
-    let target = evt.target
-    // Determine that this is a orthography changing button.
-    if (target.dataset.orthSwitch === undefined) {
-      return
-    }
-
-    // target is a <button data-orth-swith value="ORTHOGRAPHY">
-    let orth = target.value
-    changeOrth(orth)
-
-    // Update the UI appropriately
-
-    // Climb up the DOM tree to find the <details> and its <summary> that contains the title.
-    let detailsElement = target.closest('details')
-    if (!detailsElement) {
-      // there absolutely should be a <de
-      throw new Error('Could not find relevant <details> element!')
-    }
-    let summaryElement = detailsElement.querySelector('summary')
-    if (!summaryElement) {
-      throw new Error('Could not find relevant <summary> element!')
-    }
-
-    // Change the title appropriately and close the menu
-    summaryElement.innerText = target.innerText
-    detailsElement.open = false
-
-    // Clear the selected class from all options
-    for (let el of detailsElement.querySelectorAll('[data-orth-switch]')) {
-      let li = el.closest('.menu-choice')
-      li.classList.remove('menu-choice--selected')
-    }
-    target.closest('.menu-choice').classList.add('menu-choice--selected')
-  })
+  document.body.addEventListener('click', handleClickSwitchOrthography)
 }
 
 /**
@@ -65,4 +31,55 @@ export function changeOrth (which) {
       el.innerText = newText
     }
   }
+}
+
+/**
+ * Switches orthography. This assumes the following HTML:
+ *
+ *  <details>
+ *    <summary>CURRENT ORTHOGRAPHY</summary>
+ *    <ul>
+ *      <li class="menu-choice menu-choice--selected">
+ *        <button data-orth-switch value="ORTH">CURRENT ORTHOGRAPHY</button>
+ *      </li>
+ *      <li class="menu-choice">
+ *        <button data-orth-switch value="ORTH">DIFFERENT ORTHOGRAPHY</button>
+ *      </li>
+ *    </ul>
+ *  </details>
+ */
+function handleClickSwitchOrthography(evt) {
+  let target = evt.target
+  // Determine that this is a orthography changing button.
+  if (target.dataset.orthSwitch === undefined) {
+    return
+  }
+
+  // target is a <button data-orth-swith value="ORTHOGRAPHY">
+  let orth = target.value
+  changeOrth(orth)
+
+  ////////////////////// Update the UI appropriately /////////////////////////
+
+  // Climb up the DOM tree to find the <details> and its <summary> that contains the title.
+  let detailsElement = target.closest('details')
+  if (!detailsElement) {
+    // there absolutely should be a <de
+    throw new Error('Could not find relevant <details> element!')
+  }
+  let summaryElement = detailsElement.querySelector('summary')
+  if (!summaryElement) {
+    throw new Error('Could not find relevant <summary> element!')
+  }
+
+  // Change the title appropriately and close the menu
+  summaryElement.innerText = target.innerText
+  detailsElement.open = false
+
+  // Clear the selected class from all options
+  for (let el of detailsElement.querySelectorAll('[data-orth-switch]')) {
+    let li = el.closest('.menu-choice')
+    li.classList.remove('menu-choice--selected')
+  }
+  target.closest('.menu-choice').classList.add('menu-choice--selected')
 }

--- a/src/orthography.js
+++ b/src/orthography.js
@@ -34,7 +34,25 @@ export function changeOrth (which) {
 }
 
 /**
- * Switches orthography. This assumes the following HTML:
+ * Switches orthography and updates the UI.
+ */
+function handleClickSwitchOrthography(evt) {
+  let target = evt.target
+  // Determine that this is a orthography changing button.
+  if (target.dataset.orthSwitch === undefined) {
+    return
+  }
+
+  // target is a <button data-orth-swith value="ORTHOGRAPHY">
+  let orth = target.value
+  changeOrth(orth)
+
+  updateUI(target)
+}
+
+/**
+ * Updates the UI following an orthography switch.
+ * Assumes the following HTML:
  *
  *  <details>
  *    <summary>CURRENT ORTHOGRAPHY</summary>
@@ -48,21 +66,9 @@ export function changeOrth (which) {
  *    </ul>
  *  </details>
  */
-function handleClickSwitchOrthography(evt) {
-  let target = evt.target
-  // Determine that this is a orthography changing button.
-  if (target.dataset.orthSwitch === undefined) {
-    return
-  }
-
-  // target is a <button data-orth-swith value="ORTHOGRAPHY">
-  let orth = target.value
-  changeOrth(orth)
-
-  ////////////////////// Update the UI appropriately /////////////////////////
-
+function updateUI(button) {
   // Climb up the DOM tree to find the <details> and its <summary> that contains the title.
-  let detailsElement = target.closest('details')
+  let detailsElement = button.closest('details')
   if (!detailsElement) {
     // there absolutely should be a <de
     throw new Error('Could not find relevant <details> element!')
@@ -73,7 +79,7 @@ function handleClickSwitchOrthography(evt) {
   }
 
   // Change the title appropriately and close the menu
-  summaryElement.innerText = target.innerText
+  summaryElement.innerText = button.innerText
   detailsElement.open = false
 
   // Clear the selected class from all options
@@ -81,5 +87,5 @@ function handleClickSwitchOrthography(evt) {
     let li = el.closest('.menu-choice')
     li.classList.remove('menu-choice--selected')
   }
-  target.closest('.menu-choice').classList.add('menu-choice--selected')
+  button.closest('.menu-choice').classList.add('menu-choice--selected')
 }

--- a/src/orthography.js
+++ b/src/orthography.js
@@ -1,0 +1,39 @@
+/**
+ * Orthography switching.
+ */
+
+const AVAILABLE_ORTHOGRAPHIES = new Set(['Cans', 'Latn', 'LatnXMacron'])
+
+/**
+ * Listen to ALL clicks on the page, and change orthography for elements that
+ * have the data-orth-switch.
+ */
+export function registerEventListener() {
+  document.body.addEventListener('click', function (evt) {
+    let target = evt.target
+    if (!target.dataset.orthSwitch) {
+      return
+    }
+
+    let orth = target.value
+    changeOrth(orth)
+  })
+}
+
+/**
+ * Changes the orthography of EVERYTHING on the page.
+ */
+export function changeOrth (which) {
+  if (!AVAILABLE_ORTHOGRAPHIES.has(which)) {
+    throw new Error(`tried to switch to unknown orthography: ${which}`)
+  }
+
+  let elements = document.querySelectorAll('[data-orth]')
+  let attr = `orth${which}`
+  for (let el of elements) {
+    let newText = el.dataset[attr]
+    if (newText) {
+      el.innerText = newText
+    }
+  }
+}


### PR DESCRIPTION
This implements the orthography switch menu.

![GIF of using the orthography switch menu](https://user-images.githubusercontent.com/2294397/75822439-33c34b80-5d5d-11ea-87ef-332dcd1ffc32.gif)

For now, this **only affects the current page**. Reloading the page or navigating to a different page will reset the orthography to SRO/circumflex. Persisting the orthographical preference will occur in a different PR.

Addresses #123.