### PR TITLE
Add syllabics font stack

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 
 @import "./vendor/normalize.css";
+@import "./vendor/notosanscanadianaboriginal.css";
 @import "./variables.css";
 @import "./_tooltip.css";
 

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -72,8 +72,14 @@
   --toggle-box-large-font-size:     1.14em;
   --cite-text-font-size:            0.50em;
   /* Font families */
-  --heading-font-family: Raleway, Euphemia UCAS, sans-serif;
-  --body-font-family: Open Sans, Euphemia UCAS, sans-serif;
+  --syllabics-fonts:
+    Gadugi,                             /* Windows 10 */
+    'Euphemia UCAS',                    /* macOS/iOS */
+    Euphemia,                           /* Windows Vista/7/8 */
+    'Aboriginal Sans',                  /* From languagegeek.com */
+    'Noto Sans Canadian Aboriginal';    /* Fallback: ChromeOS/Chomebook and other platforms. */
+  --heading-font-family: Raleway, var(--syllabics-fonts), sans-serif;
+  --body-font-family: 'Open Sans', var(--syllabics-fonts), sans-serif;
   /* Font weights */
   --body-font-weight:           400; /* Make sure these weights line up with the Google fonts! */
   --link-font-weight:           700; /* TODO: I don't like this. 700 is too bold. */

--- a/src/css/vendor/notosanscanadianaboriginal.css
+++ b/src/css/vendor/notosanscanadianaboriginal.css
@@ -1,0 +1,13 @@
+/*
+ * Noto Sans Canadian Aboriginal (Canadian Aboriginal) http://www.google.com/fonts/earlyaccess
+ */
+@font-face {
+  font-family: 'Noto Sans Canadian Aboriginal';
+  font-style: normal;
+  font-weight: 400;
+  src: url(//fonts.gstatic.com/ea/notosanscanadianaboriginal/v1/NotoSansCanadianAboriginal-Regular.eot);
+  src: url(//fonts.gstatic.com/ea/notosanscanadianaboriginal/v1/NotoSansCanadianAboriginal-Regular.eot?#iefix) format('embedded-opentype'),
+       url(//fonts.gstatic.com/ea/notosanscanadianaboriginal/v1/NotoSansCanadianAboriginal-Regular.woff2) format('woff2'),
+       url(//fonts.gstatic.com/ea/notosanscanadianaboriginal/v1/NotoSansCanadianAboriginal-Regular.woff) format('woff'),
+       url(//fonts.gstatic.com/ea/notosanscanadianaboriginal/v1/NotoSansCanadianAboriginal-Regular.ttf) format('truetype');
+}


### PR DESCRIPTION
Syllabics support is weird on a number of devices. Hence, it is best to explicitly specify which fonts work for syllabics. The exact pre-installed font differs on across platforms :( so I've tried to add a font-stack that works for as many platforms as possible.

On devices that do not have any syllabics font pre-installed, I've bundled a CSS `@import` for [Noto Sans Canadian Aboriginal](https://fonts.google.com/earlyaccess#Noto+Sans+Canadian+Aboriginal). This font will be downloaded ONLY if the other fonts are unavailable on the system.