### PR TITLE
No more hard-coded /cree-dictionary/

### DIFF
--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -153,13 +153,7 @@ USE_TZ = True
 
 ############################## staticfiles app ###############################
 
-if DEBUG:
-    STATIC_URL = "/static/"
-else:
-    # on sapir /cree-dictionary/ is used to identify the service of the app
-    # XXX: this is kind of a hack :/
-    STATIC_URL = "/cree-dictionary/static/"
-
+STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -1,8 +1,6 @@
 """
 Definition of urls for CreeDictionary.
 """
-import API.views as api_views
-from CreeDictionary import views
 from django.conf import settings
 from django.conf.urls import url
 from django.conf.urls.static import static
@@ -11,79 +9,59 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
 from django_js_reverse.views import urls_js
 
-# 2019/May/21 Matt Yan:
+import API.views as api_views
+from CreeDictionary import views
 
-# The reason to have different rules in development/production:
-
-# static file urls / web-page urls / API urls in this project all begin with "cree-dictionary"
-# so that in production on server sapir, the cree-dictionary service can be proxy-ed by looking for
-# initial "cree-dictionary" in the url.
-
-# example url:
-# http://sapir.artsrn.ualberta.ca/cree-dictionary/search/hello
-
-# in development, though, the initial "cree-dictionary" is not needed, example:
-# http://localhost:8000/search/hello
-# Note: re_path here, for example "re_path("^(cree-dictionary/)?some/url")", isn't a good solution. It messes up with
-# url reversion
-
-
-_urlpatterns = [
+urlpatterns = [
     # user interface
-    ("", views.index, "cree-dictionary-index"),
-    ("search/<str:query_string>/", views.index, "cree-dictionary-index-with-query"),
+    path("", views.index, name="cree-dictionary-index"),
+    path(
+        "search/<str:query_string>/",
+        views.index,
+        name="cree-dictionary-index-with-query",
+    ),
     # word is a user-friendly alternative for the linguistic term "lemma"
-    (
+    path(
         "word/<str:lemma_text>/",
         views.lemma_details,
-        "cree-dictionary-index-with-lemma",
+        name="cree-dictionary-index-with-lemma",
     ),
-    ("about", views.about, "cree-dictionary-about"),
+    path("about", views.about, name="cree-dictionary-about"),
     # internal use to render boxes of search results
-    (
+    path(
         "_search_results/<str:query_string>/",
         views.search_results,
-        "cree-dictionary-search-results",
+        name="cree-dictionary-search-results",
     ),
     # internal use to render paradigm and detailed info for a lemma
-    (
+    path(
         "_lemma_details/<int:lemma_id>/",
         views.lemma_details_internal,
-        "cree-dictionary-lemma-detail",
+        name="cree-dictionary-lemma-detail",
     ),
     # cree word translation for click-in-text #todo (for matt): this
-    (
+    path(
         "_translate-cree/<str:query_string>/",
         api_views.translate_cree,
-        "cree-dictionary-word-translation-api",
+        name="cree-dictionary-word-translation-api",
     ),
-    ("admin/", admin.site.urls, "admin"),
-    (
+    path("admin/", admin.site.urls, name="admin"),
+    path(
         "change-orthography",
         views.ChangeOrthography.as_view(),
-        "cree-dictionary-change-orthography",
+        name="cree-dictionary-change-orthography",
     ),
+    # magic that allows us to reverse urls in js  https://github.com/ierror/django-js-reverse
+    path("jsreverse/", urls_js, name="js_reverse"),
 ]
 
-# XXX: ugly hack to make this work on a local instance and on Sapir
-# TODO: this should use the SCRIPT_NAME WSGI variable instead.
-urlpatterns = []
-prefix = "" if settings.DEBUG else "cree-dictionary/"
-
-for route, view, name in _urlpatterns:
-    # kwarg `name` for url reversion in html/py/js code
-    urlpatterns.append(path(prefix + route, view, name=name))
-
-# magic that allows us to reverse urls in js  https://github.com/ierror/django-js-reverse
-urlpatterns.append(url(fr"^{prefix}jsreverse/$", urls_js, name="js_reverse"))
 
 if settings.DEBUG:
-
     # saves the need to `manage.py collectstatic` in development
     urlpatterns += staticfiles_urlpatterns()
 
-    if not settings.CI:
-        import debug_toolbar
+if settings.DEBUG and not settings.CI:
+    import debug_toolbar
 
-        # necessary for debug_toolbar to work
-        urlpatterns.append(path("__debug__/", include(debug_toolbar.urls)))
+    # necessary for debug_toolbar to work
+    urlpatterns.append(path("__debug__/", include(debug_toolbar.urls)))

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -60,7 +60,7 @@ if settings.DEBUG:
     # saves the need to `manage.py collectstatic` in development
     urlpatterns += staticfiles_urlpatterns()
 
-if settings.DEBUG and not settings.CI:
+if settings.DEBUG and not settings.CI:  # pragma: no cover
     import debug_toolbar
 
     # necessary for debug_toolbar to work


### PR DESCRIPTION
Note: this requires the following change to be made to `/data/texts/opt/cree-intelligent-dictionary/mod_wsgi-express-8091/envvars`:

```
export SCRIPT_NAME=/cree-dictionary/
```

Then the systemd service needs to be restarted.