### PR TITLE
Cleanup tooltips

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -19,12 +19,11 @@
           {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
 
 
-          <div tabindex="0" class="definition-title__tooltip-icon" aria-describedby="tooltip" data-cy="information-mark">
+          <div tabindex="0" class="definition-title__tooltip-icon" data-cy="information-mark">
             <img
               src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
               alt="linguistic breakdown">
           </div>
-
 
           <div class="tooltip" role="tooltip">
             <span
@@ -82,9 +81,7 @@
 
 
 
-        <div tabindex="0" class="preverb-breakdown__tooltip-icon" aria-describedby="tooltip" data-cy="information-mark">
-
-
+        <div tabindex="0" class="preverb-breakdown__tooltip-icon" data-cy="information-mark">
           <img
             src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
             alt="preverb breakdown">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -39,7 +39,7 @@
                 {% endfor %}
               </ol>
             </span>
-            <div class="arrow" data-popper-arrow></div>
+            <div class="tooltip__arrow" data-popper-arrow></div>
           </div>
           {% endif %}
         </dfn>
@@ -95,7 +95,7 @@
           {% endfor %}
           </p>
           {% endfor %}
-          <div class="arrow" data-popper-arrow></div>
+          <div class="tooltip__arrow" data-popper-arrow></div>
         </div>
 
         {% endif %}

--- a/src/css/_tooltip.css
+++ b/src/css/_tooltip.css
@@ -7,66 +7,66 @@
  * .tooltip class in this file decides how the popup looks like
  *
  * tooltip.js attaches all the event handlers
-*/
+ */
 
 .tooltip {
-    display: none;
+  display: none;
 
-    padding: 13px;
-    padding-top: 24px;
-    border-radius: 4px;
-    border: solid 1px rgba(209, 209, 209, 0.33);
+  padding: 13px;
+  padding-top: 24px;
+  border-radius: 4px;
+  border: solid 1px rgba(209, 209, 209, 0.33);
 
-    background: var(--popup-bg-color);
-    color: var(--popup-color);
+  background: var(--popup-bg-color);
+  color: var(--popup-color);
 
-    font-size: 1rem;
-    font-weight: var(--body-font-weight);
+  font-size: 1rem;
+  font-weight: var(--body-font-weight);
 
-    box-shadow: 4px 4px 8px 0 rgba(145, 145, 145, 0.23);
-    z-index: 1;
+  box-shadow: 4px 4px 8px 0 rgba(145, 145, 145, 0.23);
+  z-index: 1;
 }
 
 .tooltip[data-show] {
-    display: block;
+  display: block;
 }
 
 .arrow,
 .arrow::before {
-    position: absolute;
+  position: absolute;
 
-    width: 8px;
-    height: 8px;
+  width: 8px;
+  height: 8px;
 
-    z-index: -1;
+  z-index: -1;
 }
 
 .arrow::before {
-    content: '';
+  content: '';
 
-    border: solid 1px rgba(209, 209, 209, 0.33);
-    border-right: 0;
-    border-bottom: 0;
+  border: solid 1px rgba(209, 209, 209, 0.33);
+  border-right: 0;
+  border-bottom: 0;
 
 
-    transform: rotate(45deg);
-    background: var(--popup-bg-color);
+  transform: rotate(45deg);
+  background: var(--popup-bg-color);
 }
 
 .tooltip[data-popper-placement^='top'] > .arrow {
-    bottom: -4px;
+  bottom: -4px;
 }
 
 .tooltip[data-popper-placement^='bottom'] > .arrow {
-    top: -4px;
+  top: -4px;
 }
 
 .tooltip[data-popper-placement^='left'] > .arrow {
-    right: -4px;
+  right: -4px;
 }
 
 .tooltip[data-popper-placement^='right'] > .arrow {
-    left: -4px;
+  left: -4px;
 }
 
 /**

--- a/src/css/_tooltip.css
+++ b/src/css/_tooltip.css
@@ -13,7 +13,6 @@
   display: none;
 
   padding: 13px;
-  padding-top: 24px;
   border-radius: 4px;
   border: solid 1px rgba(209, 209, 209, 0.33);
 
@@ -23,7 +22,7 @@
   font-size: 1rem;
   font-weight: var(--body-font-weight);
 
-  box-shadow: 4px 4px 8px 0 rgba(145, 145, 145, 0.23);
+  box-shadow: 4px 4px 8px 2px rgba(145, 145, 145, 0.23);
   z-index: 1;
 }
 

--- a/src/css/_tooltip.css
+++ b/src/css/_tooltip.css
@@ -30,8 +30,8 @@
   display: block;
 }
 
-.arrow,
-.arrow::before {
+.tooltip__arrow,
+.tooltip__arrow::before {
   position: absolute;
 
   width: 8px;
@@ -40,7 +40,7 @@
   z-index: -1;
 }
 
-.arrow::before {
+.tooltip__arrow::before {
   content: '';
 
   border: solid 1px rgba(209, 209, 209, 0.33);
@@ -52,19 +52,19 @@
   background: var(--popup-bg-color);
 }
 
-.tooltip[data-popper-placement^='top'] > .arrow {
+.tooltip[data-popper-placement^='top'] > .tooltip__arrow {
   bottom: -4px;
 }
 
-.tooltip[data-popper-placement^='bottom'] > .arrow {
+.tooltip[data-popper-placement^='bottom'] > .tooltip__arrow {
   top: -4px;
 }
 
-.tooltip[data-popper-placement^='left'] > .arrow {
+.tooltip[data-popper-placement^='left'] > .tooltip__arrow {
   right: -4px;
 }
 
-.tooltip[data-popper-placement^='right'] > .arrow {
+.tooltip[data-popper-placement^='right'] > .tooltip__arrow {
   left: -4px;
 }
 

--- a/src/css/_tooltip.css
+++ b/src/css/_tooltip.css
@@ -1,23 +1,29 @@
 /* adapted from https://popper.js.org/docs/v2/tutorial/ */
 
-/* how to use: Create `icon` element and `popup` element in html
-
-`popup` needs to be the direct next sibling of `icon` and has class tooltip
-
-.tooltip class in this file decides how the popup looks like
-
-tooltip.js attaches all the event handlers
-
+/*
+ * How to use: Create `icon` element and `popup` element in html
+ * `popup` needs to be the direct next sibling of `icon` and has class tooltip
+ *
+ * .tooltip class in this file decides how the popup looks like
+ *
+ * tooltip.js attaches all the event handlers
 */
 
 .tooltip {
-    background: #333;
-    color: white;
-    font-weight: bold;
-    padding: 4px 8px;
-    font-size: 13px;
-    border-radius: 4px;
     display: none;
+
+    padding: 13px;
+    padding-top: 24px;
+    border-radius: 4px;
+    border: solid 1px rgba(209, 209, 209, 0.33);
+
+    background: var(--popup-bg-color);
+    color: var(--popup-color);
+
+    font-size: 1rem;
+    font-weight: var(--body-font-weight);
+
+    box-shadow: 4px 4px 8px 0 rgba(145, 145, 145, 0.23);
     z-index: 1;
 }
 
@@ -28,15 +34,23 @@ tooltip.js attaches all the event handlers
 .arrow,
 .arrow::before {
     position: absolute;
+
     width: 8px;
     height: 8px;
+
     z-index: -1;
 }
 
 .arrow::before {
     content: '';
+
+    border: solid 1px rgba(209, 209, 209, 0.33);
+    border-right: 0;
+    border-bottom: 0;
+
+
     transform: rotate(45deg);
-    background: #333;
+    background: var(--popup-bg-color);
 }
 
 .tooltip[data-popper-placement^='top'] > .arrow {
@@ -60,10 +74,10 @@ tooltip.js attaches all the event handlers
  *
  * Should remove the numbering from the lists that come with the linguistic breakdowns
  */
- .linguistic-breakdown__breakdown-tail {
-    list-style: none;
-  }
-  
-  .linguistic-breakdown__breakdown-tail > li {
-    padding-left: var(--small-pad);
-  }
+.linguistic-breakdown__breakdown-tail {
+  list-style: none;
+}
+
+.linguistic-breakdown__breakdown-tail > li {
+  padding-left: var(--small-pad);
+}

--- a/src/css/_tooltip.css
+++ b/src/css/_tooltip.css
@@ -44,9 +44,6 @@
   content: '';
 
   border: solid 1px rgba(209, 209, 209, 0.33);
-  border-right: 0;
-  border-bottom: 0;
-
 
   transform: rotate(45deg);
   background: var(--popup-bg-color);
@@ -56,16 +53,36 @@
   bottom: -4px;
 }
 
+.tooltip[data-popper-placement^='top'] > .tooltip__arrow::before {
+  border-top: 0;
+  border-left: 0;
+}
+
 .tooltip[data-popper-placement^='bottom'] > .tooltip__arrow {
   top: -4px;
+}
+
+.tooltip[data-popper-placement^='bottom'] > .tooltip__arrow::before {
+  border-right: 0;
+  border-bottom: 0;
 }
 
 .tooltip[data-popper-placement^='left'] > .tooltip__arrow {
   right: -4px;
 }
 
+.tooltip[data-popper-placement^='left'] > .tooltip__arrow::before {
+  border-top: 0;
+  border-right: 0;
+}
+
 .tooltip[data-popper-placement^='right'] > .tooltip__arrow {
   left: -4px;
+}
+
+.tooltip[data-popper-placement^='right'] > .tooltip__arrow::before {
+  border-bottom: 0;
+  border-left: 0;
 }
 
 /**

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -566,18 +566,26 @@ html {
   display: inline;
   position: relative;
 }
+
 .preverb-breakdown__tooltip-icon > img {
   width: var(--tooltip-icon-size);
 
   /* vertically center the question mark*/
   position: absolute;
-  top:0;
+  top: 0;
   bottom: 0;
   margin: auto;
   /* end vertical centering */
 
-  left:0.2em;  /* space out the question mark */
+  left: 0.2em;  /* space out the question mark */
   filter: var(--blue-filter); /* blue color */
+}
+
+/**
+ * Occurs inside a tooltip. Get rid of its extra margin!
+ */
+.preverb-breakdown__preverb-definition {
+  margin: 0;
 }
 
 /********************************* PARADIGM *********************************/

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -24,7 +24,7 @@
   --app-title-color:        #0091FF; /* Color of the "itwêwina" title. */
   --app-body-color:         #000000; /* Color of body text. */
   --cite-text-color:        #182457; /* Color of dictionary citation element. */
