### PR TITLE
Use @cypress/skip-test to skip test on buggy Electron.

### DIFF
--- a/cypress/integration/orthography.spec.js
+++ b/cypress/integration/orthography.spec.js
@@ -1,3 +1,5 @@
+import { skipOn } from '@cypress/skip-test'
+
 describe('Orthography selection', function () {
   describe('switching orthography', function () {
     it('should switch to syllabics when I click on the menu', function () {
@@ -53,12 +55,14 @@ describe('Orthography selection', function () {
         .contains('Syllabics')
     })
 
-    // XXX: This test fails in headless mode for Electron version < v6.0
-    // There was a bug with setting cookies via fetch():
-    //    https://github.com/cypress-io/cypress/issues/4433
-    // This should work in Cypress 3.5.0 and greater.
-    // As of 2020-03-05 this STILL doesn't work in CI :((((
-    it.skip('should persist my preference after a page load', function () {
+    it('should persist my preference after a page load', function () {
+      // XXX: This test fails in headless mode for Electron version < v6.0
+      // There was a bug with setting cookies via fetch():
+      //    https://github.com/cypress-io/cypress/issues/4433
+      // This should work in Cypress 3.5.0 using Chrome.
+      // As of 2020-03-05 this STILL doesn't work in Travis-CI :((((
+      skipOn('electron')
+
       cy.visit('/')
 
       // Get the introduction: it should be in SRO

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,12 @@
         }
       }
     },
+    "@cypress/skip-test": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cypress/skip-test/-/skip-test-2.5.0.tgz",
+      "integrity": "sha512-OqyToxRLUG/EAfZa0w8sAooOW6tr8pYCBpo3SLsKycrV2RTj9Sy7rB+5U0MvES87kWCHtO10qMIESuw8RiEYyQ==",
+      "dev": true
+    },
     "@cypress/xvfb": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/UAlbertaALTLab/cree-intelligent-dictionary#readme",
   "devDependencies": {
+    "@cypress/skip-test": "^2.5.0",
     "acorn": "^7.1.0",
     "cssnano": "^4.1.10",
     "cypress": "^3.7.0",


### PR DESCRIPTION
Setting cookies via fetch does not seem to work on headless Electron. Thus, we'll skip the test, but run it locally, on, e.g., Chrome.