### PR TITLE
Use new fields from recordings app to display dialect and speaker bio link

### DIFF
--- a/cypress/fixtures/recording/_search/wâpamêw.json
+++ b/cypress/fixtures/recording/_search/wâpamêw.json
@@ -1,41 +1,51 @@
 [
     {
         "anonymous": false,
+        "dialect": "Maskwacîs",
         "gender": "F",
         "recording_url": "http://sapir.artsrn.ualberta.ca/validation/recording/e44429dafbd1a5d1996f784a8d22ea05006c75ffeea469337109dc8a15904789.m4a",
         "speaker": "MAR",
-        "speaker_name": "Mary Jean Littlechild",
+        "speaker_bio_url": "https://www.altlab.dev/maskwacis/Speakers/MAR.html",
+        "speaker_name": "Mary Jane Littlechild",
         "wordform": "wapamew"
     },
     {
         "anonymous": false,
+        "dialect": "Maskwacîs",
         "gender": "M",
-        "recording_url": "http://sapir.artsrn.ualberta.ca/validation/recording/da213e0ac776a153030a87c1c47bc7e0d24a91233d9a1fa1e32d4b04cb383b65.m4a",
+        "recording_url": "http://sapir.artsrn.ualberta.ca/validation/recording/2e385bbec06f738bd5e964734a6b851131ac7108a50a9b22b518c8567a1ba22c.m4a",
         "speaker": "HAR",
+        "speaker_bio_url": "https://www.altlab.dev/maskwacis/Speakers/HAR.html",
         "speaker_name": "Harley Simon",
         "wordform": "wapamew"
     },
     {
         "anonymous": false,
+        "dialect": "Maskwacîs",
         "gender": "M",
         "recording_url": "http://sapir.artsrn.ualberta.ca/validation/recording/8efae63b40e1bc44c37515ec56121bc734e2cb11d90c59d71f6d847dc6f82ac3.m4a",
         "speaker": "HAR",
+        "speaker_bio_url": "https://www.altlab.dev/maskwacis/Speakers/HAR.html",
         "speaker_name": "Harley Simon",
         "wordform": "wapamew"
     },
     {
         "anonymous": false,
+        "dialect": "Maskwacîs",
         "gender": "M",
         "recording_url": "http://sapir.artsrn.ualberta.ca/validation/recording/79d38cc7e67e73a50cb91f8d93fe96212c906d18b404f6d91412f6f7508c56c4.m4a",
         "speaker": "HAR",
+        "speaker_bio_url": "https://www.altlab.dev/maskwacis/Speakers/HAR.html",
         "speaker_name": "Harley Simon",
         "wordform": "wapamew"
     },
     {
         "anonymous": false,
+        "dialect": "Maskwacîs",
         "gender": "F",
         "recording_url": "http://sapir.artsrn.ualberta.ca/validation/recording/c9ad558301db2ffd85553fe9a778a2f2e182c5dac3438f070a47a19ad3e51cfc.m4a",
         "speaker": "ANN",
+        "speaker_bio_url": "https://www.altlab.dev/maskwacis/Speakers/ANN.html",
         "speaker_name": "Annette Lee",
         "wordform": "wapamew"
     }

--- a/src/recordings.js
+++ b/src/recordings.js
@@ -2,9 +2,6 @@
 // TODO: should come from config.
 const BASE_URL = 'https://sapir.artsrn.ualberta.ca/validation'
 
-// the specific URL for a given speaker (appended with the speaker code)
-const BASE_SPEAKER_URL = 'https://www.altlab.dev/maskwacis/Speakers/'
-
 export function fetchRecordings(wordform) {
   return fetch(`${BASE_URL}/recording/_search/${wordform}`)
     .then(function (response) {
@@ -65,7 +62,7 @@ export function retrieveListOfSpeakers() {
     // TODO: this should be derived from the recording JSON
     // TODO: as of 2020-06-04, it does not include this data :(
     createdSpeakerButton.querySelector('slot[name="speaker-dialect"]')
-      .innerText = 'Maskwacîs'
+      .innerText = recordingData['dialect']
 
     // Setup audio
     let audio = new Audio(recordingData.recording_url)
@@ -79,7 +76,7 @@ export function retrieveListOfSpeakers() {
   // the function that creates a link for an individual speaker's bio to be clicked
   function displaySpeakerBioLink(recordingData) {
     // the URL to be placed into the DOM
-    let insertedURL = BASE_SPEAKER_URL + recordingData['speaker'] + '.html'
+    let insertedURL = recordingData['speaker_bio_url']
 
     // select for the area to place the speaker link
     let container = document.querySelector('.speaker-link')


### PR DESCRIPTION
The JSON response from the recordings app now includes some additional fields:

 - `speaker_bio_url`: an absolute URI to the speaker's bio, wherever it is
 - `dialect`: currently, this is always `"Maskwacîs"`, but I think that's better to hard-code in the recordings app than in this app 😅 

This PR takes the aforementioned fields and uses them instead of using hard-coded values in `recordings.js`.

Here's some sample JSON from the updated API in the recordings app:

```json
[
    {
        "anonymous": false,
        "dialect": "Maskwacîs",
        "gender": "F",
        "recording_url": "http://sapir.artsrn.ualberta.ca/validation/recording/e44429dafbd1a5d1996f784a8d22ea05006c75ffeea469337109dc8a15904789.m4a",
        "speaker": "MAR",
        "speaker_bio_url": "https://www.altlab.dev/maskwacis/Speakers/MAR.html",
        "speaker_name": "Mary Jane Littlechild",
        "wordform": "wapamew"
    }
]
```