### PR TITLE
Use Trie to Do Prefix/Suffix Search

### DIFF
--- a/CreeDictionary/API/affix_search.py
+++ b/CreeDictionary/API/affix_search.py
@@ -1,0 +1,34 @@
+from collections import defaultdict
+from itertools import chain
+
+import marisa_trie
+from typing import List, Iterable, Tuple, Dict
+
+
+class AffixSearcher:
+    def __init__(self, words: Iterable[Tuple[str, int]]):
+        """
+        :param words: expects lowered, no diacritics words with their ids
+        """
+        self.text_to_ids: Dict[str, List[int]] = defaultdict(list)
+        for w, w_id in words:
+            self.text_to_ids[w].append(w_id)
+
+        self.trie = marisa_trie.Trie([t[0] for t in words])
+        self.inverse_trie = marisa_trie.Trie([t[0][::-1] for t in words])
+
+    def search_by_prefix(self, prefix: str) -> Iterable[int]:
+        """
+        :param prefix: expects lowered, no diacritics words
+        :return: an iterable of ids
+        """
+        return chain(*[self.text_to_ids[t] for t in self.trie.keys(prefix)])
+
+    def search_by_suffix(self, suffix: str) -> Iterable[int]:
+        """
+        :param suffix: expects lowered, no diacritics words
+        :return: an iterable of ids
+        """
+        return chain(
+            *[self.text_to_ids[x[::-1]] for x in self.inverse_trie.keys(suffix[::-1])]
+        )

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -1,7 +1,9 @@
 import logging
+import time
 import unicodedata
 from collections import defaultdict
 from functools import cmp_to_key, partial
