### PR TITLE
Implement "conventional" search

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/search.html
@@ -1,6 +1,9 @@
 {% load static %}
 <nav class="search top-bar__search">
-  <form class="search-bar search__search-bar">
+  <form class="search-bar search__search-bar"
+        method="get" action="{% url 'cree-dictionary-search' %}"
+        accept-charset="UTF-8"
+  >
     <label for="search" class="search-bar__label">
       <span class="sr-only">Search</span>
       <input id="search" class="search-bar__input" data-cy="search"

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
@@ -9,10 +9,9 @@
             <h1 class="prose__heading no-italics">{% orth 'tânisi!' %}</span></h1>
             <p>{% orth 'itwêwina' %} is a Plains Cree Dictionary.</p>
             {% with long_word='ê-kî-nitawi-kâh-kîmôci-kotiskâwêyâhk' %}
-            {% url 'cree-dictionary-index-with-query' long_word as long_word_url %}
             <p>Type any Cree word to find its English translation. You can search for
                 short Cree words (e.g., {% orth 'atim' %}) or very long Cree words
-                (e.g., <a data-cy="long-word-example" href="{{ long_word_url }}">{% orth long_word %}</a>). Or you can type an
+                (e.g., <a data-cy="long-word-example" href="{% url_for_query long_word %}">{% orth long_word %}</a>). Or you can type an
                 English word and find its possible Cree translations. You can write words
                 in Cree using standard Roman orthography (SRO) (like
                 <span lang="cr">acimosis</span>) or using syllabics (e.g.,

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -66,7 +66,7 @@
                 {% for preverb in result.preverbs %}
                     <li>
                         <span>Preverb: {% if preverb.id %}
-                            <a href="{% url 'cree-dictionary-index-with-query' preverb.text %}">{% orth preverb.text %}</a>{% else %}
+                            <a href="{% url_for_query preverb.text %}">{% orth preverb.text %}</a>{% else %}
                             {% orth preverb.text %}{% endif %}
                         </span>
 

--- a/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
+++ b/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
@@ -7,6 +7,7 @@ Template tags related to the Cree Dictionary specifically.
 
 from constants import DEFAULT_ORTHOGRAPHY, ORTHOGRAPHY_NAME
 from cree_sro_syllabics import sro2syllabics
+from CreeDictionary.utils import url_for_query
 from django import template
 from django.utils.html import format_html
 
@@ -90,6 +91,22 @@ def orth(sro_original: str, orthography):
         syllabics,
         inner_text,
     )
