### PR TITLE
Proposal: what's on prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ CreeDictionary/CreeDictionary/static/CreeDictionary/js/index.js
 CreeDictionary/CreeDictionary/static/CreeDictionary/css/styles.css
 *.css.map
 *.js.map
+
+# documents which version of xml file the production database is built with
+prod_crkeng_version.txt

--- a/Pipfile
+++ b/Pipfile
@@ -62,7 +62,7 @@ update-layouts = 'update-layouts'
 # warning: do not use these.
 # eventually we will scrap them and use a migration based work flow to preserve database changes AFTER a new
 # , well structured database is ready.
-push-db = 'rsync --progress CreeDictionary/db.sqlite3 $SAPIR_USER@sapir.artsrn.ualberta.ca:/opt/cree-intelligent-dictionary/CreeDictionary/db.sqlite3'
+push-db = 'sh ./libexec/push_db.sh'
 pull-db = 'rsync --progress $SAPIR_USER@sapir.artsrn.ualberta.ca:/opt/cree-intelligent-dictionary/CreeDictionary/db.sqlite3 CreeDictionary/db.sqlite3'
 
 [requires]

--- a/libexec/push_db.sh
+++ b/libexec/push_db.sh
@@ -1,0 +1,8 @@
+# expected to be called from Pipfile under project root directory
+
+echo "Which version of crkeng.xml did you use (200208/200218/200226 etc.)?"
+read -r version_digits
+
+rsync --progress CreeDictionary/db.sqlite3 $SAPIR_USER@sapir.artsrn.ualberta.ca:/opt/cree-intelligent-dictionary/CreeDictionary/db.sqlite3
+
+ssh $SAPIR_USER@sapir.artsrn.ualberta.ca "echo $version_digits >> /opt/cree-intelligent-dictionary/CreeDictionary/res/prod_crkeng_version.txt"


### PR DESCRIPTION
Before closing #256, I noticed the desired search results antti mentions was not showing up. I went on to investigate. It took me a long time to found out the production database is built with the  newer crkeng.xml but not the newer fst files.

It has come to me that it's very hard to determine what's being used in the database on Sapir, one of the complication is that the database depends on both the xml version and the fst version used to build it, which again can be accidentally differerent from vcs-tracked fst being used in the search code.

An emerging issue is Antti also needs the xml to be updated, see #351, 

```
# and we got this many xmls already
root@arrl-web003:/data/texts/crk/dicts/itwewina# ls
crkeng_cw_md_200208.xml  crkeng_cw_md_200218.xml  engcrk_cw_md_200226.xml  W_aggr_corp_morph_log_freq.txt

```

which demands the production database to be replaced manually. I understand we will switch to a solve-it-once-for-all new database. But I really want to write an API with minimal effort.

We should have an API `/status/`. It only accepts get request, and should output the following:

```json
{"Database": {"CrkengVersion": "200218", "FSTUsed": "2020-03-01"}, 
"Code": {"FSTUsed": "2020-03-01"} }
```

The value of "Database" key is obtained and uploaded to Sapir while newly built database is uploaed to Sapir. While `.Code.FSTUsed`  can be obtained by accessing `lasted modified` status of the fst file at runtime



