### PR TITLE
New presentation for inflected form search results

### DIFF
--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -12,7 +12,7 @@ import attr
 import CreeDictionary.hfstol as temp_hfstol
 from attr import attrs
 from constants import (POS, ConcatAnalysis, FSTTag, Label, Language,
-                       ParadigmSize)
+                       ParadigmSize, SimpleLexicalCategory)
 from cree_sro_syllabics import syllabics2sro
 from django.conf import settings
 from django.db import models, transaction
@@ -191,7 +191,7 @@ class Wordform(models.Model):
         result["lemma_url"] = self.get_absolute_url()
 
         result["wordclass_help"] = None
-        maybe_full_word_class = fst_analysis_parser.extract_simple_lc(self.analysis)
+        maybe_full_word_class = self.full_word_class
         if maybe_full_word_class is not None:
             word_class = FSTTag(maybe_full_word_class.without_pos())
             result["wordclass_help"] = FST_TAG_LABELS.get(word_class, {}).get(
@@ -213,6 +213,10 @@ class Wordform(models.Model):
             if homographs.filter(**{field: getattr(self, field)}).count() == 1:
                 return field
         return "id"  # id always guarantees unique match
+
+    @property
+    def full_word_class(self) -> Optional[SimpleLexicalCategory]:
+        return fst_analysis_parser.extract_simple_lc(self.analysis)
 
     @property
     def paradigm(self) -> List[Layout]:

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -189,16 +189,20 @@ class Wordform(models.Model):
             definition.serialize() for definition in self.definitions.all()
         ]
         result["lemma_url"] = self.get_absolute_url()
-
-        result["wordclass_help"] = None
-        maybe_full_word_class = self.full_word_class
-        if maybe_full_word_class is not None:
-            word_class = FSTTag(maybe_full_word_class.without_pos())
-            result["wordclass_help"] = FST_TAG_LABELS.get(word_class, {}).get(
-                LabelFriendliness.ENGLISH, None
-            )
+        result["wordclass_help"] = self.get_user_friendly_wordclass_help_for_cree()
 
         return result
+
+    def get_user_friendly_wordclass_help_for_cree(self) -> Optional[str]:
+        """
+        Attempts to get a description, e.g., "like: wîcihêw" or "like:
+        micisow" for this wordform.
+        """
+        maybe_full_word_class = self.full_word_class
+        if maybe_full_word_class is None:
+            return None
+        word_class = FSTTag(maybe_full_word_class.without_pos())
+        return FST_TAG_LABELS.get(word_class, {}).get(LabelFriendliness.ENGLISH, None)
 
     @cached_property
     def homograph_disambiguator(self) -> Optional[str]:

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -17,9 +17,11 @@
         </dfn>
 
         {% if result.is_lemma %}
