### PR TITLE
Use CSRF token from DOM

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -14,6 +14,7 @@
 </head>
 <body class="app">
   <a href="#start-of-content" tabindex="0" class="skip-to-content">Skip to content</a>
+  {% csrf_token %}
   {% include './svg-sprites.html' %}
   {% include './components/header.html' %}
 

--- a/src/index.js
+++ b/src/index.js
@@ -199,13 +199,15 @@ function setupAudioOnPageLoad() {
 }
 
 $(() => {
+  let csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value
+
   // XXX: HACK! reloads the site when the back button is pressed.
   $(window).on('popstate', function () {
     location.reload()
   })
 
   setupAudioOnPageLoad()
-  orthography.registerEventListener()
+  orthography.registerEventListener(csrfToken)
 
   let route = window.location.pathname
   let $input = $('#search')


### PR DESCRIPTION
There was an issue with retrieving the CSRF token from cookies. This is needed in order for orthography switching to work. So instead of using cookies, we use `{% csrf_token %}` to place the token in the DOM, and then extract that token and give it to the orthography module.