+from itertools import chain
 from typing import (
     Any,
     Callable,
@@ -29,11 +31,11 @@ from django.utils.encoding import iri_to_uri
 from django.utils.functional import cached_property
 from sortedcontainers import SortedSet
 
+import CreeDictionary.hfstol as temp_hfstol
+from .affix_search import AffixSearcher
 from constants import POS, ConcatAnalysis, FSTTag, Label, Language, ParadigmSize
 from fuzzy_search import CreeFuzzySearcher
 from paradigm import Layout
-from .schema import SerializedSearchResult, SerializedWordform, SerializedDefinition
-import CreeDictionary.hfstol as temp_hfstol
 from shared import paradigm_filler
 from utils import fst_analysis_parser, get_modified_distance
 from utils.cree_lev_dist import remove_cree_diacritics
@@ -42,6 +44,7 @@ from utils.fst_analysis_parser import (
     LabelFriendliness,
     partition_analysis,
 )
+from .schema import SerializedSearchResult, SerializedWordform, SerializedDefinition
 
 logger = logging.getLogger(__name__)
 
@@ -166,9 +169,8 @@ class Wordform(models.Model):
     # pure MD content won't be included
     PREVERB_ASCII_LOOKUP: Dict[str, Set["Wordform"]] = defaultdict(set)
 
-    # initialized in apps.py, facilitates affix search
-    N_TH_LETTER_TO_LEMMA_IDS: List[Dict[str, Set[int]]] = []
-    INVERSE_N_TH_LETTER_TO_LEMMA_IDS: List[Dict[str, Set[int]]] = []
+    # initialized in apps.py
+    affix_searcher: AffixSearcher
 
     # this is initialized upon app ready.
     MORPHEME_RANKINGS: Dict[str, float] = {}
@@ -369,59 +371,14 @@ class Wordform(models.Model):
 
         # there will be too many matches for some shorter queries
         if len(user_query) > settings.AFFIX_SEARCH_THRESHOLD:
-            # prefix search
-            no_diacritics_query_string = remove_cree_diacritics(user_query)
-            possible_wf_ids = Wordform.N_TH_LETTER_TO_LEMMA_IDS[0][
-                no_diacritics_query_string[0]
-            ].copy()
-            for letter_index, letter_to_ids in enumerate(
-                Wordform.N_TH_LETTER_TO_LEMMA_IDS
-            ):
-                if letter_index == 0:
-                    # accounted for before the for loop
-                    continue
+            # prefix and suffix search
+            ids_by_prefix = Wordform.affix_searcher.search_by_prefix(user_query)
+            ids_by_suffix = Wordform.affix_searcher.search_by_suffix(user_query)
 
-                if letter_index >= len(user_query):
-                    break
-
-                possible_wf_ids &= letter_to_ids[
-                    no_diacritics_query_string[letter_index]
-                ]
-
-            for possible_wf in Wordform.objects.filter(
-                id__in=possible_wf_ids, is_lemma=True
+            for wf in Wordform.objects.filter(
+                id__in=set(chain(ids_by_prefix, ids_by_suffix))
             ):
-                if remove_cree_diacritics(possible_wf.text).startswith(
-                    no_diacritics_query_string
-                ):
-                    cree_results.add(
-                        CreeResult(possible_wf.analysis, possible_wf, possible_wf.lemma)
-                    )
-            # suffix search
-            possible_wf_ids = Wordform.INVERSE_N_TH_LETTER_TO_LEMMA_IDS[0][
-                no_diacritics_query_string[-1]
-            ].copy()
-            for letter_index, letter_to_ids in enumerate(
-                Wordform.INVERSE_N_TH_LETTER_TO_LEMMA_IDS
-            ):
-                if letter_index == 0:
-                    # accounted for before the for loop
-                    continue
-
-                if letter_index >= len(user_query):
-                    break
-                possible_wf_ids &= letter_to_ids[
-                    no_diacritics_query_string[-letter_index - 1]
-                ]
-            for possible_wf in Wordform.objects.filter(
-                id__in=possible_wf_ids, is_lemma=True
-            ):
-                if remove_cree_diacritics(possible_wf.text).endswith(
-                    no_diacritics_query_string
-                ):
-                    cree_results.add(
-                        CreeResult(possible_wf.analysis, possible_wf, possible_wf.lemma)
-                    )
+                cree_results.add(CreeResult(wf.analysis, wf, wf.lemma))
 
         # utilize the spell relax in descriptive_analyzer
         # TODO: use shared.descriptive_analyzer (HFSTOL) when this bug is fixed:

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -151,8 +151,6 @@ USE_TZ = True
 
 ############################## API app settings ###############################
 
-# how many letters from the start/end do we check, larger length means more memory used, longer initialization time, but faster search
-AFFIX_SEARCH_LENGTH = 4
 # We only apply affix search for user queries longer than the threshold length
 AFFIX_SEARCH_THRESHOLD = 4
 

--- a/Pipfile
+++ b/Pipfile
@@ -30,6 +30,7 @@ typing-extensions = "~=3.7"
 attrs = "~=19.1"
 django-js-reverse = "~=0.9"
 sortedcontainers = {git = "https://github.com/Madoshakalaka/python-sortedcontainers.git"}
+marisa-trie = "~=0.7"
 
 [scripts]
 # look stuff up

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6e3f9b459e6807c82bab852593ec1cfaac5f4bf9e78c51dd7593713c04eda5d3"
+            "sha256": "f984b2aa131b5712e97c39a0d4d59372f2f890618c1a3fe0b2f85866367e69d1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -106,6 +106,14 @@
             "index": "pypi",
             "version": "==1.2.11"
         },
+        "marisa-trie": {
+            "hashes": [
+                "sha256:4419abb6b603c97e863fad994abe57ed247fb12491f4bbacb2d762bd2e8958b6",
+                "sha256:c73bc25d868e8c4ea7aa7f1e19892db07bba2463351269b05340ccfa06eb2baf"
+            ],
+            "index": "pypi",
+            "version": "==0.7.5"
+        },
         "pytz": {
             "hashes": [
                 "sha256:26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32",
@@ -145,10 +153,10 @@
         },
         "asgiref": {
             "hashes": [
-                "sha256:3e4192eaec0758b99722f0b0666d5fbfaa713054d92e8de5b58ba84ec5ce696f",
-                "sha256:c8f49dd3b42edcc51d09dd2eea8a92b3cfc987ff7e6486be734b4d0cbfd5d315"
+                "sha256:8036f90603c54e93521e5777b2b9a39ba1bad05773fcf2d208f0299d1df58ce5",
+                "sha256:9ca8b952a0a9afa61d30aa6d3d9b570bb3fd6bafcf7ec9e6bed43b936133db1c"
             ],
-            "version": "==3.2.5"
+            "version": "==3.2.7"
         },
         "attrs": {
             "hashes": [
@@ -266,10 +274,10 @@
         },
         "gitdir": {
             "hashes": [
-                "sha256:e9eac186373c819e5fd8fc305de39381ab863c155536f253d74554e389834672"
+                "sha256:8b158e21c5b4b8b27e2dd712dff824b4149a6cd65569af759f2cc2c47fe74e22"
             ],
             "index": "pypi",
-            "version": "==1.2.0"
+            "version": "==1.2.1"
         },
         "hypothesis": {
             "extras": [
@@ -291,11 +299,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
-                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
+                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
+                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.5.0"
+            "version": "==1.6.0"
         },
         "more-itertools": {
             "hashes": [


### PR DESCRIPTION
[marisa-trie](https://github.com/pytries/marisa-trie) is a python wrapper to a C library. The library implements Trie data structure with convinient prefix search utilities.

I re-implemented prefix/suffix search with tries. Based on my profiling, the end result is not necessarily faster because the bottleneck happens at database access. (The trie look up finishes in e^-5 seconds while the database access takes from 100 to 500 ms depending on how many results we present)

However the code is definitely more readible.