### PR TITLE
Fix pipon definition merge

### DIFF
--- a/CreeDictionary/DatabaseManager/xml_importer.py
+++ b/CreeDictionary/DatabaseManager/xml_importer.py
@@ -513,7 +513,6 @@ def import_xmls(dir_name: Path, multi_processing: int = 1, verbose=True):
                         keyword_counter += 1
 
                 # now we create definition for all (possibly inflected) entries in xml that are forms of this lemma.
-                # d_s_dicts = xml_lemma_to_definition_src_dicts.get(generated_wordform)
 
                 # try to match our generated wordform to entries in the xml file,
                 # in order to get its definition from the entries
@@ -522,7 +521,7 @@ def import_xmls(dir_name: Path, multi_processing: int = 1, verbose=True):
                 # first get homographic entries from the xml file
                 pos_lc_tuples_in_xml = xml_lemma_to_pos_lc.get(generated_wordform)
 
-                # The case when we do have holographic entries in xml,
+                # The case when we do have homographic entries in xml,
                 # Then we check whether these entries' pos and lc agrees with our generated wordform
                 if pos_lc_tuples_in_xml is not None:
                     for xml_pos, xml_lc in pos_lc_tuples_in_xml:
@@ -534,8 +533,6 @@ def import_xmls(dir_name: Path, multi_processing: int = 1, verbose=True):
                             )
                 # The case when we don't have holographic entries in xml,
                 # The generated inflection doesn't have a definition
-                else:
-                    pass
 
                 for d_s_dict in d_s_dicts:
 

--- a/CreeDictionary/DatabaseManager/xml_importer.py
+++ b/CreeDictionary/DatabaseManager/xml_importer.py
@@ -13,6 +13,7 @@ from API.models import Definition, DictionarySource, EnglishKeyword, Wordform
 from DatabaseManager import xml_entry_lemma_finder
 from DatabaseManager.cree_inflection_generator import expand_inflections
 from DatabaseManager.log import DatabaseManagerLogger
+from DatabaseManager.xml_consistency_checker import does_lc_match_xml_entry
 from constants import POS
 from utils import fst_analysis_parser
 from utils.crkeng_xml_utils import extract_l_str, parse_xml_lc
@@ -462,22 +463,14 @@ def import_xmls(dir_name: Path, multi_processing: int = 1, verbose=True):
         db_lemma = None
         _, _, xml_lc = xml_lemma_pos_lcs[0]
 
-        # for use in building/merging definition
-        xml_lemmas = {t[0] for t in xml_lemma_pos_lcs}
-
-        xml_lemma_to_definition_src_dicts: Dict[str, List[Dict[str, Set[str]]]] = {
-            xml_lemma: [
-                xml_lemma_pos_lc_to_str_definitions[(xml_lemma,) + pos_lc_tuple]
-                for pos_lc_tuple in xml_lemma_to_pos_lc[xml_lemma]
-            ]
-            for xml_lemma in xml_lemmas
-        }
-
         # build wordforms and definition in db
         for generated_analysis, generated_wordforms in expanded[true_lemma_analysis]:
 
-            generated_lemma = fst_analysis_parser.extract_lemma(generated_analysis)
-            assert generated_lemma is not None
+            generated_lemma_lc = fst_analysis_parser.extract_lemma_and_category(
+                generated_analysis
+            )
+            assert generated_lemma_lc is not None
+            generated_lemma, generated_lc = generated_lemma_lc
 
             for generated_wordform in generated_wordforms:
                 # generated_inflections contain different spellings of one fst analysis
@@ -520,22 +513,43 @@ def import_xmls(dir_name: Path, multi_processing: int = 1, verbose=True):
                         keyword_counter += 1
 
                 # now we create definition for all (possibly inflected) entries in xml that are forms of this lemma.
-                d_s_dicts = xml_lemma_to_definition_src_dicts.get(generated_wordform)
+                # d_s_dicts = xml_lemma_to_definition_src_dicts.get(generated_wordform)
 
-                if d_s_dicts is not None:
-                    for d_s_dict in d_s_dicts:
+                # try to match our generated wordform to entries in the xml file,
+                # in order to get its definition from the entries
+                d_s_dicts: List[dict] = []
 
-                        for (str_definition, source_strings) in d_s_dict.items():
-                            db_definition = Definition(
-                                id=definition_counter,
-                                text=str_definition,
-                                wordform=db_inflection,
+                # first get homographic entries from the xml file
+                pos_lc_tuples_in_xml = xml_lemma_to_pos_lc.get(generated_wordform)
+
+                # The case when we do have holographic entries in xml,
+                # Then we check whether these entries' pos and lc agrees with our generated wordform
+                if pos_lc_tuples_in_xml is not None:
+                    for xml_pos, xml_lc in pos_lc_tuples_in_xml:
+                        if does_lc_match_xml_entry(generated_lc, xml_pos, xml_lc):
+                            d_s_dicts.append(
+                                xml_lemma_pos_lc_to_str_definitions[
+                                    (generated_wordform, xml_pos, xml_lc)
+                                ]
                             )
-                            assert definition_counter not in citations
-                            citations[definition_counter] = set(source_strings)
+                # The case when we don't have holographic entries in xml,
+                # The generated inflection doesn't have a definition
+                else:
+                    pass
 
-                            definition_counter += 1
-                            db_definitions.append(db_definition)
+                for d_s_dict in d_s_dicts:
+
+                    for (str_definition, source_strings) in d_s_dict.items():
+                        db_definition = Definition(
+                            id=definition_counter,
+                            text=str_definition,
+                            wordform=db_inflection,
+                        )
+                        assert definition_counter not in citations
+                        citations[definition_counter] = set(source_strings)
+
+                        definition_counter += 1
+                        db_definitions.append(db_definition)
 
         assert db_lemma is not None
         for wordform in db_wordforms_for_analysis:

--- a/CreeDictionary/tests/DatabaseManager_tests/test_xml_importer_regressions.py
+++ b/CreeDictionary/tests/DatabaseManager_tests/test_xml_importer_regressions.py
@@ -50,13 +50,15 @@ def test_import_pipon_of_different_word_classes(shared_datadir):
 
     assert (
         Wordform.objects.filter(text="pipon", is_lemma=True, pos="N")
-        .definitions.all()
-        .count()
-        == 2
-    )
-    assert (
-        Wordform.objects.filter(text="pipon", is_lemma=True, pos="V")
+        .get()
         .definitions.all()
         .count()
         == 1
+    )
+    assert (
+        Wordform.objects.filter(text="pipon", is_lemma=True, pos="V")
+        .get()
+        .definitions.all()
+        .count()
+        == 2
     )


### PR DESCRIPTION
This PR fixes #412, where both the verb and the noun _pipon_ were wrongly associated with same 3 definitions. Some code didn't deal with things to enough resolution.

Now it's correct:

![Screenshot from 2020-06-01 20-48-40](https://user-images.githubusercontent.com/44753941/83475199-16307b80-a44b-11ea-82de-235bb50b1fa1.png)

Potentially this also fixes some other cases.

I'll update production database after this is merged to master. 