### PR TITLE
Add "Results not found" message

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -32,7 +32,7 @@
 
     <section class="search-results">
       <ol class="search-results__results" id="search-result-list">
-        {% if search_results %}
+        {% if did_search %}
         {% include "CreeDictionary/word-entries.html" %}
         {% endif %}
       </ol>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
@@ -4,7 +4,7 @@
 {% load creedictionary_extras %}
 
 {% block prose %}
-<article class="prose box" {% if search_results or lemma_id %}style="display:none;"{% endif %}>
+<article class="prose box"{% if did_search or lemma_id %} style="display:none"{% endif %}>
   <h1 class="prose__heading no-italics">{% orth 'tânisi!' %}</span></h1>
   <p>{% orth 'itwêwina' %} is a Plains Cree Dictionary.</p>
   {% with long_word='ê-kî-nitawi-kâh-kîmôci-kotiskâwêyâhk' %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -140,5 +140,9 @@
 
   </article>
 </li>
+{% empty %}
+  <li class="search-results__no-result box box--rounded box--bad-outcome" data-cy="no-search-result">
+    No results found for <output class="query--bad">{{ query_string }}</output>
+  </li>
 {% endfor %}
 {# vim: set ft=htmldjango et sw=2 ts=2 sts=2: #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -3,141 +3,142 @@
 {% load static %}
 
 {% for result in search_results %}
-    <li class="search-results__result" data-cy="search-results">
-        <article class="definition box box--rounded" data-cy="search-result">
-            <header class="definition__header">
-                <h2 class="definition-title definition-title--search-result">
+<li class="search-results__result" data-cy="search-results">
+  <article class="definition box box--rounded" data-cy="search-result">
+    <header class="definition__header">
+      <h2 class="definition-title definition-title--search-result">
 
-                    <dfn class="definition-title__word" data-cy="definition-title">
-                        {% if result.is_lemma %}
-                            <a class="definition-title__link" href="{{ result.lemma_wordform.lemma_url }}">
-                                {% orth result.lemma_wordform.text %}</a>
-                        {% else %}
-                            {% orth result.matched_cree %}
-                        {% endif %}
-                        <span class="definition-title__pos">({{ result.lemma_wordform|presentational_pos }})</span>
-                        {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
-
-
-                            <div tabindex="0" class="definition-title__tooltip-icon" aria-describedby="tooltip" data-cy="information-mark">
-                                <img
-                                        src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
-                                        alt="linguistic breakdown">
-                            </div>
+        <dfn class="definition-title__word" data-cy="definition-title">
+          {% if result.is_lemma %}
+          <a class="definition-title__link" href="{{ result.lemma_wordform.lemma_url }}">
+            {% orth result.lemma_wordform.text %}</a>
+          {% else %}
+          {% orth result.matched_cree %}
+          {% endif %}
+          <span class="definition-title__pos">({{ result.lemma_wordform|presentational_pos }})</span>
+          {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
 
 
-                            <div class="tooltip" role="tooltip">
-                                <span
-                                        data-cy="linguistic-breakdown">{% if result.linguistic_breakdown_head %}
-                                    {{ result.linguistic_breakdown_head|join:" + " }}
-                                    + {% endif %}
-                                    <strong>{{ result.lemma_wordform.text }}:</strong>
-                                    <ol class="linguistic-breakdown">                                    
-                                        {% for linguistic_tag in result.linguistic_breakdown_tail %}
-                                            <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
-                                                {{ linguistic_tag }}
-                                            </li>
-                                        {% endfor %}
-                                    </ol>
-                                </span>
-                                <div class="arrow" data-popper-arrow></div>
-                            </div>
-                        {% endif %}
-                    </dfn>
-
-                </h2>
-            </header>
-
-            {# Show the matched lemma (when this is NOT a lemma. #}
-            {% if not result.is_lemma %}
-                <p class="reference-to-lemma" data-cy="reference-to-lemma">
-                    Form of
-                    <a class="reference-to-lemma__lemma" href="{{ result.lemma_wordform.lemma_url }}"
-                       >{% orth result.lemma_wordform.text %}</a>
-                </p>
-            {% endif %}
+          <div tabindex="0" class="definition-title__tooltip-icon" aria-describedby="tooltip" data-cy="information-mark">
+            <img
+              src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
+              alt="linguistic breakdown">
+          </div>
 
 
-            {# Theses are the definitions for the inflection (non-lemma), could be empty  #}
-            <ol class="meanings meanings--search-result">
-                {% for def in result.definitions %}
-                    <li class="meanings__meaning" data-cy="lemma-meaning" data-cy="link-to-lemma">{{ def.text }}
-                        {% for source in def.source_ids %}
-                            <cite class="cite-dict">{{ source }}</cite>
-                        {% endfor %}
-                    </li>
+          <div class="tooltip" role="tooltip">
+            <span
+              data-cy="linguistic-breakdown">{% if result.linguistic_breakdown_head %}
+              {{ result.linguistic_breakdown_head|join:" + " }}
+              + {% endif %}
+              <strong>{{ result.lemma_wordform.text }}:</strong>
+              <ol class="linguistic-breakdown">
+                {% for linguistic_tag in result.linguistic_breakdown_tail %}
+                <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
+                  {{ linguistic_tag }}
+                </li>
                 {% endfor %}
-            </ol>
+              </ol>
+            </span>
+            <div class="arrow" data-popper-arrow></div>
+          </div>
+          {% endif %}
+        </dfn>
 
-            {# show preverb breakdown #}
-            <ol class="preverb-breakdown">
-                {% for preverb in result.preverbs %}
-                    <li>
-                        <span>Preverb: {% if preverb.id %}
-                            <a href="{% url_for_query preverb.text %}">{% orth preverb.text %}</a>{% else %}
-                            {% orth preverb.text %}{% endif %}
-                        </span>
+      </h2>
+    </header>
 
-                        {% if preverb.id %} {# we know the preverb in the database #}
-
-
-
-                            <div tabindex="0" class="preverb-breakdown__tooltip-icon" aria-describedby="tooltip" data-cy="information-mark">
-
-
-                                <img
-                                        src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
-                                        alt="preverb breakdown">
-                            </div>
-
-                            <div class="tooltip" role="tooltip">
-                                {% for definition in preverb.definitions %}
-                                    <p class="preverb-breakdown__preverb-definition">{{ definition.text }}
-                                        {% for source in definition.source_ids %}
-                                            <cite class="cite-dict cite-dict--popup">{{ source }}</cite>
-                                        {% endfor %}
-                                    </p>
-                                {% endfor %}
-                                <div class="arrow" data-popper-arrow></div>
-                            </div>
-
-                        {% endif %}
-                    </li>
-                {% endfor %}
-            </ol>
-            {# end preverb breakdown #}
-
-            {% if not result.is_lemma %}
-                {# show everything about the lemma #}
-
-                <hr class="cleave-inflection-from-lemma">
-
-                <header class="definition__header">
-                    <h2 class="definition-title definition-title--search-result">
-
-                        <dfn class="definition-title__word" data-cy="definition-title">
-                            <a class="definition-title__link" href="{{ result.lemma_wordform.lemma_url }}"
-                               >
-                                {# data- attributes are supported in HTML5 not in XHTML #}
-                                {% orth result.lemma_wordform.text %}</a>
-                        </dfn>
-                    </h2>
-                </header>
-
-                {# Theses are the definitions for the lemma, gauranteed to exist in the database #}
-                <ol class="meanings meanings--search-result">
-                    {% for def in result.lemma_wordform.definitions %}
-                        <li class="meanings__meaning" data-cy="lemma-meaning" data-cy="link-to-lemma">{{ def.text }}
-                            {% for source in def.source_ids %}
-                                <cite class="cite-dict">{{ source }}</cite>
-                            {% endfor %}
-                        </li>
-                    {% endfor %}
-                </ol>
+    {# Show the matched lemma (when this is NOT a lemma. #}
+    {% if not result.is_lemma %}
+    <p class="reference-to-lemma" data-cy="reference-to-lemma">
+    Form of
+    <a class="reference-to-lemma__lemma" href="{{ result.lemma_wordform.lemma_url }}"
+                                         >{% orth result.lemma_wordform.text %}</a>
+    </p>
+    {% endif %}
 
 
-            {% endif %}
+    {# Theses are the definitions for the inflection (non-lemma), could be empty  #}
+    <ol class="meanings meanings--search-result">
+      {% for def in result.definitions %}
+      <li class="meanings__meaning" data-cy="lemma-meaning" data-cy="link-to-lemma">{{ def.text }}
+        {% for source in def.source_ids %}
+        <cite class="cite-dict">{{ source }}</cite>
+        {% endfor %}
+      </li>
+      {% endfor %}
+    </ol>
 
-        </article>
-    </li>
+    {# show preverb breakdown #}
+    <ol class="preverb-breakdown">
+      {% for preverb in result.preverbs %}
+      <li>
+        <span>Preverb: {% if preverb.id %}
+          <a href="{% url_for_query preverb.text %}">{% orth preverb.text %}</a>{% else %}
+          {% orth preverb.text %}{% endif %}
+        </span>
+
+        {% if preverb.id %} {# we know the preverb in the database #}
+
+
+
+        <div tabindex="0" class="preverb-breakdown__tooltip-icon" aria-describedby="tooltip" data-cy="information-mark">
+
+
+          <img
+            src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
+            alt="preverb breakdown">
+        </div>
+
+        <div class="tooltip" role="tooltip">
+          {% for definition in preverb.definitions %}
+          <p class="preverb-breakdown__preverb-definition">{{ definition.text }}
+          {% for source in definition.source_ids %}
+          <cite class="cite-dict cite-dict--popup">{{ source }}</cite>
+          {% endfor %}
+          </p>
+          {% endfor %}
+          <div class="arrow" data-popper-arrow></div>
+        </div>
+
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ol>
+    {# end preverb breakdown #}
+
+    {% if not result.is_lemma %}
+    {# show everything about the lemma #}
+
+    <hr class="cleave-inflection-from-lemma">
+
+    <header class="definition__header">
+      <h2 class="definition-title definition-title--search-result">
+
+        <dfn class="definition-title__word" data-cy="definition-title">
+          <a class="definition-title__link" href="{{ result.lemma_wordform.lemma_url }}"
+                                            >
+                                            {# data- attributes are supported in HTML5 not in XHTML #}
+                                            {% orth result.lemma_wordform.text %}</a>
+        </dfn>
+      </h2>
+    </header>
+
+    {# Theses are the definitions for the lemma, gauranteed to exist in the database #}
+    <ol class="meanings meanings--search-result">
+      {% for def in result.lemma_wordform.definitions %}
+      <li class="meanings__meaning" data-cy="lemma-meaning" data-cy="link-to-lemma">{{ def.text }}
+        {% for source in def.source_ids %}
+        <cite class="cite-dict">{{ source }}</cite>
+        {% endfor %}
+      </li>
+      {% endfor %}
+    </ol>
+
+
+    {% endif %}
+
+  </article>
+</li>
 {% endfor %}
+{# vim: set ft=htmldjango et sw=2 ts=2 sts=2: #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -142,7 +142,7 @@
 </li>
 {% empty %}
   <li class="search-results__no-result box box--rounded box--bad-outcome" data-cy="no-search-result">
-    No results found for <output class="query--bad">{{ query_string }}</output>
+    No results found for <output class="query">{{ query_string }}</output>
   </li>
 {% endfor %}
 {# vim: set ft=htmldjango et sw=2 ts=2 sts=2: #}

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -54,14 +54,17 @@ def index(request):  # pragma: no cover
         search_results = [
             search_result.serialize() for search_result in Wordform.search(user_query)
         ]
+        did_search = True
     else:
         search_results = []
+        did_search = False
 
     context = {
         "word_search_form": WordSearchForm(),
         # when we have initial query word to search and display
         "query_string": user_query,
         "search_results": search_results,
+        "did_search": did_search,
     }
     return HttpResponse(render(request, "CreeDictionary/index.html", context))
 

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -49,15 +49,19 @@ def index(request):  # pragma: no cover
     """
 
     user_query = request.GET.get("q", None)
+
+    if user_query:
+        search_results = [
+            search_result.serialize() for search_result in Wordform.search(user_query)
+        ]
+    else:
+        search_results = []
+
     context = {
         "word_search_form": WordSearchForm(),
         # when we have initial query word to search and display
         "query_string": user_query,
-        "search_results": [
-            search_result.serialize() for search_result in Wordform.search(user_query)
-        ]
-        if user_query
-        else [],
+        "search_results": search_results,
     }
     return HttpResponse(render(request, "CreeDictionary/index.html", context))
 

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -77,7 +77,10 @@ def search_results(request, query_string: str):  # pragma: no cover
     return render(
         request,
         "CreeDictionary/word-entries.html",
-        {"search_results": [r.serialize() for r in results]},
+        {
+            "query_string": query_string,
+            "search_results": [r.serialize() for r in results],
+        },
     )
 
 

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -339,7 +339,7 @@ context('Searching', () => {
   })
 
   describe('When results are not found', function () {
-    // TODO: we should probably choose a more mature word ¯\_(ツ)_/¯
+    // TODO: we should probably choose a more mature example ¯\_(ツ)_/¯
     const NON_WORD = 'pîpîpôpô'
 
     it('should report no results found for ordinary search', function () {
@@ -354,9 +354,9 @@ context('Searching', () => {
       })
 
       // There should be something telling us that there are no results
-      cy.get('[data-cy=search-result]')
-        .contains(NON_WORD)
-        .contains(`No results found for ${NON_WORD}`)
+      cy.get('[data-cy=no-search-result]')
+        .and('contain', 'No results found')
+        .should('contain', NON_WORD)
     })
   })
 })

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -39,13 +39,13 @@ context('Searching', () => {
       cy.get('[data-cy=search]')
       // get a word (nipaw)
         .type('nipaw')
-      
+
       // tab through the elements to force the tooltip to pop up
       cy.get('[data-cy=information-mark]').first().click()
 
       // see the linguistic breakdown as an ordered list
       cy.get('[data-cy=linguistic-breakdown]').contains('li', 'Action word')
-      
+
     })
 
     it('should allow the tooltip to be focused on when the user tabs through it', () => {
@@ -59,7 +59,7 @@ context('Searching', () => {
 
       // tab through the page elements until arriving on the '?' icon
       cy.get('[data-cy=information-mark]').first().click()
-      
+
       // it should trigger the focus icon's outline's focused state
       cy.get('[data-cy=information-mark]').first().focus().should('have.css', 'outline')
     })
@@ -335,6 +335,28 @@ context('Searching', () => {
         expect(loc.pathname).to.eq(originalPathname)
         expect(loc.search).to.eq(originalSearch)
       })
+    })
+  })
+
+  describe('When results are not found', function () {
+    // TODO: we should probably choose a more mature word ¯\_(ツ)_/¯
+    const NON_WORD = 'pîpîpôpô'
+
+    it('should report no results found for ordinary search', function () {
+      cy.visit('/')
+
+      cy.get('[data-cy=search]')
+        .type(NON_WORD)
+
+      cy.location().should((loc) => {
+        expect(loc.pathname).to.eq('/search')
+        expect(loc.search).to.contain(`q=${encodeURIComponent(NON_WORD)}`)
+      })
+
+      // There should be something telling us that there are no results
+      cy.get('[data-cy=search-result]')
+        .contains(NON_WORD)
+        .contains(`No results found for ${NON_WORD}`)
     })
   })
 })

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -358,5 +358,13 @@ context('Searching', () => {
         .and('contain', 'No results found')
         .should('contain', NON_WORD)
     })
+
+    it('should report no results found when visiting the page directly', function () {
+      cy.visitSearch(NON_WORD)
+
+      cy.get('[data-cy=no-search-result]')
+        .and('contain', 'No results found')
+        .should('contain', NON_WORD)
+    })
   })
 })

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1007,6 +1007,17 @@ a.menu-choice__label:active {
   margin-block-end: 16px;
 }
 
+/**
+ * MODIFIER bad-outcome
+ *
+ * When displaying that something went wrong.
+ */
+.box--bad-outcome {
+  color: rgb(26, 9, 13);
+  background-color: rgb(227, 167, 175);
+  text-shadow: 1px 1px 0 #e0e0e0,
+               2px 2px 2px rgba(206, 77, 77, 0.2);
+}
 
 /******************************** ABOUT PAGE ********************************/
 
@@ -1163,3 +1174,19 @@ a.menu-choice__label:active {
 
   cursor: pointer;
 }
+
+/**
+ * BLOCK query
+ *
+ * For showing the user query on the page.
+ */
+.query {
+  font-style: italic;
+  quotes: "«" "»";
+}
+
+/**
+ * Show the quotes to indicate that this is verbatim.
+ */
+.query::before { content: open-quote; }
+.query::after { content: close-quote; }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1013,10 +1013,10 @@ a.menu-choice__label:active {
  * When displaying that something went wrong.
  */
 .box--bad-outcome {
-  color: rgb(26, 9, 13);
-  background-color: rgb(227, 167, 175);
-  text-shadow: 1px 1px 0 #e0e0e0,
-               2px 2px 2px rgba(206, 77, 77, 0.2);
+  color: var(--bad-outcome-color);
+  background-color: var(--bad-outcome-bg-color);
+  text-shadow: 1px 1px 0 var(--embossed-highlight),
+               2px 2px 2px var(--bad-outcome-shadow);
 }
 
 /******************************** ABOUT PAGE ********************************/

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -46,6 +46,10 @@
   --soft-hr-color:          #CCCCCC; /* Make the <hr> less harsh */
   --menu-hover-color:       var(--box-bg-color); /* An inverted colour scheme */
   --menu-hover-bg-color:    #0072C8; /* A dark background to contrast highlighted menu items. */
+  --bad-outcome-color:      #1A090D; /* A dark red text colour */
+  --bad-outcome-bg-color:   #E3A7AF; /* A light red (not quite pink) background */
+  --bad-outcome-shadow:     rgba(206, 77, 77, 0.2);
+  --embossed-highlight:     #e0e0e0;
 
   /* special way of changing svg fill color when svg is embedded in <img> */
   /* to change the color. Generate a "filter" attribute with the desired color code*/


### PR DESCRIPTION
Shows a dedicated message when there are no results for a given query, like this:

<img width="497" alt="Searching for 'notaword' with no results" src="https://user-images.githubusercontent.com/2294397/79270504-8d8a5b80-7e5b-11ea-9e4d-71daf7506a32.png">


Fixes #294.