### PR TITLE
regression test for #355 preverb issue

### DIFF
--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -212,7 +212,7 @@ context('Regressions', () => {
 
     // there should be only one result
     cy.get('[data-cy=search-results]').should('have.length', 1)
-
+      .and('should.contain', 'go and')
   })
 
 

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -208,7 +208,7 @@ context('Regressions', () => {
    * See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/355
    */
   it('should not present un-related translation for preverbs', function () {
-    cy.visitSearch('e-')
+    cy.visitSearch('nitawi-')
 
     // there should be only one result
     cy.get('[data-cy=search-results]').should('have.length', 1)

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -214,6 +214,4 @@ context('Regressions', () => {
     cy.get('[data-cy=search-results]').should('have.length', 1)
       .and('contain', 'go and')
   })
-
-
 })

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -212,7 +212,7 @@ context('Regressions', () => {
 
     // there should be only one result
     cy.get('[data-cy=search-results]').should('have.length', 1)
-      .and('should.contain', 'go and')
+      .and('contain', 'go and')
   })
 
 

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -200,4 +200,20 @@ context('Regressions', () => {
     cy.visitSearch('Edmonton')
     cy.get('[data-cy=search-results]').should('be.visible')
   })
+
+
+  /**
+   * Ensure preverbs don't get weird search results
+   *
+   * See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/355
+   */
+  it('should not present un-related translation for preverbs', function () {
+    cy.visitSearch('e-')
+
+    // there should be only one result
+    cy.get('[data-cy=search-results]').should('have.length', 1)
+
+  })
+
+
 })


### PR DESCRIPTION
Since a hallmark of #355 is an extra entry with un-related translation, this regression test notifies the developer when future alike issues happen.