### PR TITLE
Remove jQuery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3740,11 +3740,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
-    },
     "js-base64": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "wait-on": "^3.3.0"
   },
   "dependencies": {
-    "@popperjs/core": "^2.0.5",
-    "jquery": "^3.5.0"
+    "@popperjs/core": "^2.0.5"
   }
 }


### PR DESCRIPTION
What it says on the tin. No more jQuery! Our bundle size is now down to 21K minified, or 7.6K gzipped! Quite 3G friendly!