### PR TITLE
change: links from altlab.ualberta.ca -> www.altlab.dev

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/about.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/about.html
@@ -25,18 +25,18 @@
     lexical materials in <a href="https://uofrpress.ca/Books/C/Cree-Words" class="source-title">nêhiyawêwin :
     itwêwina / Cree: Words</a>. (Compiled by Arok Wolvengrey. Regina: Canadian
     Plains Research Center, 2001), and in the
-    <a href="http://altlab.ualberta.ca/maskwacis/dictionary.html" class="source-title">Maskwacîs Dictionary of Cree Words /
+    <a href="https://www.altlab.dev/maskwacis/dictionary.html" class="source-title">Maskwacîs Dictionary of Cree Words /
     Nêhiyaw Pîkiskwêwinisa</a> (Maskwachees Cultural College, Maskwacîs, 2009).</p>
 
     <h3 class="prose__heading"> Spoken Cree — {% orth 'nêhiyaw-pîkiskwêwina' %}</h3>
     <p>The careful pronunciations of the Cree words by first-language speakers
     in Maskwacîs, Alberta, have been recorded in the joint project
-    <a href="http://altlab.ualberta.ca/maskwacis/" class="source-title">Spoken Dictionary of Maskwacîs Cree –
+    <a href="https://www.altlab.dev/maskwacis/" class="source-title">Spoken Dictionary of Maskwacîs Cree –
     {% orth 'nêhiyaw-pîkiskwêwina maskwacîsihk' %}</a> between
     then Miyo Wahkohtowin Education, now
     <a href="https://www.maskwacised.ca/">Maskwacîs Education Schools
     Commission</a> and the <a href="http://altlab.artsrn.ualberta.ca/">Alberta Language Technology Lab</a>
-    (2014–on-going). The pronunciations of the Cree words have been graciously provided by the individuals at <a href="http://altlab.ualberta.ca/maskwacis/Speakers/speakers.html">this page</a>.</p>
+    (2014–on-going). The pronunciations of the Cree words have been graciously provided by the individuals at <a href="https://www.altlab.dev/maskwacis/Speakers/speakers.html">this page</a>.</p>
   </section>
 
   <section id="credits" class="prose box box--spaced">

--- a/cypress/integration/recordings.spec.js
+++ b/cypress/integration/recordings.spec.js
@@ -93,8 +93,8 @@ context('Recordings', function () {
       // clicking the buttons should output sound
       cy.get('[data-cy=recordings-list__item]').click({ multiple: true })
 
-      // the name of the speaker should appear as a link: said link should contain the base speaker link URL (http://altlab.ualberta.ca/maskwacis/Speakers/)
-      cy.get('[data-cy=recordings-list__item-speaker]').should('have.attr', 'href').should('contain', 'http://altlab.ualberta.ca/maskwacis/Speakers/')
+      // the name of the speaker should appear as a link: said link should contain the base speaker link URL
+      cy.get('[data-cy=recordings-list__item-speaker]').should('have.attr', 'href').should('contain', 'https://www.altlab.dev/maskwacis/Speakers/')
     })
   })
 })

--- a/src/recordings.js
+++ b/src/recordings.js
@@ -3,7 +3,7 @@
 const BASE_URL = 'https://sapir.artsrn.ualberta.ca/validation'
 
 // the specific URL for a given speaker (appended with the speaker code)
-const BASE_SPEAKER_URL = 'http://altlab.ualberta.ca/maskwacis/Speakers/'
+const BASE_SPEAKER_URL = 'https://www.altlab.dev/maskwacis/Speakers/'
 
 export function fetchRecordings(wordform) {
   return fetch(`${BASE_URL}/recording/_search/${wordform}`)
@@ -72,7 +72,7 @@ export function retrieveListOfSpeakers() {
     audio.preload = 'none'
     createdSpeakerButton.addEventListener('click', () => {
       audio.play()
-      displaySpeakerBioLink(recordingData)     
+      displaySpeakerBioLink(recordingData)
     })
   }
 
@@ -89,7 +89,7 @@ export function retrieveListOfSpeakers() {
 
     // link inside the template
     let createdLink = createdTemplateNode.firstChild
-    
+
     // variable (speaker's name) to be inserted into the DOM
     let speakerName = recordingData['speaker_name']
 
@@ -103,11 +103,11 @@ export function retrieveListOfSpeakers() {
       createdLink.href = insertedURL
 
       // and place the node into the DOM
-      container.appendChild(createdTemplateNode)   
+      container.appendChild(createdTemplateNode)
     } else {
       // remove the node that was created:
       container.removeChild(container.childNodes[1]) // may need to extract the inner parameter based on Eddie's feedback...
-        
+
       // create a new node for the new speaker name
       let newSpeakerNode = document.getElementById('template:speaker-bio-link').content.cloneNode(true)
       // ...and place the newly clicked speaker's name into it
@@ -116,7 +116,7 @@ export function retrieveListOfSpeakers() {
       // get the URL again and reinsert into the newly created node
       createdLink = newSpeakerNode.firstChild
       createdLink.href = insertedURL
-      
+
       // place said node into the DOM
       container.appendChild(newSpeakerNode)
     }


### PR DESCRIPTION
Changes links from <http://altlab.ualberta.ca> (hosted on Sapir) to <https://www.altlab.dev> (hosted by Compute Canada).

Resolves #457 

@aarppe, please let me know if this is the correct way forward.