+
+
+@register.simple_tag(name="url_for_query")
+def url_for_query_tag(user_query: str) -> str:
+    """
+    Same as url_for_query(query), but usable in a template:
+
+    e.g.,
+
+        {% url_for_query 'wâpamêw' %}
+
+    yields:
+
+        /search?q=w%C3%A2pam%C3%AAw
+    """
+    return url_for_query(user_query)
 
 
 def to_macrons(sro_circumflex: str) -> str:

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -31,6 +31,7 @@ from django_js_reverse.views import urls_js
 _urlpatterns = [
     # user interface
     ("", views.index, "cree-dictionary-index"),
+    ("search", views.index, "cree-dictionary-search"),
     ("search/<str:query_string>/", views.index, "cree-dictionary-index-with-query"),
     # word is a user-friendly alternative for the linguistic term "lemma"
     (

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -32,6 +32,7 @@ _urlpatterns = [
     # user interface
     ("", views.index, "cree-dictionary-index"),
     ("search", views.index, "cree-dictionary-search"),
+    # DEPRECATED: this route 👇 is a permanent redirect to the route above ☝️
     (
         "search/<str:query_string>/",
         views.redirect_search,

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -32,7 +32,11 @@ _urlpatterns = [
     # user interface
     ("", views.index, "cree-dictionary-index"),
     ("search", views.index, "cree-dictionary-search"),
-    ("search/<str:query_string>/", views.index, "cree-dictionary-index-with-query"),
+    (
+        "search/<str:query_string>/",
+        views.redirect_search,
+        "cree-dictionary-index-with-query",
+    ),
     # word is a user-friendly alternative for the linguistic term "lemma"
     (
         "word/<str:lemma_text>/",

--- a/CreeDictionary/CreeDictionary/utils.py
+++ b/CreeDictionary/CreeDictionary/utils.py
@@ -5,9 +5,21 @@
 Utilities that depend for the CreeDictionary Django application.
 """
 
+from urllib.parse import ParseResult, urlencode, urlunparse
+
 from django.urls import reverse
 
 
 def url_for_query(user_query: str) -> str:
-    path = reverse("cree-dictionary-search")
-    return f"{path}?q={user_query}"
+    """
+    Produces a relative URL to search for the given user query.
+    """
+    parts = ParseResult(
+        scheme="",
+        netloc="",
+        params="",
+        path=reverse("cree-dictionary-search"),
+        query=urlencode((("q", user_query),)),
+        fragment="",
+    )
+    return urlunparse(parts)

--- a/CreeDictionary/CreeDictionary/utils.py
+++ b/CreeDictionary/CreeDictionary/utils.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""
+Utilities that depend for the CreeDictionary Django application.
+"""
+
+from django.urls import reverse
+
+
+def url_for_query(user_query: str) -> str:
+    path = reverse("cree-dictionary-search")
+    return f"{path}?q={user_query}"

--- a/CreeDictionary/CreeDictionary/utils.py
+++ b/CreeDictionary/CreeDictionary/utils.py
@@ -2,7 +2,7 @@
 # -*- coding: UTF-8 -*-
 
 """
-Utilities that depend for the CreeDictionary Django application.
+Utilities that depend on the CreeDictionary Django application.
 """
 
 from urllib.parse import ParseResult, urlencode, urlunparse

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -38,7 +38,7 @@ def lemma_details(request, lemma_text: str = None):  # pragma: no cover
         return redirect("cree-dictionary-index-with-query", query_string=lemma_text)
 
 
-def index(request, query_string=None):  # pragma: no cover
+def index(request):  # pragma: no cover
     """
     homepage with optional initial search results to display
 
@@ -47,15 +47,15 @@ def index(request, query_string=None):  # pragma: no cover
     :return:
     """
 
-    query_string = request.GET.get("q", query_string)
+    user_query = request.GET.get("q", None)
     context = {
         "word_search_form": WordSearchForm(),
         # when we have initial query word to search and display
-        "query_string": query_string,
+        "query_string": user_query,
         "search_results": [
-            search_result.serialize() for search_result in Wordform.search(query_string)
+            search_result.serialize() for search_result in Wordform.search(user_query)
         ]
-        if query_string
+        if user_query
         else [],
     }
     return HttpResponse(render(request, "CreeDictionary/index.html", context))

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -5,6 +5,7 @@ from constants import ORTHOGRAPHY_NAME, ParadigmSize
 from CreeDictionary.forms import WordSearchForm
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
+from django.urls import reverse
 from django.views import View
 
 # "pragma: no cover" works with coverage.
@@ -122,3 +123,16 @@ class ChangeOrthography(View):
         response = HttpResponse(status=HTTPStatus.NO_CONTENT)
         response.set_cookie("orth", orth)
         return response
+
+
+def redirect_search(request, query_string: str):
+    """
+    Permanently redirect from old search URL to new search URL.
+
+        /search/TERM -> /search?q=TERM
+
+    """
+
+    path = reverse("cree-dictionary-search")
+    new_uri = f"{path}?q={query_string}"
+    return redirect(new_uri, permanent=True)

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -132,7 +132,9 @@ def redirect_search(request, query_string: str):
         /search/TERM -> /search?q=TERM
 
     """
+    return redirect(url_for_query(query_string), permanent=True)
 
+
+def url_for_query(user_query: str) -> str:
     path = reverse("cree-dictionary-search")
-    new_uri = f"{path}?q={query_string}"
-    return redirect(new_uri, permanent=True)
+    return f"{path}?q={user_query}"

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -5,8 +5,9 @@ from constants import ORTHOGRAPHY_NAME, ParadigmSize
 from CreeDictionary.forms import WordSearchForm
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
-from django.urls import reverse
 from django.views import View
+
+from .utils import url_for_query
 
 # "pragma: no cover" works with coverage.
 # It excludes the clause or line (could be a function/class/if else block) from coverage
@@ -133,8 +134,3 @@ def redirect_search(request, query_string: str):
 
     """
     return redirect(url_for_query(query_string), permanent=True)
-
-
-def url_for_query(user_query: str) -> str:
-    path = reverse("cree-dictionary-search")
-    return f"{path}?q={user_query}"

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -46,6 +46,7 @@ def index(request, query_string=None):  # pragma: no cover
     :return:
     """
 
+    query_string = request.GET.get("q", query_string)
     context = {
         "word_search_form": WordSearchForm(),
         # when we have initial query word to search and display

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -36,7 +36,7 @@ def lemma_details(request, lemma_text: str = None):  # pragma: no cover
         }
         return HttpResponse(render(request, "CreeDictionary/index.html", context))
     else:
-        return redirect("cree-dictionary-index-with-query", query_string=lemma_text)
+        return redirect(url_for_query(lemma_text or ""))
 
 
 def index(request):  # pragma: no cover

--- a/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
@@ -149,3 +149,16 @@ def test_no_hyphens_in_syllabics():
         """,
         rendered,
     )
+
+
+def test_url_for_query_tag():
+    """
+    Test that it works at all.
+    """
+
+    context = Context({"query": "wapamew"})
+    template = Template("{% load creedictionary_extras %}" "{% url_for_query query %}")
+
+    rendered = template.render(context)
+    assert "search" in rendered
+    assert "wapamew" in rendered

--- a/CreeDictionary/tests/CreeDictionary_tests/test_search_redirect.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_search_redirect.py
@@ -9,8 +9,8 @@ from django.urls import reverse
 
 @pytest.mark.django_db
 def test_redirect(client):
-    lemma = "wâpamêw"
-    response = client.get(reverse("cree-dictionary-index-with-query", args=[lemma]))
+    wordform = "wâpamêw"
+    response = client.get(reverse("cree-dictionary-index-with-query", args=[wordform]))
     assert (
         response.status_code == HTTPStatus.MOVED_PERMANENTLY
     ), "Did not get a redirect"

--- a/CreeDictionary/tests/CreeDictionary_tests/test_search_redirect.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_search_redirect.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
+from http import HTTPStatus
+
 import pytest
 from django.urls import reverse
 
@@ -9,4 +11,6 @@ from django.urls import reverse
 def test_redirect(client):
     lemma = "wâpamêw"
     response = client.get(reverse("cree-dictionary-index-with-query", args=[lemma]))
-    assert response.status_code in range(300, 400), "Did not get a redirect"
+    assert (
+        response.status_code == HTTPStatus.MOVED_PERMANENTLY
+    ), "Did not get a redirect"

--- a/CreeDictionary/tests/CreeDictionary_tests/test_search_redirect.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_search_redirect.py
@@ -4,6 +4,7 @@
 from http import HTTPStatus
 
 import pytest
+from CreeDictionary.utils import url_for_query
 from django.urls import reverse
 
 
@@ -14,3 +15,6 @@ def test_redirect(client):
     assert (
         response.status_code == HTTPStatus.MOVED_PERMANENTLY
     ), "Did not get a redirect"
+
+    # Ensure the redirect is for the correct query.
+    assert url_for_query(wordform) in response.url

--- a/CreeDictionary/tests/CreeDictionary_tests/test_search_redirect.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_search_redirect.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_redirect(client):
+    lemma = "wâpamêw"
+    response = client.get(reverse("cree-dictionary-index-with-query", args=[lemma]))
+    assert response.status_code in range(300, 400), "Did not get a redirect"

--- a/CreeDictionary/tests/CreeDictionary_tests/test_utils.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_utils.py
@@ -7,7 +7,9 @@ import pytest
 from CreeDictionary.utils import url_for_query
 
 
-@pytest.mark.parametrize("query", ["awa"])
+@pytest.mark.parametrize("query", ["awa", "wâpamêw", "ᐚᐸᒣᐤ"])
 def test_query_always_ascii(query: str):
     url = url_for_query(query)
-    assert all(c in ascii_printable for c in url)
+    assert all(
+        c in ascii_printable for c in url
+    ), f"{url!r} should not contain non-ascii characters"

--- a/CreeDictionary/tests/CreeDictionary_tests/test_utils.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_utils.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from string import printable as ascii_printable
+
+import pytest
+from CreeDictionary.utils import url_for_query
+
+
+@pytest.mark.parametrize("query", ["awa"])
+def test_query_always_ascii(query: str):
+    url = url_for_query(query)
+    assert all(c in ascii_printable for c in url)

--- a/cypress/integration/paradigm.spec.js
+++ b/cypress/integration/paradigm.spec.js
@@ -15,7 +15,7 @@ context('Paradigms', () => {
     // Create test cases for each word above
     for (let {pos, lemma, inflections} of testCases) {
       it(`should display the paradigm for an ${pos} word`, () => {
-        cy.visit(`/search/${lemma}`)
+        cy.visitSearch(lemma)
         cy.get('[data-cy=search-results]')
           .contains('a', lemma)
           .click()
@@ -35,7 +35,7 @@ context('Paradigms', () => {
     // upstream layouts are broken :/
     it.skip('should display titles within the paradigm', () => {
       // TODO: move this test into the previous test when the layout is fixed.
-      cy.visit('/search/minôsis')
+      cy.visitSearch('minôsis')
       cy.get('[data-cy=search-results]')
         .contains('a', 'minôsis')
         .click()

--- a/cypress/integration/recordings.spec.js
+++ b/cypress/integration/recordings.spec.js
@@ -8,7 +8,7 @@ context('Recordings', function () {
         .as('recordingsResults')
 
       // Get to the definition/paradigm page for "wâpamêw"
-      cy.visit('/search/wâpamêw')
+      cy.visitSearch('wâpamêw')
       cy.contains('a', 'wâpamêw')
         .click()
       cy.url()

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -5,7 +5,7 @@ context('Regressions', () => {
    * magic is done for us. So, test that this is the case!
    */
   it('should handle a non-ASCII letter in the URL properly', () => {
-    cy.visit('/search/acâhkos')
+    cy.visitSearch('acâhkos')
 
     cy.get('[data-cy=search-results]')
       .should('contain', 'atâhk')
@@ -13,26 +13,26 @@ context('Regressions', () => {
 
   // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/147
   it('should allow space characters in exact strings', () => {
-    cy.visit('/search/acâhkos kâ-osôsit')
+    cy.visitSearch('acâhkos kâ-osôsit')
     cy.get('[data-cy=search-results]')
       .should('contain', 'acâhkos kâ-osôsit')
 
-    cy.visit('/search/acâhkosa kâ-otakohpit')
+    cy.visitSearch('acâhkosa kâ-otakohpit')
     cy.get('[data-cy=search-results]')
       .should('contain', 'acâhkosa kâ-otakohpit')
   })
 
   // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/147
   it('should allow space characters in spell-relaxed results', () => {
-    cy.visit('/search/niki nitawi kiskinwahamakosin')
+    cy.visitSearch('niki nitawi kiskinwahamakosin')
     cy.get('[data-cy=search-results]')
       .should('contain', 'kiskinwahamâkosiw')
 
-    cy.visit('/search/ka ki awasisiwiyan')
+    cy.visitSearch('ka ki awasisiwiyan')
     cy.get('[data-cy=search-results]')
       .should('contain', 'awâsisîwiw')
 
-    cy.visit('/search/na nipat')
+    cy.visitSearch('na nipat')
     cy.get('[data-cy=search-results]')
       .should('contain', 'nipâw')
   })
@@ -40,38 +40,38 @@ context('Regressions', () => {
 
   // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/158
   it('should display relevant English results', () => {
-    cy.visit('/search/see')
+    cy.visitSearch('see')
     cy.get('[data-cy=search-results]')
       .should('contain', 'wâpiw')
       .and('contain', 'wâpahtam')
       .and('contain', 'wâpamêw')
 
-    cy.visit('/search/eat')
+    cy.visitSearch('eat')
     cy.get('[data-cy=search-results]')
       .should('contain', 'mîcisow')
       .and('contain', 'mîciw')
       .and('contain', 'mowêw')
 
-    cy.visit('/search/sleep')
+    cy.visitSearch('sleep')
     cy.get('[data-cy=search-results]')
       .should('contain', 'nipâw')
   })
 
   // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/161
   it('should show preverbs', () => {
-    cy.visit('/search/ati')
+    cy.visitSearch('ati')
     cy.get('[data-cy=search-results]')
       .should('contain', 'ati-')
 
-    cy.visit('/search/ati-')
+    cy.visitSearch('ati-')
     cy.get('[data-cy=search-results]')
       .should('contain', 'ati-')
 
-    cy.visit('/search/nitawi')
+    cy.visitSearch('nitawi')
     cy.get('[data-cy=search-results]')
       .should('contain', 'nitawi-')
 
-    cy.visit('/search/pe')
+    cy.visitSearch('pe')
     cy.get('[data-cy=search-results]')
       .should('contain', 'pê-')
 
@@ -79,22 +79,22 @@ context('Regressions', () => {
 
   // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/160
   it('should show results for pronouns', () => {
-    cy.visit('/search/oma')
+    cy.visitSearch('oma')
     cy.get('[data-cy=search-results]')
       .should('contain', 'ôma')
 
-    cy.visit('/search/awa')
+    cy.visitSearch('awa')
     cy.get('[data-cy=search-results]')
       .should('contain', 'awa')
 
-    cy.visit('/search/niya')
+    cy.visitSearch('niya')
     cy.get('[data-cy=search-results]')
       .should('contain', 'niya')
   })
 
   // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/176
   it('should show results for lexicalized diminutive forms', () => {
-    cy.visit('/search/acâhkos')
+    cy.visitSearch('acâhkos')
     cy.get('[data-cy=search-results]')
       .should('contain', 'atâhk')
   })
@@ -102,7 +102,7 @@ context('Regressions', () => {
   // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/176
   describe('should show idiomatic lemmas', () => {
     it('The Cree word ayiwinis should give you ayiwinisa as lemma', () => {
-      cy.visit('/search/ayiwinis')
+      cy.visitSearch('ayiwinis')
       cy.get('[data-cy=search-results]')
         .should('contain', 'ayiwinisa')
     })
@@ -111,7 +111,7 @@ context('Regressions', () => {
   // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/176
   describe('should show at least two lemmas for lexicalized diminutive forms', () => {
     it('should show atâhk and acâhkos for acâhkos', () => {
-      cy.visit('/search/acâhkos')
+      cy.visitSearch('acâhkos')
       cy.get('[data-cy=search-results]')
         .should('contain', 'atâhk')
         .and('contain', 'acâhkos')
@@ -121,7 +121,7 @@ context('Regressions', () => {
     // Note: It's in dispute whether minôsis should be treated as a diminutive form of minôs
     // todo: enable this test if fst recognized minôsis as diminutive minôs
     it.skip('should show minôs and minôsis for minôsis', () => {
-      cy.visit('/search/minôsis')
+      cy.visitSearch('minôsis')
       cy.get('[data-cy=search-results]')
         .should('contain', 'minôsis')
         .and('contain', 'minôs')
@@ -130,7 +130,7 @@ context('Regressions', () => {
   })
 
   it('The Cree word ayiwinis should give you ayiwinisa as lemma', () => {
-    cy.visit('/search/ayiwinis')
+    cy.visitSearch('ayiwinis')
     cy.get('[data-cy=search-results]')
       .should('contain', 'ayiwinisa')
   })
@@ -138,7 +138,7 @@ context('Regressions', () => {
 
   // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/181
   it('should just show two meanings for the lemma nipâw', () => {
-    cy.visit('/search/nipâw')
+    cy.visitSearch('nipâw')
     cy.get('[data-cy=search-results]').first()
       .find('[data-cy=lemma-meaning]').should('have.length', 2)
   })
@@ -174,7 +174,7 @@ context('Regressions', () => {
 
   it('should show 3>1,2 rather than 3\', 3 in the VTA layout', function () {
     // Go to a VTA word:
-    cy.visit('/search/wâpamêw')
+    cy.visitSearch('wâpamêw')
     cy.contains('a', 'wâpamêw')
       .click()
 

--- a/cypress/integration/routing.spec.js
+++ b/cypress/integration/routing.spec.js
@@ -11,7 +11,7 @@ describe('urls for lemma detail page should be handled correctly', ()=>{
   })
 
   it('should redirect to search page if no match is found', function () {
-    // pôpô is a fictional word
+    // pîpîpôpô is a fictional word
     let fakeWord = 'pîpîpôpô'
     cy.visit(`/word/${fakeWord}/`)
     cy.get('[data-cy=paradigm]')

--- a/cypress/integration/routing.spec.js
+++ b/cypress/integration/routing.spec.js
@@ -11,15 +11,17 @@ describe('urls for lemma detail page should be handled correctly', ()=>{
   })
 
   it('should redirect to search page if no match is found', function () {
-    // poopoo is a fictional word
-    cy.visit('/word/poopoo/')
+    // pôpô is a fictional word
+    let fakeWord = 'pîpîpôpô'
+    cy.visit(`/word/${fakeWord}/`)
     cy.get('[data-cy=paradigm]')
       .should('not.exist')
 
     // test if the redirection happens
     cy.location().should(
       (loc)=>{
-        expect(loc.pathname).to.eq('/search/poopoo/')
+        expect(loc.pathname).to.eq('/search')
+        expect(loc.search).to.eq(`?q=${encodeURIComponent(fakeWord)}`)
       }
     )
 
@@ -31,7 +33,8 @@ describe('urls for lemma detail page should be handled correctly', ()=>{
     // test if the redirection happens
     cy.location().should(
       (loc)=>{
-        expect(loc.pathname).to.eq(`/search/${encodeURIComponent('nipâw')}/`)
+        expect(loc.pathname).to.eq('/search')
+        expect(loc.search).to.eq(`?q=${encodeURIComponent('nipâw')}`)
       }
     )
   })
@@ -45,7 +48,8 @@ describe('urls for lemma detail page should be handled correctly', ()=>{
     // test if the redirection happens
     cy.location().should(
       (loc)=>{
-        expect(loc.pathname).to.eq('/search/pipon/')
+        expect(loc.pathname).to.eq('/search')
+        expect(loc.search).to.eq('?q=pipon')
       }
     )
   })

--- a/cypress/integration/routing.spec.js
+++ b/cypress/integration/routing.spec.js
@@ -3,15 +3,14 @@
 // corresponding requirements: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/143
 describe('urls for lemma detail page should be handled correctly', ()=>{
   it('should show lemma detail (paradigms) if a unambiguous url is given', function () {
-
     // Get to the definition/paradigm page for "wâpamêw"
     cy.visit('/word/wâpamêw/')
     cy.get('[data-cy=paradigm]')
       .should('be.visible')
       .and('contain', 'kiwâpamitin')
   })
-  it('should redirect to search page if no match is found', function () {
 
+  it('should redirect to search page if no match is found', function () {
     // poopoo is a fictional word
     cy.visit('/word/poopoo/')
     cy.get('[data-cy=paradigm]')
@@ -24,7 +23,6 @@ describe('urls for lemma detail page should be handled correctly', ()=>{
       }
     )
 
-
     // wrong constraint pos=N is supplied, nipâw should have pos V
     cy.visit('/word/nipâw', {qs:{'pos':'N'}})
     cy.get('[data-cy=paradigm]')
@@ -36,11 +34,9 @@ describe('urls for lemma detail page should be handled correctly', ()=>{
         expect(loc.pathname).to.eq(`/search/${encodeURIComponent('nipâw')}/`)
       }
     )
-
   })
 
   it('should redirect to search page if the lemma_text in /word/lemma_text matches multiple results', function () {
-
     // pipon is a verb as well as a noun
     cy.visit('/word/pipon/')
     cy.get('[data-cy=paradigm]')
@@ -52,13 +48,11 @@ describe('urls for lemma detail page should be handled correctly', ()=>{
         expect(loc.pathname).to.eq('/search/pipon/')
       }
     )
-
   })
 
   it('should add relevant constraints as query params in href for ambiguous lemmas on the search page', function () {
-
     // pipon is a verb as well as a noun
-    cy.visit('/search/pipon/')
+    cy.visitSearch('pipon')
 
     let lemmaUrls = []
 
@@ -66,9 +60,5 @@ describe('urls for lemma detail page should be handled correctly', ()=>{
     cy.get('[data-cy=definition-title] a').each(($e)=>{
       lemmaUrls.push($e.attr('href'))
     }).then(()=>expect(lemmaUrls).to.have.members(['/word/pipon/?pos=N', '/word/pipon/?pos=V']))
-
-
   })
-
-
 })

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -230,7 +230,6 @@ context('Searching', () => {
     // At present, I want to target the definition's title, then look at the children to see if the the 'i' icon is
     // there. There's probably a more elegant way to do this but I think that'll come as I become more comfortable with the codebase.
     it('should show the \'info\' icon to allow users to access additional information', () => {
-
       // borrowed the following four lines from above and used 'nipaw' for testing purposes.
       const searchTerm = 'niya'
       cy.visit('/')
@@ -267,6 +266,8 @@ context('Searching', () => {
         expect(loc.pathname).to.eq('/search')
         expect(loc.search).to.contain('q=niya')
       })
+
+      // Press ENTER!
       cy.get('[data-cy=search]')
         .type('{Enter}')
 

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -255,23 +255,24 @@ context('Searching', () => {
     })
 
     it('should not change location upon pressing enter', function () {
-      let originalLocation
+      let originalPathname, originalSearch
       cy.visit('/')
 
       cy.get('[data-cy=search]')
         .type('niya')
 
-      cy.location('pathname').should(loc => {
-        originalLocation = loc
+      cy.location().should((loc) => {
+        originalPathname = loc.pathname
+        originalSearch = loc.search
         expect(loc.pathname).to.eq('/search')
-        expect(loc.query).to.contain('q=niya')
+        expect(loc.search).to.contain('q=niya')
       })
-
       cy.get('[data-cy=search]')
         .type('{Enter}')
 
       cy.location().should(loc => {
-        expect(loc).to.eq(originalLocation)
+        expect(loc.pathname).to.eq(originalPathname)
+        expect(loc.search).to.eq(originalSearch)
       })
     })
   })

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -44,7 +44,7 @@ context('Searching', () => {
     })
 
     it('should perform the search by going directly to the URL', () => {
-      cy.visit('/search/minos')
+      cy.visit('/search?q=minos', { escapeComponents: false })
 
       cy.get('[data-cy=search-results]')
         .should('contain', 'cat')
@@ -222,15 +222,15 @@ context('Searching', () => {
         .should('have.class', 'search-progress--error')
     })
   })
-  
-    
+
+
   describe('When I perform a search, I should see the \'info\' icon on corresponding entries', () => {
     // Right – this is the test for issue #239 (https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/239).
-    
+
     // At present, I want to target the definition's title, then look at the children to see if the the 'i' icon is
     // there. There's probably a more elegant way to do this but I think that'll come as I become more comfortable with the codebase.
     it('should show the \'info\' icon to allow users to access additional information', () => {
-      
+
       // borrowed the following four lines from above and used 'nipaw' for testing purposes.
       const searchTerm = 'niya'
       cy.visit('/')

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -240,4 +240,39 @@ context('Searching', () => {
       cy.get('[data-cy=search-result]').find('[data-cy=information-mark]')
     })
   })
+
+  describe('When I type at the search bar, I should see results instantly', function () {
+    it('should display results in the page', function () {
+      cy.visit('/')
+
+      cy.get('[data-cy=search]')
+        .type('niya')
+
+      cy.location('pathname')
+        .should('contain', '/search')
+      cy.location('search')
+        .and('contain', 'q=niya')
+    })
+
+    it('should not change location upon pressing enter', function () {
+      let originalLocation
+      cy.visit('/')
+
+      cy.get('[data-cy=search]')
+        .type('niya')
+
+      cy.location('pathname').should(loc => {
+        originalLocation = loc
+        expect(loc.pathname).to.eq('/search')
+        expect(loc.query).to.contain('q=niya')
+      })
+
+      cy.get('[data-cy=search]')
+        .type('{Enter}')
+
+      cy.location().should(loc => {
+        expect(loc).to.eq(originalLocation)
+      })
+    })
+  })
 })

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -52,7 +52,7 @@ context('Searching', () => {
   })
 
   describe('search results should be ranked by modified levenshtein distance', () => {
-    it.only('should show nipîhk before nîpîhk if the search string is the former', () => {
+    it('should show nipîhk before nîpîhk if the search string is the former', () => {
       cy.visitSearch('nipîhk')
 
       cy.get('[data-cy=search-results]').first()
@@ -68,7 +68,7 @@ context('Searching', () => {
       let lemma = 'atâhk'
       let dicts = ['CW', 'MD']
 
-      cy.visit(`/search/${lemma}`)
+      cy.visitSearch(lemma)
       cy.get('[data-cy=search-results]')
         .contains('[data-cy=search-result]', lemma)
         .as('definition')
@@ -109,7 +109,6 @@ context('Searching', () => {
 
       cy.get('[data-cy=search-results]')
         .contains('âyiman')
-
     })
 
     it('should handle English-influenced spelling', () => {
@@ -147,7 +146,7 @@ context('Searching', () => {
 
   it('should leave out not normatized content', () => {
     // nipa means "Kill Him" in MD
-    cy.visit('/search/nipa')
+    cy.visitSearch('nipa')
 
     cy.get('[data-cy=search-results]')
       .should('contain', 'sleeps')

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -1,5 +1,4 @@
 context('Searching', () => {
-
   describe('A tooltip should show up when the user click/focus on the i icon beside the matched wordform', () => {
     it('should show tooltip when the user focuses on the i icon beside ê-wâpamat', () => {
       cy.visit('/')
@@ -31,10 +30,7 @@ context('Searching', () => {
         .and('contain', 'wâpamêw') // lemma
         .and('contain', 'Action word') // verb
     })
-
-  }
-  )
-
+  })
 
   describe('I want to know what a Cree word means in English', () => {
     // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/120
@@ -56,9 +52,8 @@ context('Searching', () => {
   })
 
   describe('search results should be ranked by modified levenshtein distance', () => {
-    it('should show nipîhk before nîpîhk if the search string is the former', () => {
-
-      cy.visit('/search/nipîhk')
+    it.only('should show nipîhk before nîpîhk if the search string is the former', () => {
+      cy.visitSearch('nipîhk')
 
       cy.get('[data-cy=search-results]').first()
         .should('contain', 'nipîhk')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,7 +24,7 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
-// TODO: fix bug in Cypress: always encodeURIComponent in call to visit:
+// fixes a bug (feature?) in Cypress: always encodeURIComponent in call to visit:
 Cypress.Commands.overwrite('visit', (originalVisit, url, options) => {
   let newURL = url.split('/').map(encodeURIComponent).join('/')
   if (newURL !== url) {
@@ -35,4 +35,13 @@ Cypress.Commands.overwrite('visit', (originalVisit, url, options) => {
   }
 
   return originalVisit(newURL, options)
+})
+
+
+Cypress.Commands.add('visitSearch', { prevSubject: false}, (searchTerm) => {
+  Cypress.log({
+    name: 'visitSearch',
+    message: `visiting search page for: ${searchTerm}`
+  })
+  return cy.visit(`/search/${searchTerm}`)
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,9 +24,26 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
-// fixes a bug (feature?) in Cypress: always encodeURIComponent in call to visit:
+/**
+ * Fixes a bug (feature?) in Cypress: always encodeURIComponent in call to visit:
+ * Additional options:
+ *
+ *  escapeComponents: Boolean [default: true]  -- whether to escape URL components
+ */
 Cypress.Commands.overwrite('visit', (originalVisit, url, options) => {
-  let newURL = url.split('/').map(encodeURIComponent).join('/')
+  // Escape components by default:
+  if (options.escapeComponents === undefined) {
+    options.escapeComponents = true
+  }
+
+  let newURL
+  if (options.escapeComponents) {
+    newURL = url.split('/').map(encodeURIComponent).join('/')
+  } else {
+    newURL = url
+  }
+  delete options.escapeComponents
+
   if (newURL !== url) {
     Cypress.log({
       name: 'visit',
@@ -37,11 +54,13 @@ Cypress.Commands.overwrite('visit', (originalVisit, url, options) => {
   return originalVisit(newURL, options)
 })
 
-
-Cypress.Commands.add('visitSearch', { prevSubject: false}, (searchTerm) => {
+/**
+ * Visit the search page for the given search query.
+ */
+Cypress.Commands.add('visitSearch', { prevSubject: false }, (searchQuery) => {
   Cypress.log({
     name: 'visitSearch',
-    message: `visiting search page for: ${searchTerm}`
+    message: `visiting search page for: ${searchQuery}`
   })
-  return cy.visit(`/search/${searchTerm}`)
+  return cy.visit(`/search?q=${encodeURIComponent(searchQuery)}`, { escapeComponents: false })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,10 +25,13 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 /**
- * Fixes a bug (feature?) in Cypress: always encodeURIComponent in call to visit:
+ * Fixes a bug (feature?) in Cypress: it should call encodeURIComponent() for
+ * /path/components/ in visit(). This way paths with non-ASCII stuff is
+ * escaped automatically.
+ *
  * Additional options:
  *
- *  escapeComponents: Boolean [default: true]  -- whether to escape URL components
+ *  escapeComponents: Boolean [default: true]  -- whether to escape URL components at all.
  */
 Cypress.Commands.overwrite('visit', (originalVisit, url, options = {}) => {
   // Escape components by default:

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -30,7 +30,7 @@
  *
  *  escapeComponents: Boolean [default: true]  -- whether to escape URL components
  */
-Cypress.Commands.overwrite('visit', (originalVisit, url, options) => {
+Cypress.Commands.overwrite('visit', (originalVisit, url, options = {}) => {
   // Escape components by default:
   if (options.escapeComponents === undefined) {
     options.escapeComponents = true

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,9 @@ function loadResults($input) {
   }
 
   /**
-   * Returns the URL for a query.
+   * Returns a URL that search for the given query.
+   *
+   * The URL is constructed by using the <form>'s action="" attribute.
    */
   function urlForQuery(userQuery) {
     let form = $input.get(0).closest('form')

--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,8 @@ function loadResults($input) {
    * Returns the URL for a query.
    */
   function urlForQuery(userQuery) {
-    return Urls['cree-dictionary-index-with-query'](userQuery)
+    let form = $input.get(0).closest('form')
+    return form.action + `?q=${encodeURIComponent(userQuery)}`
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -89,17 +89,17 @@ function prepareTooltips() {
  * @param {jQuery} $input
  */
 function loadResults($input) {
-  let text = $input.val()
+  let userQuery = $input.val()
   let $searchResultList = $('#search-result-list')
 
-  if (text !== '') {
+  if (userQuery !== '') {
     issueSearch()
   } else {
     goToHomePage()
   }
 
   function issueSearch() {
-    window.history.replaceState(text, document.title, Urls['cree-dictionary-index-with-query'](text))
+    window.history.replaceState(userQuery, document.title, urlForQuery(userQuery))
 
     hideInstruction()
 
@@ -114,7 +114,7 @@ function loadResults($input) {
       if (xhttp.status === 200) {
         // user input may have changed during the request
         const inputNow = $input.val()
-        if (inputNow === text) { // hasn't changed
+        if (inputNow === userQuery) { // hasn't changed
           // Remove loading cards
           indicateLoadedSuccessfully()
           cleanParadigm()
@@ -130,13 +130,14 @@ function loadResults($input) {
     }
 
     xhttp.onerror = function () {
+      // TODO: we should do something here!
     }
-    xhttp.open('GET', Urls['cree-dictionary-search-results'](text), true)
+    xhttp.open('GET', Urls['cree-dictionary-search-results'](userQuery), true)
     xhttp.send()
   }
 
   function goToHomePage() {
-    window.history.replaceState(text, document.title, Urls['cree-dictionary-index']())
+    window.history.replaceState(userQuery, document.title, Urls['cree-dictionary-index']())
 
     showInstruction()
 
@@ -144,6 +145,12 @@ function loadResults($input) {
     $searchResultList.empty()
   }
 
+  /**
+   * Returns the URL for a query.
+   */
+  function urlForQuery(userQuery) {
+    return Urls['cree-dictionary-index-with-query'](userQuery)
+  }
 }
 
 /**


### PR DESCRIPTION
This implements the "conventional" search pattern, instead of using pretty URLs:

This is done in a few steps:

 - [x] Make a helper in integration tests to visit the search page given a term
 - [x] Create new URL that is otherwise identical to the existing search, except it happens at `/search?q=`:
 - [x] Redirect `/search/TERM` to `/search?q=TERM`
 - [x] Modify JavaScript to infer the search page and parameter from the search `<form>`

Closes #212 