-          <span class="definition-title__pos" data-cy="word-class">
-            ({{ result.lemma_wordform|presentational_pos }} — {{ result.lemma_wordform.wordclass_help }})
-          </span>
+          {% with help=result.lemma_wordform.wordclass_help %}
+            <span class="definition-title__pos" data-cy="word-class">
+              ({{ result.lemma_wordform|presentational_pos }}{% if help %} — {{ help }}{% endif %})
+            </span>
+          {% endwith %}
         {% endif %}
 
         {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
@@ -56,9 +58,12 @@
             <a class="reference-to-lemma__lemma"
                href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
           </span>
-          <span class="definition-title__pos" data-cy="word-class">
-            ({{ result.lemma_wordform|presentational_pos }} — {{ result.lemma_wordform.wordclass_help }})
-          </span>
+
+          {% with help=result.lemma_wordform.wordclass_help %}
+            <span class="definition-title__pos" data-cy="word-class">
+              ({{ result.lemma_wordform|presentational_pos }}{% if help %} — {{ help }}{% endif %})
+            </span>
+          {% endwith %}
         </p>
       {% endif %}
     </header>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -16,14 +16,6 @@
           {% endif %}
         </dfn>
 
-        {% if result.is_lemma %}
-          {% with help=result.lemma_wordform.wordclass_help %}
-            <span class="definition-title__pos" data-cy="word-class">
-              ({{ result.lemma_wordform|presentational_pos }}{% if help %} — {{ help }}{% endif %})
-            </span>
-          {% endwith %}
-        {% endif %}
-
         {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
           <div tabindex="0" class="definition-title__tooltip-icon" data-cy="information-mark">
             <img
@@ -50,22 +42,22 @@
         {% endif %}
       </h2>
 
-      {# Show the matched lemma (when this is NOT a lemma. #}
-      {% if not result.is_lemma %}
-        <p class="definition-title__form-of" data-cy="elaboration">
+      <p class="definition-title__form-of" data-cy="elaboration">
+        {# Show the matched lemma (when this is NOT a lemma. #}
+        {% if not result.is_lemma %}
           <span class="reference-to-lemma" data-cy="reference-to-lemma">
             Form of
             <a class="reference-to-lemma__lemma"
                href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
           </span>
+        {% endif %}
 
-          {% with help=result.lemma_wordform.wordclass_help %}
-            <span class="definition-title__pos" data-cy="word-class">
-              ({{ result.lemma_wordform|presentational_pos }}{% if help %} — {{ help }}{% endif %})
-            </span>
-          {% endwith %}
-        </p>
-      {% endif %}
+        {% with help=result.lemma_wordform.wordclass_help %}
+          <span class="definition-title__pos" data-cy="word-class">
+            ({{ result.lemma_wordform|presentational_pos }}{% if help %} — {{ help }}{% endif %})
+          </span>
+        {% endwith %}
+      </p>
     </header>
 
     {# Theses are the definitions for the inflection (non-lemma), could be empty  #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -17,7 +17,9 @@
         </dfn>
 
         {% if result.is_lemma %}
-          <span class="definition-title__pos" data-cy="word-class">({{ result.lemma_wordform|presentational_pos }})</span>
+          <span class="definition-title__pos" data-cy="word-class">
+            ({{ result.lemma_wordform|presentational_pos }} — {{ result.lemma_wordform.wordclass_help }})
+          </span>
         {% endif %}
 
         {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
@@ -54,7 +56,9 @@
             <a class="reference-to-lemma__lemma"
                href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
           </span>
-          <span class="definition-title__pos" data-cy="word-class">({{ result.lemma_wordform|presentational_pos }})</span>
+          <span class="definition-title__pos" data-cy="word-class">
+            ({{ result.lemma_wordform|presentational_pos }} — {{ result.lemma_wordform.wordclass_help }})
+          </span>
         </p>
       {% endif %}
     </header>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -16,6 +16,10 @@
           {% endif %}
         </dfn>
 
+        {% if result.is_lemma %}
+          <span class="definition-title__pos" data-cy="word-class">({{ result.lemma_wordform|presentational_pos }})</span>
+        {% endif %}
+
         {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
           <div tabindex="0" class="definition-title__tooltip-icon" data-cy="information-mark">
             <img

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -6,19 +6,17 @@
 <li class="search-results__result" data-cy="search-results">
   <article class="definition box box--rounded" data-cy="search-result">
     <header class="definition__header">
-      <h2 class="definition-title definition-title--search-result" data-wordform="{{ result.matched_cree }}">
-
+      <h2 class="definition-title definition-title--search-result" data-cy="matched-wordform" data-wordform="{{ result.matched_cree }}">
+        {# the matched wordform itself: #}
         <dfn class="definition-title__word" data-cy="definition-title">
           {% if result.is_lemma %}
-          <a class="definition-title__link" data-cy="lemma-link" href="{{ result.lemma_wordform.lemma_url }}">
-            {% orth result.lemma_wordform.text %}</a>
+            <a class="definition-title__link" data-cy="lemma-link" href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
           {% else %}
-          {% orth result.matched_cree %}
+            {% orth result.matched_cree %}
           {% endif %}
-          <span class="definition-title__pos">({{ result.lemma_wordform|presentational_pos }})</span>
-          {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
+        </dfn>
 
-
+        {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
           <div tabindex="0" class="definition-title__tooltip-icon" data-cy="information-mark">
             <img
               src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
@@ -41,21 +39,21 @@
             </span>
             <div class="tooltip__arrow" data-popper-arrow></div>
           </div>
-          {% endif %}
-        </dfn>
-
+        {% endif %}
       </h2>
+
+      {# Show the matched lemma (when this is NOT a lemma. #}
+      {% if not result.is_lemma %}
+        <p class="definition-title__form-of" data-cy="elaboration">
+          <span class="reference-to-lemma" data-cy="reference-to-lemma">
+            Form of
+            <a class="reference-to-lemma__lemma"
+               href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
+          </span>
+          <span class="definition-title__pos" data-cy="word-class">({{ result.lemma_wordform|presentational_pos }})</span>
+        </p>
+      {% endif %}
     </header>
-
-    {# Show the matched lemma (when this is NOT a lemma. #}
-    {% if not result.is_lemma %}
-    <p class="reference-to-lemma" data-cy="reference-to-lemma">
-    Form of
-    <a class="reference-to-lemma__lemma" href="{{ result.lemma_wordform.lemma_url }}"
-                                         >{% orth result.lemma_wordform.text %}</a>
-    </p>
-    {% endif %}
-
 
     {# Theses are the definitions for the inflection (non-lemma), could be empty  #}
     <ol class="meanings meanings--search-result">

--- a/CreeDictionary/constants/__init__.py
+++ b/CreeDictionary/constants/__init__.py
@@ -99,12 +99,11 @@ class SimpleLexicalCategory(Enum):
     def without_pos(self) -> str:
         """
         >>> SimpleLexicalCategory.VAI.without_pos()
-        "AI"
+        'AI'
         >>> SimpleLexicalCategory.NID.without_pos()
-        "ID"
+        'ID'
         >>> SimpleLexicalCategory.IPC.without_pos()
-        "IPC"
-
+        'IPC'
         """
         if self.is_verb():
             assert self.value.startswith("V")

--- a/CreeDictionary/constants/__init__.py
+++ b/CreeDictionary/constants/__init__.py
@@ -2,9 +2,8 @@
 constants
 """
 from enum import Enum
-
 # type alias
-from typing import NewType, NamedTuple
+from typing import NamedTuple, NewType
 
 # Orthography
 DEFAULT_ORTHOGRAPHY = "Latn"
@@ -96,6 +95,24 @@ class SimpleLexicalCategory(Enum):
 
     def is_noun(self):
         return self.value[0] == "N"
+
+    def without_pos(self) -> str:
+        """
+        >>> SimpleLexicalCategory.VAI.without_pos()
+        "AI"
+        >>> SimpleLexicalCategory.NID.without_pos()
+        "ID"
+        >>> SimpleLexicalCategory.IPC.without_pos()
+        "IPC"
+
+        """
+        if self.is_verb():
+            assert self.value.startswith("V")
+            return self.value[1:]
+        if self.is_noun():
+            assert self.value.startswith("N")
+            return self.value[1:]
+        return self.value
 
     def to_fst_output_style(self):
         """

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -417,6 +417,17 @@ context('Searching', () => {
         .contains('[data-cy="word-class"]', wordclassHelp)
     })
 
+    // Regression: it used to display 'Preverb — None' :/
+    it('should not display wordclass help if it does not exist', function () {
+      // Preverbs do not have an elaboration (right now)
+      const preverb = 'nitawi-'
+      cy.visitSearch(preverb)
+
+      cy.get('[data-cy=search-result]')
+        .contains('[data-cy=word-class]', 'Preverb')
+        .should('not.contain', 'None')
+    })
+
     /**
      * @returns {string} the wordform, as if you typed very quickly on your niece's peanut butter-smeared iPad
      */

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -376,7 +376,7 @@ context('Searching', () => {
     const nonLemmaForm = 'nikî-nitawi-wâpamâw'
 
     it('should display the match wordform and word class on the same line for lemmas', function () {
-      cy.visitSearch('wapamew')
+      cy.visitSearch(fudgeUpOrthography(lemma))
 
       // make sure we get at least one search result...
       cy.get('[data-cy=search-result]')
@@ -389,7 +389,7 @@ context('Searching', () => {
     })
 
     it('should display the matched word form and its lemma/word class on separate lines for non-lemmas', function () {
-      cy.visitSearch(nonLemmaForm)
+      cy.visitSearch(fudgeUpOrthography(nonLemmaForm))
 
       // make sure we get at least one search result...
       cy.get('[data-cy=search-result]')
@@ -411,6 +411,13 @@ context('Searching', () => {
       cy.get('@elaboration')
         .contains('[data-cy="word-class"]', wordclass)
     })
+
+    /**
+     * @returns {string} the wordform, as if you typed very quickly on your niece's peanut butter-smeared iPad
+     */
+    function fudgeUpOrthography(normatizedWordform) {
+      return normatizedWordform.normalize('NFKD').replace(/[\u0300-\u035f-]/g, '').toLowerCase()
+    }
   })
 })
 

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -373,6 +373,7 @@ context('Searching', () => {
   describe('display of the header', function () {
     const lemma = 'wâpamêw'
     const wordclass = 'Verb'
+    const wordclassHelp = 'like: wîcihêw'
     const nonLemmaForm = 'nikî-nitawi-wâpamâw'
 
     it('should display the match wordform and word class on the same line for lemmas', function () {
@@ -386,6 +387,8 @@ context('Searching', () => {
       cy.get('@search-result')
         .contains('header [data-cy="matched-wordform"]', lemma)
         .contains('header [data-cy="matched-wordform"]', wordclass)
+      cy.get('@search-result')
+        .contains('header [data-cy="word-class"]', wordclassHelp)
     })
 
     it('should display the matched word form and its lemma/word class on separate lines for non-lemmas', function () {
@@ -410,6 +413,8 @@ context('Searching', () => {
         .and('contain', lemma)
       cy.get('@elaboration')
         .contains('[data-cy="word-class"]', wordclass)
+      cy.get('@elaboration')
+        .contains('[data-cy="word-class"]', wordclassHelp)
     })
 
     /**

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -370,8 +370,8 @@ context('Searching', () => {
     })
   })
 
-  describe('display of lemma wordforms', function () {
-    it('should display the matched wordform', function () {
+  describe('display of the header', function () {
+    it('should display the match wordform and word class on the same line for lemmas', function () {
       cy.visitSearch('wapamew')
 
       // make sure we get at least one search result...
@@ -383,10 +383,8 @@ context('Searching', () => {
         .contains('header [data-cy="matched-wordform"]', 'wâpamêw')
         .contains('header [data-cy="matched-wordform"]', 'Verb')
     })
-  })
 
-  describe('display of inflected forms (non-lemmas)', function () {
-    it('should display the matched wordform', function () {
+    it('should display the matched word form and its lemma/word class on separate lines for non-lemmas', function () {
       cy.visitSearch('nikinitawiwapamaw')
 
       // make sure we get at least one search result...

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -370,7 +370,22 @@ context('Searching', () => {
     })
   })
 
-  describe('display of inflected forms', function () {
+  describe('display of lemma wordforms', function () {
+    it('should display the matched wordform', function () {
+      cy.visitSearch('wapamew')
+
+      // make sure we get at least one search result...
+      cy.get('[data-cy=search-result]')
+        .as('search-result')
+
+      // now let's make sure the NORMATIZED form is in the search result
+      cy.get('@search-result')
+        .contains('header [data-cy="matched-wordform"]', 'wâpamêw')
+        .contains('header [data-cy="matched-wordform"]', 'Verb')
+    })
+  })
+
+  describe('display of inflected forms (non-lemmas)', function () {
     it('should display the matched wordform', function () {
       cy.visitSearch('nikinitawiwapamaw')
 

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -369,4 +369,32 @@ context('Searching', () => {
         .should('contain', NON_WORD)
     })
   })
+
+  describe('display of inflected forms', function () {
+    it('should display the matched wordform', function () {
+      cy.visitSearch('nikinitawiwapamaw')
+
+      // make sure we get at least one search result...
+      cy.get('[data-cy=search-result]')
+        .as('search-result')
+
+      // now let's make sure the NORMATIZED form is in the search result
+      cy.get('@search-result')
+        .contains('header [data-cy="matched-wordform"]', 'nikî-nitawi-wâpamâw')
+
+      // now make sure the 'form of' text is below that
+      cy.get('@search-result')
+        .get('header [data-cy="elaboration"]')
+        .as('elaboration')
+
+      cy.get('@elaboration')
+        .get('[data-cy="reference-to-lemma"]')
+        .should('contain', 'Form of')
+        .and('contain', 'wâpamêw')
+      cy.get('@elaboration')
+        .contains('[data-cy="word-class"]', 'Verb')
+    })
+  })
 })
+
+

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -386,7 +386,8 @@ context('Searching', () => {
       // now let's make sure the NORMATIZED form is in the search result
       cy.get('@search-result')
         .contains('header [data-cy="matched-wordform"]', lemma)
-        .contains('header [data-cy="matched-wordform"]', wordclass)
+      cy.get('@search-result')
+        .contains('header [data-cy="word-class"]', wordclass)
       cy.get('@search-result')
         .contains('header [data-cy="word-class"]', wordclassHelp)
     })

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -371,6 +371,10 @@ context('Searching', () => {
   })
 
   describe('display of the header', function () {
+    const lemma = 'wâpamêw'
+    const wordclass = 'Verb'
+    const nonLemmaForm = 'nikî-nitawi-wâpamâw'
+
     it('should display the match wordform and word class on the same line for lemmas', function () {
       cy.visitSearch('wapamew')
 
@@ -380,12 +384,12 @@ context('Searching', () => {
 
       // now let's make sure the NORMATIZED form is in the search result
       cy.get('@search-result')
-        .contains('header [data-cy="matched-wordform"]', 'wâpamêw')
-        .contains('header [data-cy="matched-wordform"]', 'Verb')
+        .contains('header [data-cy="matched-wordform"]', lemma)
+        .contains('header [data-cy="matched-wordform"]', wordclass)
     })
 
     it('should display the matched word form and its lemma/word class on separate lines for non-lemmas', function () {
-      cy.visitSearch('nikinitawiwapamaw')
+      cy.visitSearch(nonLemmaForm)
 
       // make sure we get at least one search result...
       cy.get('[data-cy=search-result]')
@@ -393,7 +397,7 @@ context('Searching', () => {
 
       // now let's make sure the NORMATIZED form is in the search result
       cy.get('@search-result')
-        .contains('header [data-cy="matched-wordform"]', 'nikî-nitawi-wâpamâw')
+        .contains('header [data-cy="matched-wordform"]', nonLemmaForm)
 
       // now make sure the 'form of' text is below that
       cy.get('@search-result')
@@ -403,9 +407,9 @@ context('Searching', () => {
       cy.get('@elaboration')
         .get('[data-cy="reference-to-lemma"]')
         .should('contain', 'Form of')
-        .and('contain', 'wâpamêw')
+        .and('contain', lemma)
       cy.get('@elaboration')
-        .contains('[data-cy="word-class"]', 'Verb')
+        .contains('[data-cy="word-class"]', wordclass)
     })
   })
 })

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -455,10 +455,13 @@ html {
   outline: 3px solid var(--search-focus-color);
 }
 
-.reference-to-lemma {
+.definition-title__form-of {
   margin: var(--gap) 0 0;
 
   font-size: var(--reference-to-lemma-size);
+}
+
+.reference-to-lemma {
   font-style: italic;
 }
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -458,7 +458,7 @@ html {
 .definition-title__form-of {
   margin: var(--gap) 0 0;
 
-  font-size: var(--reference-to-lemma-size);
+  font-size: var(--form-of-size);
 }
 
 .reference-to-lemma {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -456,7 +456,7 @@ html {
 }
 
 .definition-title__form-of {
-  margin: var(--gap) 0 0;
+  margin: var(--small-gap) 0 0;
 
   font-size: var(--form-of-size);
 }

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -63,8 +63,8 @@
   --branding-font-size:             1.50em; /* the title, e.g., "itwêwina" */
   --branding-subtitle-font-size:    0.75em; /* the subtitle, e.g., "Plains Cree Dictionary" */
   --definition-title-size:          2.00em;
+  --form-of-size:                   1.50em;
   --tooltip-icon-size:              1.75rem; /* size of the ℹ️  button or 🔊 button */
-  --reference-to-lemma-size:        1.50em;
   --preverb-breakdown-size:         1.50em;
   --prominent-font-size:            1.50em; /* For text that should be prominent! */
   --prose-heading-font-size:        1.25em;

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -63,7 +63,7 @@
   --branding-font-size:             1.50em; /* the title, e.g., "itwêwina" */
   --branding-subtitle-font-size:    0.75em; /* the subtitle, e.g., "Plains Cree Dictionary" */
   --definition-title-size:          2.00em;
-  --form-of-size:                   1.50em;
+  --form-of-size:                   1.25em;
   --tooltip-icon-size:              1.75rem; /* size of the ℹ️  button or 🔊 button */
   --preverb-breakdown-size:         1.50em;
   --prominent-font-size:            1.50em; /* For text that should be prominent! */


### PR DESCRIPTION
Fixes #399 

 - [x] shift word class down to "elaboration"
 - [x] add Cree explanation for word class
 - [x] ensure the word class is still visible for lemmas

This is what it looks like...

~~for the lemma form of verbs~~: 
<img width="489" alt="Screen Shot 2020-06-05 at 1 36 16 PM" src="https://user-images.githubusercontent.com/2294397/83915993-9ef03580-a731-11ea-9bd9-333f7fab87f7.png">

**EDIT**: this is what it looks like for verbs now (consistent with non-lemma forms):
<img width="306" alt="Screen Shot 2020-06-05 at 3 13 09 PM" src="https://user-images.githubusercontent.com/2294397/83923284-2b552500-a73f-11ea-879f-fc1303d49d22.png">


for inflected forms of verbs:
<img width="489" alt="Screen Shot 2020-06-05 at 1 36 28 PM" src="https://user-images.githubusercontent.com/2294397/83916018-ab748e00-a731-11ea-808e-a3c4a0b04e92.png">

for nouns:
<img width="487" alt="Screen Shot 2020-06-05 at 1 37 40 PM" src="https://user-images.githubusercontent.com/2294397/83916078-c5ae6c00-a731-11ea-8a3d-b65927c153ff.png">

for particles/preverbs:
<img width="483" alt="Screen Shot 2020-06-05 at 1 35 59 PM" src="https://user-images.githubusercontent.com/2294397/83916159-ebd40c00-a731-11ea-9388-59912d34d421.png">
