### PR TITLE
Place progress in base

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/about.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/about.html
@@ -2,8 +2,7 @@
 {% load static %}
 {% load creedictionary_extras %}
 
-{% block content %}
-<main id="start-of-content" class="app__content app__pane">
+{% block prose %}
   <section id="source-materials" class="prose box box--spaced">
     <h2 class="prose__section-title">Source Materials</h2>
 
@@ -89,6 +88,6 @@
     <p>Find a problem? Email us at
     <a href="mailto:altlab@ualberta.ca" class="about__link">altlab@ualberta.ca</a>.</p>
   </section>
-</main>
 {% endblock %}
+
 {# vim: set ft=htmldjango et ts=2 sw=2 sts=2 : #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -18,22 +18,31 @@
   {% include './svg-sprites.html' %}
   {% include './components/header.html' %}
 
-{% comment %}
-JavaScript adds the class .search-progress--loading or
-.search-progress-error, and changes the value:
-{% endcomment %}
-<progress id="loading-indicator" class="search-progress" data-cy="loading-indicator" max="1"></progress>
+  {% comment %}
+  JavaScript adds the class .search-progress--loading or
+  .search-progress-error, and changes the value:
+  {% endcomment %}
+  <progress id="loading-indicator" class="search-progress" data-cy="loading-indicator" max="1"></progress>
 
-{% block content %}
-{% comment %}
-N.B.: Make sure whatever is placed here has is a <main> or has role=main and
-has id="start-of-content"
-{% endcomment %}
-  <main id="start-of-content">
-    <strong> Placeholder content! </strong> If you're seeing this, something
-    went wrong.
+  <main id="start-of-content" class="app__content app__pane">
+    <div id="introduction-text">
+    {% block prose %}
+    {% endblock %}
+    </div>
+
+    <section class="search-results">
+      <ol class="search-results__results" id="search-result-list">
+        {% if search_results %}
+        {% include "CreeDictionary/word-entries.html" %}
+        {% endif %}
+      </ol>
+    </section>
+
+    {% if lemma_id %}
+      {% include 'CreeDictionary/paradigm.html' %}
+    {% endif %}
+
   </main>
-{% endblock %}
 
 <footer class="app-footer">
     <div class="app-footer__links footer-links app-footer__site-links">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -25,7 +25,7 @@
   <progress id="loading-indicator" class="search-progress" data-cy="loading-indicator" max="1"></progress>
 
   <main id="start-of-content" class="app__content app__pane">
-    <div id="introduction-text">
+    <div id="prose">
     {% block prose %}
     {% endblock %}
     </div>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -18,6 +18,12 @@
   {% include './svg-sprites.html' %}
   {% include './components/header.html' %}
 
+{% comment %}
+JavaScript adds the class .search-progress--loading or
+.search-progress-error, and changes the value:
+{% endcomment %}
+<progress id="loading-indicator" class="search-progress" data-cy="loading-indicator" max="1"></progress>
+
 {% block content %}
 {% comment %}
 N.B.: Make sure whatever is placed here has is a <main> or has role=main and

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
@@ -25,11 +25,6 @@
           </article>
 
         <section class="search-results">
-            {% comment %}
-                JavaScript adds the class .search-progress--loading or
-                .search-progress-error, and changes the value:
-            {% endcomment %}
-            <progress id="loading-indicator" class="search-progress" data-cy="loading-indicator" max="1"></progress>
             <ol class="search-results__results" id="search-result-list">
                 {% if search_results %}
                     {% include "CreeDictionary/word-entries.html" %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
@@ -3,38 +3,25 @@
 {% load static %}
 {% load creedictionary_extras %}
 
-{% block content %}
-    <main id="start-of-content" class="app__content app__pane">
-          <article class="prose box" id="introduction-text" {% if search_results or lemma_id %}style="display:none;"{% endif %}>
-            <h1 class="prose__heading no-italics">{% orth 'tânisi!' %}</span></h1>
-            <p>{% orth 'itwêwina' %} is a Plains Cree Dictionary.</p>
-            {% with long_word='ê-kî-nitawi-kâh-kîmôci-kotiskâwêyâhk' %}
-            {% url 'cree-dictionary-index-with-query' long_word as long_word_url %}
-            <p>Type any Cree word to find its English translation. You can search for
-                short Cree words (e.g., {% orth 'atim' %}) or very long Cree words
-                (e.g., <a data-cy="long-word-example" href="{{ long_word_url }}">{% orth long_word %}</a>). Or you can type an
-                English word and find its possible Cree translations. You can write words
-                in Cree using standard Roman orthography (SRO) (like
-                <span lang="cr">acimosis</span>) or using syllabics (e.g.,
-                <span lang="cr">ᐊᒋᒧᓯᐢ</span>).</p>
-            {% endwith %}
-            <p>{% orth 'itwêwina' %} was made by the University of Alberta ALTLab,
-                in collaboration with the First Nations University and Maskwacîs Education
-                Schools Commission (MESC). The dictionary entries are courtesy of Dr.
-                Arok Wolvengrey and MESC.</p>
-          </article>
-
-        <section class="search-results">
-            <ol class="search-results__results" id="search-result-list">
-                {% if search_results %}
-                    {% include "CreeDictionary/word-entries.html" %}
-                {% endif %}
-            </ol>
-        </section>
-
-        {% if lemma_id %}
-            {% include 'CreeDictionary/paradigm.html' %}
-        {% endif %}
-    </main>
+{% block prose %}
+<article class="prose box" {% if search_results or lemma_id %}style="display:none;"{% endif %}>
+  <h1 class="prose__heading no-italics">{% orth 'tânisi!' %}</span></h1>
+  <p>{% orth 'itwêwina' %} is a Plains Cree Dictionary.</p>
+  {% with long_word='ê-kî-nitawi-kâh-kîmôci-kotiskâwêyâhk' %}
+  {% url 'cree-dictionary-index-with-query' long_word as long_word_url %}
+  <p>Type any Cree word to find its English translation. You can search for
+      short Cree words (e.g., {% orth 'atim' %}) or very long Cree words
+      (e.g., <a data-cy="long-word-example" href="{{ long_word_url }}">{% orth long_word %}</a>). Or you can type an
+      English word and find its possible Cree translations. You can write words
+      in Cree using standard Roman orthography (SRO) (like
+      <span lang="cr">acimosis</span>) or using syllabics (e.g.,
+      <span lang="cr">ᐊᒋᒧᓯᐢ</span>).</p>
+  {% endwith %}
+  <p>{% orth 'itwêwina' %} was made by the University of Alberta ALTLab,
+      in collaboration with the First Nations University and Maskwacîs Education
+      Schools Commission (MESC). The dictionary entries are courtesy of Dr.
+      Arok Wolvengrey and MESC.</p>
+</article>
 {% endblock %}
+
 {# vim: set ft=htmldjango et ts=2 sw=2 sts=2 : #}

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -184,4 +184,20 @@ context('Regressions', () => {
     cy.contains('th', 's/he → you (one)')           // 3Sg -> 2Sg
     cy.contains('th', 's/he/they (further) → him/her') // 4 -> 3
   })
+
+  /**
+   * Ensure search can be initiated from about page.
+   *
+   * See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/280
+   */
+  it('should search from the about page', function () {
+    cy.visit('/about')
+    cy.get('[data-cy="search"]')
+      .type('acâhkos')
+
+    cy.url()
+      .should('contain', '/search')
+    cy.get('[data-cy=search-results]')
+      .should('contain', 'atâhk')
+  })
 })

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1053,7 +1053,18 @@ a.menu-choice__label:active {
 /***************************** SEARCH PROGRESS *****************************/
 
 .search-progress {
-  width: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+
+  display: block;
+  width: 100vw;
+  height: 1rem;
+  border: 0;
+
+  color: var(--app-title-color);
+  background-color: var(--footer-text-color);
 
   opacity: 0;
   visibility: hidden;

--- a/src/index.js
+++ b/src/index.js
@@ -56,14 +56,14 @@ function cleanParadigm() {
 }
 
 
-function showInstruction() {
-  let instruction = $('#introduction-text')
-  instruction.show()
+function showProse() {
+  let prose = $('#prose')
+  prose.show()
 }
 
-function hideInstruction() {
-  let instruction = $('#introduction-text')
-  instruction.hide()
+function hideProse() {
+  let prose = $('#prose')
+  prose.hide()
 }
 
 /**
@@ -101,7 +101,7 @@ function loadResults($input) {
   function issueSearch() {
     window.history.replaceState(text, document.title, Urls['cree-dictionary-index-with-query'](text))
 
-    hideInstruction()
+    hideProse()
 
     let xhttp = new XMLHttpRequest()
 
@@ -138,7 +138,7 @@ function loadResults($input) {
   function goToHomePage() {
     window.history.replaceState(text, document.title, Urls['cree-dictionary-index']())
 
-    showInstruction()
+    showProse()
 
     hideLoadingIndicator()
     $searchResultList.empty()


### PR DESCRIPTION
The progress bar used to only be loaded on `index.html`; pages like `about` would not load the progress bar. So I extracted its html and placed it into `base.html` so it would be on every page, then I visually placed the progress bar on the top of the screen, so that it's always visible when loading.

Fixes #280.