-  --cite-text-popup-color:  #ffffff; /* Color of dictionary citation element. */
+  --cite-text-popup-color:  var(--cite-text-color); /* Color of dictionary citation element. */
   --popup-color:            #000000; /* Color of popup/tooltip text. */
   --popup-bg-color:         #ffffff; /* Color of popup/tooltip background. */
   --footer-bg-color:        #EBE9E9; /* Background color of the "sunken" footer. */

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -25,6 +25,8 @@
   --app-body-color:         #000000; /* Color of body text. */
   --cite-text-color:        #182457; /* Color of dictionary citation element. */
   --cite-text-popup-color:  #ffffff; /* Color of dictionary citation element. */
+  --popup-color:            #000000; /* Color of popup/tooltip text. */
+  --popup-bg-color:         #ffffff; /* Color of popup/tooltip background. */
   --footer-bg-color:        #EBE9E9; /* Background color of the "sunken" footer. */
   --footer-text-color:      #404040; /* Background color of the "sunken" footer. */
   --header-stripe-color:    var(--app-title-color); /* Color of the "stripe" to the left of the title. */

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,6 @@
 // "Urls" is a magic variable that allows use to reverse urls in javascript
 // See https://github.com/ierror/django-js-reverse
 
-import $ from 'jquery'
-
 // Process CSS with PostCSS automatically. See rollup.config.js for more
 // details.
 import './css/styles.css'
