### PR TITLE
Introduce setting: RUNNING_ON_SAPIR

### DIFF
--- a/CreeDictionary/CreeDictionary/hostutils.py
+++ b/CreeDictionary/CreeDictionary/hostutils.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""
+Detect which host we're running on.
+"""
+
+import socket
+
+_SAPIR_HOSTNAME = "arrl-web003"
+HOSTNAME = socket.gethostname()
+HOST_IS_SAPIR = HOSTNAME == _SAPIR_HOSTNAME

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -90,7 +90,8 @@ if DEBUG:
         }
 
         INTERNAL_IPS = ["127.0.0.1"]
-else:  # enable mod_wsgi for production
+
+if RUNNING_ON_SAPIR:
     # Sapir uses `wsgi_express` that requires mod_wsgi
     INSTALLED_APPS.append("mod_wsgi.server")
 
@@ -168,12 +169,12 @@ AFFIX_SEARCH_THRESHOLD = 4
 
 ############################## staticfiles app ###############################
 
-if DEBUG:
-    STATIC_URL = "/static/"
-else:
+if RUNNING_ON_SAPIR:
     # on sapir /cree-dictionary/ is used to identify the service of the app
     # XXX: this is kind of a hack :/
     STATIC_URL = "/cree-dictionary/static/"
+else:
+    STATIC_URL = "/static/"
 
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -37,7 +37,7 @@ RUNNING_ON_SAPIR = (
 DEBUG = os.environ.get("DEBUG", "False").lower() == "true"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-if RUNNING_ON_SAPIR:
+if RUNNING_ON_SAPIR:  # pragma: no cover
     assert not DEBUG
 
 # travis has CI equals True
@@ -45,9 +45,9 @@ CI = os.environ.get("CI", "False").lower() == "true"
 
 if DEBUG:
     ALLOWED_HOSTS = ["*"]
-elif RUNNING_ON_SAPIR:
+elif RUNNING_ON_SAPIR:  # pragma: no cover
     ALLOWED_HOSTS = ["sapir.artsrn.ualberta.ca"]
-else:
+else:  # pragma: no cover
     ALLOWED_HOSTS = [HOSTNAME]
 
 # Application definition
@@ -91,7 +91,7 @@ if DEBUG:
 
         INTERNAL_IPS = ["127.0.0.1"]
 
-if RUNNING_ON_SAPIR:
+if RUNNING_ON_SAPIR:  # pragma: no cover
     # Sapir uses `wsgi_express` that requires mod_wsgi
     INSTALLED_APPS.append("mod_wsgi.server")
 
@@ -169,7 +169,7 @@ AFFIX_SEARCH_THRESHOLD = 4
 
 ############################## staticfiles app ###############################
 
-if RUNNING_ON_SAPIR:
+if RUNNING_ON_SAPIR:  # pragma: no cover
     # on sapir /cree-dictionary/ is used to identify the service of the app
     # XXX: this is kind of a hack :/
     STATIC_URL = "/cree-dictionary/static/"

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -15,6 +15,8 @@ import posixpath
 from pathlib import Path
 from sys import stderr
 
+from .hostutils import HOST_IS_SAPIR, HOSTNAME
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -24,19 +26,29 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "72bcb9a0-d71c-4d51-8694-6bbec435ab34"
 
+# sapir.artsrn.ualberta.ca has some... special requirements,
+# so let's hear about it!
+RUNNING_ON_SAPIR = (
+    os.environ.get("RUNNING_ON_SAPIR", str(HOST_IS_SAPIR)).lower() == "true"
+)
+
 # Debug is default to False
 # Turn it to True in development
+DEBUG = os.environ.get("DEBUG", "False").lower() == "true"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DEBUG", "False").lower() == "true"
+if RUNNING_ON_SAPIR:
+    assert not DEBUG
 
 # travis has CI equals True
 CI = os.environ.get("CI", "False").lower() == "true"
 
 if DEBUG:
     ALLOWED_HOSTS = ["*"]
-else:
+elif RUNNING_ON_SAPIR:
     ALLOWED_HOSTS = ["sapir.artsrn.ualberta.ca"]
+else:
+    ALLOWED_HOSTS = [HOSTNAME]
 
 # Application definition
 

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -1,8 +1,6 @@
 """
 Definition of urls for CreeDictionary.
 """
-import API.views as api_views
-from CreeDictionary import views
 from django.conf import settings
 from django.conf.urls import url
 from django.conf.urls.static import static
@@ -10,6 +8,9 @@ from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
 from django_js_reverse.views import urls_js
+
+import API.views as api_views
+from CreeDictionary import views
 
 # 2019/May/21 Matt Yan:
 
@@ -28,6 +29,8 @@ from django_js_reverse.views import urls_js
 # url reversion
 
 
+# TODO: Convert this to an idiomatic Django style when we drop support for
+# Sapir and mod-wsgi.
 _urlpatterns = [
     # user interface
     ("", views.index, "cree-dictionary-index"),
@@ -75,7 +78,7 @@ _urlpatterns = [
 # XXX: ugly hack to make this work on a local instance and on Sapir
 # TODO: this should use the SCRIPT_NAME WSGI variable instead.
 urlpatterns = []
-prefix = "" if settings.DEBUG else "cree-dictionary/"
+prefix = "cree-dictionary/" if settings.RUNNING_ON_SAPIR else ""
 
 for route, view, name in _urlpatterns:
     # kwarg `name` for url reversion in html/py/js code
@@ -85,7 +88,6 @@ for route, view, name in _urlpatterns:
 urlpatterns.append(url(fr"^{prefix}jsreverse/$", urls_js, name="js_reverse"))
 
 if settings.DEBUG:
-
     # saves the need to `manage.py collectstatic` in development
     urlpatterns += staticfiles_urlpatterns()
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,9 +1,8 @@
 # DEBUG
-Django magical variable. This is default to production setting `False`. You should add `DEBUG=False` to .env file
- in development.
- 
- > if you forget to add DEBUG=True, most probably you will get error message `"mod_wsgi" not found`
->. Because the django app mod_wsgi is only required in production.
+
+Django magical variable. This defaults to the production setting `False`.
+You should add `DEBUG=False` to .env file in development.
+Note: `DEBUG` CANNOT be enabled on Sapir!
 
 # USE_TEST_DB
 
@@ -12,3 +11,16 @@ It specifies whether to use `test_db.sqlite3` instead of `db.sqlite3`. It defaul
 Note: python unit tests under `CreeDictionary/tests` always creates in memory empty database unless specified 
 in the test code otherwise. E.g. `CreeDictionary/tests/API_test/model_test.py` is
  an example configuration where `test_db.sqlite3` is actually used.
+
+# RUNNING_ON_SAPIR
+
+Whether we're running on `sapir.artsrn.ualberta.ca`. There are various
+hacks required to make this run properly on Sapir, which are
+conditionally enabled using this flag. Note, that if unspecified, the
+app will try to determine if it's running on Sapir automatically, by
+querying the system's hostname.
+
+It is recommend that you leave this environment variable **unset**.
+ 
+> if you set `RUNNING_ON_SAPIR` to True, you most probably will get the error message `"mod_wsgi" not found`
+> because the Django app `mod_wsgi` is only required on Sapir.

--- a/docs/production-on-sapir.md
+++ b/docs/production-on-sapir.md
@@ -112,3 +112,13 @@ This only needs to be done once and is probably already done. This serves for do
     ```
 
 - `sudo a2ensite cree-dictionary`
+
+# `RUNNING_ON_SAPIR` setting and environment variable
+
+This setting is `True` when the app detects it's running on Sapir during
+startup. You can also force this setting by doing setting the
+environment variable to `True`.
+
+This settings enables certain "features" (read: hacks) required for
+running the application properly on Sapir. These features are not
+required in other production scenarios.


### PR DESCRIPTION
This setting will ease the transition to move from Sapir to a different production environment. It is necessary to make #378 work.

Fixes #379 