### PR TITLE
FAST affix search

### DIFF
--- a/CreeDictionary/API/apps.py
+++ b/CreeDictionary/API/apps.py
@@ -1,7 +1,10 @@
+from collections import defaultdict
 from pathlib import Path
 
 from django.apps import AppConfig
 from django.db import connection, OperationalError
+from typing import List, Dict, Set
+import string
 
 from utils import shared_res_dir
 from utils.cree_lev_dist import remove_cree_diacritics
@@ -62,6 +65,58 @@ def read_morpheme_rankings():
             Wordform.MORPHEME_RANKINGS[morpheme] = float(freq)
 
 
+def initialize_affix_search():
+    """
+    build dictionaries to facilitate affix search
+    """
+    # how many letters from the start/end do we check, larger length means more memory used, longer initialization time, but faster search
+    length = 5
+
+    n_th_letter_to_lemma_wordform_ids: List[Dict[str, Set[int]]] = [
+        defaultdict(set) for _ in range(length)
+    ]
+    inverse_n_th_letter_to_lemma_wordform_ids: List[Dict[str, Set[int]]] = [
+        defaultdict(set) for _ in range(length)
+    ]
+
+    from .models import Wordform
+
+    cree_letter_to_ascii = {
+        ascii_letter: ascii_letter for ascii_letter in string.ascii_lowercase
+    }
+    cree_letter_to_ascii.update(
+        {"â": "a", "ā": "a", "ê": "e", "ē": "e", "ī": "i", "î": "i", "ô": "o", "ō": "o"}
+    )
+    for wf in Wordform.objects.filter(is_lemma=True):
+        for i in range(length):
+            try:
+                lowered_letter = wf.text[i].lower()
+            except IndexError:
+                break
+            n_th_letter_to_lemma_wordform_ids[i][
+                cree_letter_to_ascii.get(lowered_letter, lowered_letter)
+            ].add(wf.id)
+
+        for i in range(length):
+            try:
+                lowered_letter = wf.text[-i - 1].lower()
+            except IndexError:
+                break
+
+            inverse_n_th_letter_to_lemma_wordform_ids[i][
+                cree_letter_to_ascii.get(lowered_letter, lowered_letter)
+            ].add(wf.id)
+
+    Wordform.N_TH_LETTER_TO_LEMMA_IDS = n_th_letter_to_lemma_wordform_ids
+    Wordform.INVERSE_N_TH_LETTER_TO_LEMMA_IDS = (
+        inverse_n_th_letter_to_lemma_wordform_ids
+    )
+
+    Wordform.WORDFORM_LEMMA_IDS = set(
+        Wordform.objects.filter(is_lemma=True).values_list("id", flat=True)
+    )
+
+
 class APIConfig(AppConfig):
     name = "API"
 
@@ -73,4 +128,5 @@ class APIConfig(AppConfig):
         """
         initialize_fuzzy_search()
         initialize_preverb_search()
+        initialize_affix_search()
         read_morpheme_rankings()

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -234,8 +234,10 @@ def test_search_text_with_ambiguous_word_classes():
     """
     # pipon can be viewed as a Verb as well as a Noun
     results = Wordform.search("pipon")
-    assert len(results) == 2
-    assert {r.lemma_wordform.pos for r in results} == {"N", "V"}
+    assert {r.lemma_wordform.pos for r in results if r.matched_cree == "pipon"} == {
+        "N",
+        "V",
+    }
 
 
 @pytest.mark.django_db

--- a/cypress/integration/routing.spec.js
+++ b/cypress/integration/routing.spec.js
@@ -63,6 +63,6 @@ describe('urls for lemma detail page should be handled correctly', ()=>{
     // both results should be present
     cy.get('[data-cy=definition-title] a').each(($e)=>{
       lemmaUrls.push($e.attr('href'))
-    }).then(()=>expect(lemmaUrls).to.have.members(['/word/pipon/?pos=N', '/word/pipon/?pos=V']))
+    }).then(()=>expect(lemmaUrls).to.include('/word/pipon/?pos=N').and.to.include('/word/pipon/?pos=V'))
   })
 })

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -153,6 +153,15 @@ context('Searching', () => {
       .and('not.contain', 'Kill')
   })
 
+  it('should do prefix search and suffix search', () => {
+
+    cy.visitSearch('nipaw')
+
+    cy.get('[data-cy=search-results]')
+      .should('contain', 'nipawâkan')
+      .and('contain', 'mâci-nipâw')
+  })
+
   describe('Loading indicator', () => {
     beforeEach(() => {
       cy.server()


### PR DESCRIPTION
@aarppe Hi please forgive me diverting from the priorities. But I get really intrigued by implementing a usable affix search tonight. I only spent this afternoon on this, and the result is really decent!

So prefix/suffix search will be conducted for user queries bigger than length 4 now (the length can be adjusted easily in code), for shorter results will possibly have too many matches .

I limited the search space with early hashing: Wordforms are classified by their n-th letters beforehand. The result is a lot better than #359 as search results show up generally fast when I test locally.

Here is the screenshot for _nipaw_, it's imperfect compared to the requirements in #133. But I guess that's due to other representation problems in our faulty database.  

![Screenshot from 2020-03-24 23-22-16](https://user-images.githubusercontent.com/44753941/77505094-d5ebc600-6e27-11ea-9086-1c6d79b4b862.png)
