### PR TITLE
Recordings on the search page (inefficient implementation)

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -18,6 +18,15 @@
   {% include './svg-sprites.html' %}
   {% include './components/header.html' %}
 
+  {# The 🔊 button template. Gets inflated by JavaScript. #}
+  <template id="template:play-button">
+    <button aria-label="Play recording" class="definition-title__play-button" data-cy="play-recording">
+      <svg class="definition-title__play-icon" focusable="false">
+        <use xlink:href="#fa-volume-up-solid" />
+      </svg>
+    </button>
+  </template>
+
   {% comment %}
   JavaScript adds the class .search-progress--loading or
   .search-progress-error, and changes the value:

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/paradigm.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/paradigm.html
@@ -9,17 +9,7 @@ This should be included or placed dynamical within <main>
 {% load inflection_extras %}
 {% load creedictionary_extras %}
 
-
 {% spaceless %}
-{# This is not in the DOM by default, but JS places in the <h1 id="head"> #}
-<template id="template:play-button">
-  <button aria-label="Play recording" class="definition-title__play-button" data-cy="play-recording">
-    <svg class="definition-title__play-icon" focusable="false">
-      <use xlink:href="#fa-volume-up-solid" />
-    </svg>
-  </button>
-</template>
-
 <article class="definition" id="paradigm">
   <header class="definition__header">
     <h1 id="head" class="definition-title">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -6,7 +6,7 @@
 <li class="search-results__result" data-cy="search-results">
   <article class="definition box box--rounded" data-cy="search-result">
     <header class="definition__header">
-      <h2 class="definition-title definition-title--search-result">
+      <h2 class="definition-title definition-title--search-result" data-wordform="{{ result.matched_cree }}">
 
         <dfn class="definition-title__word" data-cy="definition-title">
           {% if result.is_lemma %}

--- a/cypress/integration/recordings.spec.js
+++ b/cypress/integration/recordings.spec.js
@@ -3,7 +3,7 @@
  */
 context('Recordings', function () {
   describe('On the search page', () => {
-    it.skip('should display for words  on the search page', () => {
+    it('should display for words  on the search page', () => {
       // 'wâpamêw' is the word that we have a bunch of recordings for
       cy.visitSearch('wâpamêw')
 

--- a/cypress/integration/recordings.spec.js
+++ b/cypress/integration/recordings.spec.js
@@ -32,13 +32,8 @@ context('Recordings', function () {
     })
 
     it('should display the lemma\'s multiple speakers when the speaker icon is clicked', () => {
-      // begin from the start page
-      cy.visit('/')
-
-      // select the searchbar
-      cy.get('[data-cy=search]')
-        // look up a word (wapamew)
-        .type('wapamew')
+      // 'wâpamêw' is the word that we have a bunch of recordings for
+      cy.visitSearch('wâpamêw')
 
       // select the word and move to its paradigm,
       cy.get('[data-cy=definition-title').first().click()
@@ -49,17 +44,12 @@ context('Recordings', function () {
         .click()
 
       // the names of the speakers should appear on the page as a list of buttons to be interacted with
-      cy.get('[data-cy=recordings-list').find('li')
+      cy.get('[data-cy=recordings-list').find('button')
     })
 
     it('should play an individual speaker\'s pronounciation of the word when the speaker\'s name is clicked', () => {
-      // begin from the start page
-      cy.visit('/')
-
-      // select the searchbar
-      cy.get('[data-cy=search]')
-        // look up a word (wapamew)
-        .type('wapamew')
+      // 'wâpamêw' is the word that we have a bunch of recordings for
+      cy.visitSearch('wâpamêw')
 
       // select the word and move to its paradigm,
       cy.get('[data-cy=definition-title').first().click()
@@ -70,7 +60,7 @@ context('Recordings', function () {
         .click()
 
       // the names of the speakers should appear on the page as a list of buttons to be interacted with
-      cy.get('[data-cy=recordings-list').find('li')
+      cy.get('[data-cy=recordings-list').find('button')
 
       // clicking the buttons should output sound (can't figure out how to play them serially + not at once...but that may be okay?)
       cy.get('[data-cy=recordings-list__item').click({ multiple: true })

--- a/cypress/integration/recordings.spec.js
+++ b/cypress/integration/recordings.spec.js
@@ -2,6 +2,18 @@
  * Tests about hearing recording snippets.
  */
 context('Recordings', function () {
+  describe('On the search page', () => {
+    it('should display for words  on the search page', () => {
+      // 'wâpamêw' is the word that we have a bunch of recordings for
+      cy.visitSearch('wâpamêw')
+
+      // Play the recording:
+      cy.contains('.definition-title', 'wâpamêw')
+        .find('button[data-cy=play-recording]')
+        .click()
+    })
+  })
+
   describe('On the definition page', () => {
     it('should play a recording via a 🔊 icon', function () {
       cy.fixture('recording/_search/wâpamêw', 'utf-8')

--- a/cypress/integration/recordings.spec.js
+++ b/cypress/integration/recordings.spec.js
@@ -3,7 +3,7 @@
  */
 context('Recordings', function () {
   describe('On the search page', () => {
-    it('should display for words  on the search page', () => {
+    it.skip('should display for words  on the search page', () => {
       // 'wâpamêw' is the word that we have a bunch of recordings for
       cy.visitSearch('wâpamêw')
 
@@ -48,7 +48,7 @@ context('Recordings', function () {
       cy.visitSearch('wâpamêw')
 
       // select the word and move to its paradigm,
-      cy.get('[data-cy=definition-title').first().click()
+      cy.get('[data-cy=definition-title]').first().click()
 
       // then hover/focus on the speaker icon
       cy.get('[data-cy=play-recording]').focus()
@@ -56,7 +56,7 @@ context('Recordings', function () {
         .click()
 
       // the names of the speakers should appear on the page as a list of buttons to be interacted with
-      cy.get('[data-cy=recordings-list').find('button')
+      cy.get('[data-cy=recordings-list]').find('button')
     })
 
     it('should play an individual speaker\'s pronounciation of the word when the speaker\'s name is clicked', () => {
@@ -64,7 +64,7 @@ context('Recordings', function () {
       cy.visitSearch('wâpamêw')
 
       // select the word and move to its paradigm,
-      cy.get('[data-cy=definition-title').first().click()
+      cy.get('[data-cy=definition-title]').first().click()
 
       // then hover/focus on the speaker icon
       cy.get('[data-cy=play-recording]').focus()
@@ -72,7 +72,7 @@ context('Recordings', function () {
         .click()
 
       // the names of the speakers should appear on the page as a list of buttons to be interacted with
-      cy.get('[data-cy=recordings-list').find('button')
+      cy.get('[data-cy=recordings-list]').find('button')
 
       // clicking the buttons should output sound (can't figure out how to play them serially + not at once...but that may be okay?)
       cy.get('[data-cy=recordings-list__item').click({ multiple: true })

--- a/cypress/integration/recordings.spec.js
+++ b/cypress/integration/recordings.spec.js
@@ -32,48 +32,48 @@ context('Recordings', function () {
     })
 
     it('should display the lemma\'s multiple speakers when the speaker icon is clicked', () => {
-      // begin from the start page 
-      cy.visit('/');
+      // begin from the start page
+      cy.visit('/')
 
       // select the searchbar
       cy.get('[data-cy=search]')
         // look up a word (wapamew)
-        .type('wapamew');
+        .type('wapamew')
 
       // select the word and move to its paradigm,
-      cy.get('[data-cy=definition-title').first().click();
+      cy.get('[data-cy=definition-title').first().click()
 
       // then hover/focus on the speaker icon
       cy.get('[data-cy=play-recording]').focus()
         // click the icon
-        .click();
+        .click()
 
       // the names of the speakers should appear on the page as a list of buttons to be interacted with
-      cy.get('[data-cy=recordings-list').find('li');
+      cy.get('[data-cy=recordings-list').find('li')
     })
 
     it('should play an individual speaker\'s pronounciation of the word when the speaker\'s name is clicked', () => {
-      // begin from the start page 
-      cy.visit('/');
+      // begin from the start page
+      cy.visit('/')
 
       // select the searchbar
       cy.get('[data-cy=search]')
         // look up a word (wapamew)
-        .type('wapamew');
+        .type('wapamew')
 
       // select the word and move to its paradigm,
-      cy.get('[data-cy=definition-title').first().click();
+      cy.get('[data-cy=definition-title').first().click()
 
       // then hover/focus on the speaker icon
       cy.get('[data-cy=play-recording]').focus()
         // click the icon
-        .click();
+        .click()
 
       // the names of the speakers should appear on the page as a list of buttons to be interacted with
-      cy.get('[data-cy=recordings-list').find('li');
+      cy.get('[data-cy=recordings-list').find('li')
 
       // clicking the buttons should output sound (can't figure out how to play them serially + not at once...but that may be okay?)
-      cy.get('[data-cy=recordings-list__item').click({ multiple: true });
+      cy.get('[data-cy=recordings-list__item').click({ multiple: true })
     })
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -90,10 +90,19 @@ function hideProse() {
  */
 function prepareSearchResults(searchResultsList) {
   prepareTooltips()
+  loadRecordingsForAllSearchResults(searchResultsList)
+}
 
+/**
+ * Given a list of search results, this will attempt to match a recording to
+ * its match wordform.
+ *
+ * @param {Element} searchResultsList
+ */
+function loadRecordingsForAllSearchResults(searchResultsList) {
   for (let result of searchResultsList.querySelectorAll('[data-wordform]')) {
     let wordform = result.dataset.wordform
-    let container = result // do this reassignment because of the lexical scoping :/
+    let container = result // do this reassignment because of the lexical scoping :(
     fetchFirstRecordingURL(wordform)
       .then((recordingURL) => createAudioButton(recordingURL, container))
       .catch(() => {/* ignore :/ */})

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,14 @@ document.addEventListener('DOMContentLoaded', () => {
   } else if (route === '/search') {
     // Search page
     prepareTooltips()
+
+    for (let result of getSearchResultList().querySelectorAll('[data-wordform]')) {
+      let wordform = result.dataset.wordform
+      let container = result // do this reassignment because of the lexical scoping :/
+      fetchFirstRecordingURL(wordform)
+        .then((recordingURL) => createAudioButton(recordingURL, container))
+        .catch(() => {/* ignore :/ */})
+    }
   } else if (route.match(/^[/]word[/].+/)) {
     // Word detail/paradigm page. This one has the 🔊 button.
     setSubtitle(getEntryHead())
@@ -136,6 +144,7 @@ function loadSearchResults(searchInput) {
         cleanParadigm()
         searchResultList.innerHTML = html
         prepareTooltips()
+
       })
       .catch(() => {
         indicateLoadingFailure()
@@ -191,6 +200,7 @@ function setupAudioOnPageLoad() {
 
   fetchFirstRecordingURL(wordform)
     .then((recordingURL) => {
+      // TODO: it shouldn't be placed be **inside** the title <h1>...
       let button = createAudioButton(recordingURL, title)
       button.addEventListener('click', retrieveListOfSpeakers)
     })
@@ -225,16 +235,16 @@ function createAudioButton(recordingURL, element) {
   recording.preload = 'none'
 
   let template = document.getElementById('template:play-button')
+
   let fragment = template.content.cloneNode(true)
+  let button = fragment.querySelector('button')
+  button.addEventListener('click', () => recording.play())
 
   // Place "&nbsp;<button>...</button>"
-  // at the end of the <h1?
-  // TODO: it shouldn't really be **inside** the <h1>...
-  let button = fragment.childNodes[0]
+  // at the end of the element
   let nbsp = document.createTextNode(NO_BREAK_SPACE)
   element.appendChild(nbsp)
   element.appendChild(button)
-  button.addEventListener('click', () => recording.play())
 
   return button
 }

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,8 @@ function hideProse() {
  * Prepares interactive elements of each search result, including:
  *  - tooltips
  *  - recordings
+ *
+ * @param {Element} searchResultsList
  */
 function prepareSearchResults(searchResultsList) {
   prepareTooltips()

--- a/src/index.js
+++ b/src/index.js
@@ -187,23 +187,11 @@ function setupAudioOnPageLoad() {
   }
 
   // TODO: setup baseURL from <link rel=""> or something.
-  let template = document.getElementById('template:play-button')
   let wordform = getEntryHead()
 
   fetchFirstRecordingURL(wordform)
     .then((recordingURL) => {
-      let recording = new Audio(recordingURL)
-      recording.preload = 'none'
-
-      let fragment = template.content.cloneNode(true)
-      // Place "&nbsp;<button>...</button>"
-      // at the end of the <h1?
-      // TODO: it shouldn't really be **inside** the <h1>...
-      let button = fragment.childNodes[0]
-      let nbsp = document.createTextNode(NO_BREAK_SPACE)
-      title.appendChild(nbsp)
-      title.appendChild(button)
-      button.addEventListener('click', () => recording.play())
+      let button = createAudioButton(recordingURL, title)
       button.addEventListener('click', retrieveListOfSpeakers)
     })
     .catch(() => {
@@ -227,6 +215,28 @@ function makeRouteRelativeToSlash(route) {
 function getEntryHead() {
   let dataElement = document.getElementById('data:head')
   return dataElement.value
+}
+
+/**
+ * Creates the 🔊 button and places it beside the desired element.
+ */
+function createAudioButton(recordingURL, element) {
+  let recording = new Audio(recordingURL)
+  recording.preload = 'none'
+
+  let template = document.getElementById('template:play-button')
+  let fragment = template.content.cloneNode(true)
+
+  // Place "&nbsp;<button>...</button>"
+  // at the end of the <h1?
+  // TODO: it shouldn't really be **inside** the <h1>...
+  let button = fragment.childNodes[0]
+  let nbsp = document.createTextNode(NO_BREAK_SPACE)
+  element.appendChild(nbsp)
+  element.appendChild(button)
+  button.addEventListener('click', () => recording.play())
+
+  return button
 }
 
 ////////////////////// Fetch information from the page ///////////////////////

--- a/src/index.js
+++ b/src/index.js
@@ -48,15 +48,8 @@ document.addEventListener('DOMContentLoaded', () => {
     setSubtitle('Contact us')
   } else if (route === '/search') {
     // Search page
-    prepareTooltips()
 
-    for (let result of getSearchResultList().querySelectorAll('[data-wordform]')) {
-      let wordform = result.dataset.wordform
-      let container = result // do this reassignment because of the lexical scoping :/
-      fetchFirstRecordingURL(wordform)
-        .then((recordingURL) => createAudioButton(recordingURL, container))
-        .catch(() => {/* ignore :/ */})
-    }
+    prepareSearchResults(getSearchResultList())
   } else if (route.match(/^[/]word[/].+/)) {
     // Word detail/paradigm page. This one has the 🔊 button.
     setSubtitle(getEntryHead())
@@ -89,6 +82,23 @@ function showProse() {
 
 function hideProse() {
   hideElement(document.getElementById('prose'))
+}
+
+/**
+ * Prepares interactive elements of each search result, including:
+ *  - tooltips
+ *  - recordings
+ */
+function prepareSearchResults(searchResultsList) {
+  prepareTooltips()
+
+  for (let result of searchResultsList.querySelectorAll('[data-wordform]')) {
+    let wordform = result.dataset.wordform
+    let container = result // do this reassignment because of the lexical scoping :/
+    fetchFirstRecordingURL(wordform)
+      .then((recordingURL) => createAudioButton(recordingURL, container))
+      .catch(() => {/* ignore :/ */})
+  }
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -105,6 +105,10 @@ function loadRecordingsForAllSearchResults(searchResultsList) {
   for (let result of searchResultsList.querySelectorAll('[data-wordform]')) {
     let wordform = result.dataset.wordform
     let container = result // do this reassignment because of the lexical scoping :(
+
+    // TODO: instead of making a request for each search result,
+    // TODO: use a "bulk query" option that uses one request to load all
+    // TODO: this requires code in the recording-validation-interface
     fetchFirstRecordingURL(wordform)
       .then((recordingURL) => createAudioButton(recordingURL, container))
       .catch(() => {/* ignore :/ */})

--- a/src/index.js
+++ b/src/index.js
@@ -64,9 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
 function setupSearchBar() {
   let searchBar = document.getElementById('search')
   searchBar.addEventListener('input', () => {
-    let query = searchBar.value
     loadSearchResults(searchBar)
-    changeTitleBySearchQuery(query)
   })
 }
 
@@ -108,6 +106,7 @@ function loadSearchResults(searchInput) {
   let searchResultList = getSearchResultList()
 
   if (userQuery !== '') {
+    changeTitleBySearchQuery(userQuery)
     issueSearch()
   } else {
     goToHomePage()

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,6 @@ document.addEventListener('DOMContentLoaded', () => {
     setSubtitle('Contact us')
   } else if (route === '/search') {
     // Search page
-
     prepareSearchResults(getSearchResultList())
   } else if (route.match(/^[/]word[/].+/)) {
     // Word detail/paradigm page. This one has the 🔊 button.
@@ -153,8 +152,7 @@ function loadSearchResults(searchInput) {
         indicateLoadedSuccessfully()
         cleanParadigm()
         searchResultList.innerHTML = html
-        prepareTooltips()
-
+        prepareSearchResults(searchResultList)
       })
       .catch(() => {
         indicateLoadingFailure()

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ function hideProse() {
  * @param {Element} searchResultsList
  */
 function prepareSearchResults(searchResultsList) {
-  prepareTooltips()
+  prepareTooltips(searchResultsList)
   loadRecordingsForAllSearchResults(searchResultsList)
 }
 
@@ -112,13 +112,14 @@ function loadRecordingsForAllSearchResults(searchResultsList) {
 }
 
 /**
- * find #search-result-list element on the page to attach relevant handlers to the tooltip icons
+ * Attach relevant handlers to the tooltip icons of search results.
+ *
+ * @param {Element} searchResultsList
  */
-function prepareTooltips() {
-  const searchResultList = getSearchResultList()
-
+function prepareTooltips(searchResultsList) {
   // attach handlers for tooltip icon at preverb breakdown
-  let tooltips = searchResultList.querySelectorAll('.definition-title__tooltip-icon, .preverb-breakdown__tooltip-icon')
+  let tooltips = searchResultsList
+    .querySelectorAll('.definition-title__tooltip-icon, .preverb-breakdown__tooltip-icon')
   for (let icon of tooltips) {
     createTooltip($(icon), $(icon).next('.tooltip'))
   }


### PR DESCRIPTION
This adds recordings to the search page. No more clicking through to the paradigm page to hear a recording!

<img width="686" alt="Screen Shot 2020-06-03 at 4 33 51 PM" src="https://user-images.githubusercontent.com/2294397/83695906-53fee280-a5b8-11ea-82c1-f2b053d3e961.png">

Note: For _n_ search results, it hammers the recording-validation app with _n_ queries. The better way to do this is if the recording-validation app had a bulk API, but alas, it does not (yet).

Fixes #404.