@@ -125,7 +123,11 @@ function prepareTooltips(searchResultsList) {
   let tooltips = searchResultsList
     .querySelectorAll('.definition-title__tooltip-icon, .preverb-breakdown__tooltip-icon')
   for (let icon of tooltips) {
-    createTooltip($(icon), $(icon).next('.tooltip'))
+    let tooltip = icon.nextElementSibling
+    if (!tooltip.classList.contains('tooltip')) {
+      throw new Error('Expected tooltip to be direct sibling of icon')
+    }
+    createTooltip(icon, tooltip)
   }
 }
 

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -1,11 +1,16 @@
 // adapted from poppers.js tutorial https://popper.js.org/docs/v2/tutorial/
 import {createPopper} from '@popperjs/core/dist/esm/popper'
 
+import $ from 'jquery'
 
 let popperInstance = null
 
+/**
+ * @param {Element} icon
+ * @param {Element} popup
+ */
 function create(icon, popup) {
-  popperInstance = createPopper(icon.get(0), popup.get(0), {
+  popperInstance = createPopper(icon, popup, {
     modifiers: [
       {
         name: 'offset',
@@ -30,20 +35,20 @@ const hideEvents = ['mouseleave', 'blur']
 /**
  * prepare the popup and the icon. Attach relevant handlers
  *
- * @param icon {jQuery}: icon that triggers the popup on hover/click/focus
- * @param popup {jQuery}: the popup that shows up
+ * @param icon {Element}: icon that triggers the popup on hover/click/focus
+ * @param popup {Element}: the popup that shows up
  */
 export function createTooltip(icon, popup) {
   showEvents.forEach(event => {
-    icon.on(event, () => {
-      popup.attr('data-show', '')
+    $(icon).on(event, () => {
+      popup.setAttribute('data-show', '')
       create(icon, popup)
     })
   })
 
   hideEvents.forEach(event => {
-    icon.on(event, () => {
-      popup.removeAttr('data-show')
+    $(icon).on(event, () => {
+      popup.removeAttribute('data-show')
       destroy()
     })
   })

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -1,8 +1,6 @@
 // adapted from poppers.js tutorial https://popper.js.org/docs/v2/tutorial/
 import {createPopper} from '@popperjs/core/dist/esm/popper'
 
-import $ from 'jquery'
-
 let popperInstance = null
 
 /**
@@ -39,17 +37,17 @@ const hideEvents = ['mouseleave', 'blur']
  * @param popup {Element}: the popup that shows up
  */
 export function createTooltip(icon, popup) {
-  showEvents.forEach(event => {
-    $(icon).on(event, () => {
+  for (let event of showEvents) {
+    icon.addEventListener(event, () => {
       popup.setAttribute('data-show', '')
       create(icon, popup)
     })
-  })
+  }
 
-  hideEvents.forEach(event => {
-    $(icon).on(event, () => {
+  for (let event of hideEvents) {
+    icon.addEventListener(event, () => {
       popup.removeAttribute('data-show')
       destroy()
     })
-  })
+  }
 }

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -1,6 +1,9 @@
 // adapted from poppers.js tutorial https://popper.js.org/docs/v2/tutorial/
 import {createPopper} from '@popperjs/core/dist/esm/popper'
 
+const showEvents = ['mouseenter', 'focus']
+const hideEvents = ['mouseleave', 'blur']
+
 let popperInstance = null
 
 /**
@@ -26,9 +29,6 @@ function destroy() {
     popperInstance = null
   }
 }
-
-const showEvents = ['mouseenter', 'focus']
-const hideEvents = ['mouseleave', 'blur']
 
 /**
  * prepare the popup and the icon. Attach relevant handlers


### PR DESCRIPTION
Some sprucing up of the tooltips:

 - [x] phase out jQuery in tooltip.js — we'll soon be able to remove 87KiB from our JavaScript bundle!
 - [x] change styles to more closely match Diane's designs

<img width="635" alt="Screen Shot 2020-06-04 at 9 15 07 AM" src="https://user-images.githubusercontent.com/2294397/83775489-3a0ae180-a644-11ea-98a5-af2758fd06b6.png">
<img width="614" alt="Screen Shot 2020-06-04 at 9 15 28 AM" src="https://user-images.githubusercontent.com/2294397/83775496-3d05d200-a644-11ea-8d8b-d4545868f723.png">
