### PR TITLE
Route relative to the index page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -199,13 +199,13 @@ function setupAudioOnPageLoad() {
 }
 
 /**
- * Makes all URL paths relative to the index.
- * In development, the index is '/'.
- * On Sapir (as of 2020-03-09), the index is '/cree-dictionary/'.
+ * Makes all URL paths relative to '/'.
+ * In development, the root path is '/', so nothing changes.
+ * On Sapir (as of 2020-03-09), the root path is '/cree-dictionary/'.
  */
-function makeRouteRelativeToRoute(route) {
+function makeRouteRelativeToSlash(route) {
   let baseURL = Urls['cree-dictionary-index']()
-  return baseURL + route.replace(/^[/]/, '')
+  return route.replace(baseURL, '/')
 }
 
 $(() => {
@@ -216,10 +216,9 @@ $(() => {
     location.reload()
   })
 
-  setupAudioOnPageLoad()
   orthography.registerEventListener(csrfToken)
 
-  let route = makeRouteRelativeToRoute(window.location.pathname)
+  let route = makeRouteRelativeToSlash(window.location.pathname)
   let $input = $('#search')
 
   // Tiny router.
@@ -231,6 +230,8 @@ $(() => {
     setSubtitle('About')
   } else if (route.match(/^[/]search[/].+/)) {
     prepareTooltips()
+  } else if (route.match(/^[/]word[/].+/)) {
+    setupAudioOnPageLoad()
   } else {
     throw new Error(`Could not match route: ${route}`)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -198,6 +198,16 @@ function setupAudioOnPageLoad() {
     })
 }
 
+/**
+ * Makes all URL paths relative to the index.
+ * In development, the index is '/'.
+ * On Sapir (as of 2020-03-09), the index is '/cree-dictionary/'.
+ */
+function makeRouteRelativeToRoute(route) {
+  let baseURL = Urls['cree-dictionary-index']()
+  return baseURL + route.replace(/^[/]/, '')
+}
+
 $(() => {
   let csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value
 
@@ -209,7 +219,7 @@ $(() => {
   setupAudioOnPageLoad()
   orthography.registerEventListener(csrfToken)
 
-  let route = window.location.pathname
+  let route = makeRouteRelativeToRoute(window.location.pathname)
   let $input = $('#search')
 
   // Tiny router.
@@ -221,6 +231,8 @@ $(() => {
     setSubtitle('About')
   } else if (route.match(/^[/]search[/].+/)) {
     prepareTooltips()
+  } else {
+    throw new Error(`Could not match route: ${route}`)
   }
 
   $input.on('input', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -209,18 +209,22 @@ function makeRouteRelativeToSlash(route) {
 }
 
 $(() => {
-  let csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value
-
   // XXX: HACK! reloads the site when the back button is pressed.
   $(window).on('popstate', function () {
     location.reload()
   })
 
+  let csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value
   orthography.registerEventListener(csrfToken)
 
-  let route = makeRouteRelativeToSlash(window.location.pathname)
+  // setup search bar
   let $input = $('#search')
+  $input.on('input', () => {
+    loadResults($input)
+    changeTitleByInput($input.val())
+  })
 
+  let route = makeRouteRelativeToSlash(window.location.pathname)
   // Tiny router.
   if (route === '/') {
     // Homepage
@@ -229,15 +233,12 @@ $(() => {
     // About page
     setSubtitle('About')
   } else if (route.match(/^[/]search[/].+/)) {
+    // Search page
     prepareTooltips()
   } else if (route.match(/^[/]word[/].+/)) {
+    // Word detail/paradigm page. This one has the 🔊 button.
     setupAudioOnPageLoad()
   } else {
     throw new Error(`Could not match route: ${route}`)
   }
-
-  $input.on('input', () => {
-    loadResults($input)
-    changeTitleByInput($input.val())
-  })
 })


### PR DESCRIPTION
The router used to route relative to `/`, however, this only works in development and in test. Instead, it should route relative to whatever the base path is. This PR removes the base from the path, replacing it with `/`, allowing the router to do its thing!

I also refactored `index.js` a tiny bit.

Fixes #316.