### PR TITLE
Word entry cleanup

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -20,7 +20,7 @@
 
   {# The 🔊 button template. Gets inflated by JavaScript. #}
   <template id="template:play-button">
-    <button aria-label="Play recording" class="definition-title__play-button" data-cy="play-recording">
+    <button aria-label="Play recording" class="definition__icon definition-title__play-button" data-cy="play-recording">
       <svg class="definition-title__play-icon" focusable="false">
         <use xlink:href="#fa-volume-up-solid" />
       </svg>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/paradigm.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/paradigm.html
@@ -13,7 +13,7 @@ This should be included or placed dynamical within <main>
 <article class="definition" id="paradigm">
   <header class="definition__header">
     <h1 id="head" class="definition-title">
-      <dfn class="definition-title__word">
+      <dfn class="definition__matched-head">
         <data id="data:head" value="{{ lemma.text }}">
           {% orth lemma.text %}
         </data>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/paradigm.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/paradigm.html
@@ -17,7 +17,7 @@ This should be included or placed dynamical within <main>
         <data id="data:head" value="{{ lemma.text }}">
           {% orth lemma.text %}
         </data>
-      </dfn>&nbsp;<span class="definition-title__pos">({{ lemma|presentational_pos }})</span>
+      </dfn>&nbsp;<span class="wordclass">({{ lemma|presentational_pos }})</span>
     </h1>
   </header>
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -5,9 +5,7 @@
 {% for result in search_results %}
 <li class="search-results__result" data-cy="search-results">
   <article class="definition box box--rounded" data-cy="search-result">
-
     <header class="definition__header">
-
       {# First line of the header #}
       {# TODO: change data-cy=definition-title #}
       <h2 class="definition-title definition-title--search-result" data-cy="matched-wordform">
@@ -42,6 +40,7 @@
                   {% endfor %}
                 </ol>
               </span>
+
               <div class="tooltip__arrow" data-popper-arrow></div>
             </div>
             {# NB: the "Play recording" icon will be appened here #}
@@ -83,73 +82,64 @@
     {# show preverb breakdown #}
     <ol class="preverb-breakdown">
       {% for preverb in result.preverbs %}
-      <li>
-        <span>Preverb: {% if preverb.id %}
-          <a href="{% url_for_query preverb.text %}">{% orth preverb.text %}</a>{% else %}
-          {% orth preverb.text %}{% endif %}
-        </span>
+        <li>
+          <span>Preverb: {% if preverb.id %}
+            <a href="{% url_for_query preverb.text %}">{% orth preverb.text %}</a>{% else %}
+            {% orth preverb.text %}{% endif %}
+          </span>
 
-        {% if preverb.id %} {# we know the preverb in the database #}
+          {% if preverb.id %} {# we know the preverb in the database #}
+            <div tabindex="0" class="preverb-breakdown__tooltip-icon" data-cy="information-mark">
+              <img
+                src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
+                alt="preverb breakdown">
+            </div>
 
-
-
-        <div tabindex="0" class="preverb-breakdown__tooltip-icon" data-cy="information-mark">
-          <img
-            src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
-            alt="preverb breakdown">
-        </div>
-
-        <div class="tooltip" role="tooltip">
-          {% for definition in preverb.definitions %}
-          <p class="preverb-breakdown__preverb-definition">{{ definition.text }}
-          {% for source in definition.source_ids %}
-          <cite class="cite-dict cite-dict--popup">{{ source }}</cite>
-          {% endfor %}
-          </p>
-          {% endfor %}
-          <div class="tooltip__arrow" data-popper-arrow></div>
-        </div>
-
-        {% endif %}
-      </li>
+            <div class="tooltip" role="tooltip">
+              {% for definition in preverb.definitions %}
+              <p class="preverb-breakdown__preverb-definition">{{ definition.text }}
+              {% for source in definition.source_ids %}
+              <cite class="cite-dict cite-dict--popup">{{ source }}</cite>
+              {% endfor %}
+              </p>
+              {% endfor %}
+              <div class="tooltip__arrow" data-popper-arrow></div>
+            </div>
+          {% endif %}
+        </li>
       {% endfor %}
     </ol>
     {# end preverb breakdown #}
 
     {% if not result.is_lemma %}
-    {# show everything about the lemma #}
+      {# show everything about the lemma #}
+      <hr class="cleave-inflection-from-lemma">
 
-    <hr class="cleave-inflection-from-lemma">
+      <header class="definition__header">
+        <h2 class="definition-title definition-title--search-result">
+          {# TODO: change data-cy=definition-title #}
+          <dfn class="definition__matched-head" data-cy="definition-title">
+            <a href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
+          </dfn>
+        </h2>
+      </header>
 
-    <header class="definition__header">
-      <h2 class="definition-title definition-title--search-result">
-
-        {# TODO: change data-cy=definition-title #}
-        <dfn class="definition__matched-head" data-cy="definition-title">
-          <a href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
-        </dfn>
-      </h2>
-    </header>
-
-    {# Theses are the definitions for the lemma, gauranteed to exist in the database #}
-    <ol class="meanings meanings--search-result">
-      {% for def in result.lemma_wordform.definitions %}
-      <li class="meanings__meaning" data-cy="lemma-meaning" data-cy="link-to-lemma">{{ def.text }}
-        {% for source in def.source_ids %}
-        <cite class="cite-dict">{{ source }}</cite>
+      {# Theses are the definitions for the lemma, gauranteed to exist in the database #}
+      <ol class="meanings meanings--search-result">
+        {% for def in result.lemma_wordform.definitions %}
+        <li class="meanings__meaning" data-cy="lemma-meaning" data-cy="link-to-lemma">{{ def.text }}
+          {% for source in def.source_ids %}
+          <cite class="cite-dict">{{ source }}</cite>
+          {% endfor %}
+        </li>
         {% endfor %}
-      </li>
-      {% endfor %}
-    </ol>
-
-
+      </ol>
     {% endif %}
-
   </article>
 </li>
 {% empty %}
-  <li class="search-results__no-result box box--rounded box--bad-outcome" data-cy="no-search-result">
-    No results found for <output class="query">{{ query_string }}</output>
-  </li>
+<li class="search-results__no-result box box--rounded box--bad-outcome" data-cy="no-search-result">
+  No results found for <output class="query">{{ query_string }}</output>
+</li>
 {% endfor %}
 {# vim: set ft=htmldjango et sw=2 ts=2 sts=2: #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -9,8 +9,8 @@
     <header class="definition__header">
 
       {# TODO: change data-cy=definition-title #}
-      <h2 class="definition-title definition-title--search-result" data-cy="matched-wordform" data-wordform="{{ result.matched_cree }}">
-        {# the matched wordform itself: #}
+      <h2 class="definition-title definition-title--search-result" data-cy="matched-wordform">
+        {# the matched head itself: #}
         <dfn class="definition__matched-head" data-cy="definition-title">
           {% if result.is_lemma %}
             <a data-cy="lemma-link" href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
@@ -19,30 +19,33 @@
           {% endif %}
         </dfn>
 
-        {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
-          <div tabindex="0" class="definition-title__tooltip-icon" data-cy="information-mark">
-            <img
-              src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
-              alt="linguistic breakdown">
-          </div>
+        <span class="definition__icons" data-wordform="{{ result.matched_cree }}">
+          {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
+            <div tabindex="0" class="definition__icon definition-title__tooltip-icon" data-cy="information-mark">
+              <img
+                src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
+                alt="linguistic breakdown">
+            </div>
 
-          <div class="tooltip" role="tooltip">
-            <span
-              data-cy="linguistic-breakdown">{% if result.linguistic_breakdown_head %}
-              {{ result.linguistic_breakdown_head|join:" + " }}
-              + {% endif %}
-              <strong>{{ result.lemma_wordform.text }}:</strong>
-              <ol class="linguistic-breakdown">
-                {% for linguistic_tag in result.linguistic_breakdown_tail %}
-                <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
-                  {{ linguistic_tag }}
-                </li>
-                {% endfor %}
-              </ol>
-            </span>
-            <div class="tooltip__arrow" data-popper-arrow></div>
-          </div>
-        {% endif %}
+            <div class="tooltip" role="tooltip">
+              <span
+                data-cy="linguistic-breakdown">{% if result.linguistic_breakdown_head %}
+                {{ result.linguistic_breakdown_head|join:" + " }}
+                + {% endif %}
+                <strong>{{ result.lemma_wordform.text }}:</strong>
+                <ol class="linguistic-breakdown">
+                  {% for linguistic_tag in result.linguistic_breakdown_tail %}
+                  <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
+                    {{ linguistic_tag }}
+                  </li>
+                  {% endfor %}
+                </ol>
+              </span>
+              <div class="tooltip__arrow" data-popper-arrow></div>
+            </div>
+            {# NB: the "Play recording" icon will be appened here #}
+          {% endif %}
+        </span>
       </h2>
 
       <p class="definition-title__form-of" data-cy="elaboration">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -8,11 +8,12 @@
 
     <header class="definition__header">
 
+      {# TODO: change data-cy=definition-title #}
       <h2 class="definition-title definition-title--search-result" data-cy="matched-wordform" data-wordform="{{ result.matched_cree }}">
         {# the matched wordform itself: #}
         <dfn class="definition__matched-head" data-cy="definition-title">
           {% if result.is_lemma %}
-            <a class="definition-title__link" data-cy="lemma-link" href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
+            <a data-cy="lemma-link" href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
           {% else %}
             {% orth result.matched_cree %}
           {% endif %}
@@ -121,10 +122,7 @@
 
         {# TODO: change data-cy=definition-title #}
         <dfn class="definition__matched-head" data-cy="definition-title">
-          <a class="definition-title__link" href="{{ result.lemma_wordform.lemma_url }}"
-                                            >
-                                            {# data- attributes are supported in HTML5 not in XHTML #}
-                                            {% orth result.lemma_wordform.text %}</a>
+          <a href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
         </dfn>
       </h2>
     </header>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -5,10 +5,12 @@
 {% for result in search_results %}
 <li class="search-results__result" data-cy="search-results">
   <article class="definition box box--rounded" data-cy="search-result">
+
     <header class="definition__header">
+
       <h2 class="definition-title definition-title--search-result" data-cy="matched-wordform" data-wordform="{{ result.matched_cree }}">
         {# the matched wordform itself: #}
-        <dfn class="definition-title__word" data-cy="definition-title">
+        <dfn class="definition__matched-head" data-cy="definition-title">
           {% if result.is_lemma %}
             <a class="definition-title__link" data-cy="lemma-link" href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
           {% else %}
@@ -58,7 +60,9 @@
           </span>
         {% endwith %}
       </p>
+
     </header>
+
 
     {# Theses are the definitions for the inflection (non-lemma), could be empty  #}
     <ol class="meanings meanings--search-result">
@@ -115,7 +119,8 @@
     <header class="definition__header">
       <h2 class="definition-title definition-title--search-result">
 
-        <dfn class="definition-title__word" data-cy="definition-title">
+        {# TODO: change data-cy=definition-title #}
+        <dfn class="definition__matched-head" data-cy="definition-title">
           <a class="definition-title__link" href="{{ result.lemma_wordform.lemma_url }}"
                                             >
                                             {# data- attributes are supported in HTML5 not in XHTML #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -53,10 +53,10 @@
       <p class="definition__elaboration" data-cy="elaboration">
         {# Show the matched lemma (when this is NOT a lemma. #}
         {% if not result.is_lemma %}
-          <span class="reference-to-lemma" data-cy="reference-to-lemma">
-            Form of
-            <a class="reference-to-lemma__lemma"
-               href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
+          <span class="definition__reference-to-lemma" data-cy="reference-to-lemma">
+            Form of <a
+              class="definition__matched-lemma"
+              href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
           </span>
         {% endif %}
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -61,14 +61,13 @@
         {% endif %}
 
         {% with help=result.lemma_wordform.wordclass_help %}
-          <span class="definition-title__pos" data-cy="word-class">
-            ({{ result.lemma_wordform|presentational_pos }}{% if help %} — {{ help }}{% endif %})
+          <span class="wordclass" data-cy="word-class">
+            (<span class="wordclass__general">{{ result.lemma_wordform|presentational_pos }}</span>
+            {% if help %}<span class="wordclass__help"> — {{ help }}</span>{% endif %})
           </span>
         {% endwith %}
       </p>
-
     </header>
-
 
     {# Theses are the definitions for the inflection (non-lemma), could be empty  #}
     <ol class="meanings meanings--search-result">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -8,6 +8,7 @@
 
     <header class="definition__header">
 
+      {# First line of the header #}
       {# TODO: change data-cy=definition-title #}
       <h2 class="definition-title definition-title--search-result" data-cy="matched-wordform">
         {# the matched head itself: #}
@@ -48,7 +49,8 @@
         </span>
       </h2>
 
-      <p class="definition-title__form-of" data-cy="elaboration">
+      {# Second line of the header: the elaboration #}
+      <p class="definition__elaboration" data-cy="elaboration">
         {# Show the matched lemma (when this is NOT a lemma. #}
         {% if not result.is_lemma %}
           <span class="reference-to-lemma" data-cy="reference-to-lemma">

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -465,12 +465,6 @@ html {
   font-style: italic;
 }
 
-.definition-title__pos {
-  /* Text */
-  font-style: normal;
-  font-weight: var(--body-font-weight);
-}
-
 /**
  * The actual SVG for the 🔊 icon
  */
@@ -524,6 +518,15 @@ html {
 
 .recordings-list__item:hover {
   cursor: pointer;
+}
+
+/**
+ * BLOCK wordclass
+ */
+.wordclass {
+  /* Text */
+  font-style: normal;
+  font-weight: var(--body-font-weight);
 }
 
 /**

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -428,7 +428,7 @@ html {
   margin: 0;
 }
 
-.definition-title__word {
+.definition__matched-head {
   /* Text */
   font-style: normal;
   font-weight: var(--strong-font-weight);

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -455,12 +455,13 @@ html {
   outline: 3px solid var(--search-focus-color);
 }
 
-.definition-title__form-of {
+.definition__elaboration {
   margin: var(--small-gap) 0 0;
 
   font-size: var(--form-of-size);
 }
 
+/* TODO: rename to definition__reference-to-lemma */
 .reference-to-lemma {
   font-style: italic;
 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -458,7 +458,7 @@ html {
 .definition__elaboration {
   margin: var(--small-gap) 0 0;
 
-  font-size: var(--form-of-size);
+  font-size: var(--elaboration-size);
 }
 
 .definition__reference-to-lemma {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -461,8 +461,7 @@ html {
   font-size: var(--form-of-size);
 }
 
-/* TODO: rename to definition__reference-to-lemma */
-.reference-to-lemma {
+.definition__reference-to-lemma {
   font-style: italic;
 }
 

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -63,7 +63,7 @@
   --branding-font-size:             1.50em; /* the title, e.g., "itwêwina" */
   --branding-subtitle-font-size:    0.75em; /* the subtitle, e.g., "Plains Cree Dictionary" */
   --definition-title-size:          2.00em;
-  --form-of-size:                   1.25em;
+  --elaboration-size:               1.25em;
   --tooltip-icon-size:              1.75rem; /* size of the ℹ️  button or 🔊 button */
   --preverb-breakdown-size:         1.50em;
   --prominent-font-size:            1.50em; /* For text that should be prominent! */


### PR DESCRIPTION
Just making some more systematic class names. This is the schematic of nesting of the classes now:

```
.
└── .definition
    └── .definition__header
        ├── .definition__title
        │   ├── .definition__matched-head
        │   └── .definition_icons
        │       └── .definition_icon
        └── .definition__elaboration
            ├── .definition__reference-to-lemma
            │   └── .definition__matched-lemma
            └── .wordclass
                ├── .wordclass__general
                └── .wordclass__help
```

(I realize that `.wordclass` can be used outside of the definition)

~~Blocked by #428~~