### PR TITLE
Revamp search results header

### DIFF
--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -223,14 +223,15 @@ class Wordform(models.Model):
 
     def get_emoji_for_cree_wordclass(self) -> Optional[str]:
         """
-        Attempts to get a description, e.g., "like: wîcihêw" or "like:
-        micisow" for this wordform.
+        Attempts to get an emoji description of the full wordclass.
+        e.g., "👤👵🏽" for "nôhkom"
         """
         maybe_full_word_class = self.full_word_class
         if maybe_full_word_class is None:
             return None
-        word_class = FSTTag(maybe_full_word_class.without_pos())
-        return LABELS.emoji.get(word_class)
+        fst_tag_str = maybe_full_word_class.to_fst_output_style().strip("+")
+        tags = [FSTTag(t) for t in fst_tag_str.split("+")]
+        return LABELS.emoji.get_longest(tags)
 
     @cached_property
     def homograph_disambiguator(self) -> Optional[str]:

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -21,8 +21,6 @@ from urllib.parse import quote
 
 import attr
 from attr import attrs
-
-import CreeDictionary.hfstol as temp_hfstol
 from cree_sro_syllabics import syllabics2sro
 from django.conf import settings
 from django.db import models, transaction
@@ -30,10 +28,12 @@ from django.db.models import Max, Q, QuerySet
 from django.forms import model_to_dict
 from django.urls import reverse
 from django.utils.functional import cached_property
+from sortedcontainers import SortedSet
+
+import CreeDictionary.hfstol as temp_hfstol
 from fuzzy_search import CreeFuzzySearcher
 from paradigm import Layout
 from shared import paradigm_filler
-from sortedcontainers import SortedSet
 from utils import (
     ConcatAnalysis,
     FSTTag,
@@ -199,6 +199,15 @@ class Wordform(models.Model):
         result["lemma_url"] = self.get_absolute_url()
         result["wordclass_help"] = self.get_user_friendly_wordclass_help_for_cree()
 
+        # Displayed in the word class/inflection help:
+        result["inflectional_category_plain_english"] = LABELS.english.get(
+            self.inflectional_category
+        )
+        result["inflectional_category_linguistic"] = LABELS.linguistic_long.get(
+            self.inflectional_category
+        )
+        result["wordclass_emoji"] = self.get_emoji_for_cree_wordclass()
+
         return result
 
     def get_user_friendly_wordclass_help_for_cree(self) -> Optional[str]:
@@ -211,6 +220,17 @@ class Wordform(models.Model):
             return None
         word_class = FSTTag(maybe_full_word_class.without_pos())
         return LABELS.english.get(word_class)
+
+    def get_emoji_for_cree_wordclass(self) -> Optional[str]:
+        """
+        Attempts to get a description, e.g., "like: wîcihêw" or "like:
+        micisow" for this wordform.
+        """
+        maybe_full_word_class = self.full_word_class
+        if maybe_full_word_class is None:
+            return None
+        word_class = FSTTag(maybe_full_word_class.without_pos())
+        return LABELS.emoji.get(word_class)
 
     @cached_property
     def homograph_disambiguator(self) -> Optional[str]:

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -197,7 +197,6 @@ class Wordform(models.Model):
             definition.serialize() for definition in self.definitions.all()
         ]
         result["lemma_url"] = self.get_absolute_url()
-        result["wordclass_help"] = self.get_user_friendly_wordclass_help_for_cree()
 
         # Displayed in the word class/inflection help:
         result["inflectional_category_plain_english"] = LABELS.english.get(
@@ -209,17 +208,6 @@ class Wordform(models.Model):
         result["wordclass_emoji"] = self.get_emoji_for_cree_wordclass()
 
         return result
-
-    def get_user_friendly_wordclass_help_for_cree(self) -> Optional[str]:
-        """
-        Attempts to get a description, e.g., "like: wîcihêw" or "like:
-        micisow" for this wordform.
-        """
-        maybe_full_word_class = self.full_word_class
-        if maybe_full_word_class is None:
-            return None
-        word_class = FSTTag(maybe_full_word_class.without_pos())
-        return LABELS.english.get(word_class)
 
     def get_emoji_for_cree_wordclass(self) -> Optional[str]:
         """

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -214,10 +214,10 @@ class Wordform(models.Model):
         Attempts to get an emoji description of the full wordclass.
         e.g., "👤👵🏽" for "nôhkom"
         """
-        maybe_full_word_class = self.full_word_class
-        if maybe_full_word_class is None:
+        maybe_word_class = self.word_class
+        if maybe_word_class is None:
             return None
-        fst_tag_str = maybe_full_word_class.to_fst_output_style().strip("+")
+        fst_tag_str = maybe_word_class.to_fst_output_style().strip("+")
         tags = [FSTTag(t) for t in fst_tag_str.split("+")]
         return LABELS.emoji.get_longest(tags)
 
@@ -236,7 +236,7 @@ class Wordform(models.Model):
         return "id"  # id always guarantees unique match
 
     @property
-    def full_word_class(self) -> Optional[WordClass]:
+    def word_class(self) -> Optional[WordClass]:
         return fst_analysis_parser.extract_word_class(self.analysis)
 
     @property

--- a/CreeDictionary/API/schema.py
+++ b/CreeDictionary/API/schema.py
@@ -21,8 +21,13 @@ class SerializedWordform(TypedDict):
     as_is: bool
     lemma: int  # the id of the lemma
 
-    # ---- calculated properties ---
+    # ---- calculated properties ----
     lemma_url: str
+
+    # ---- informational properties ----
+    inflectional_category_plain_english: str
+    inflectional_category_linguistic: str
+    wordclass_emoji: str
 
     # ---- foreign keys ----
     definition: List[SerializedDefinition]

--- a/CreeDictionary/API/templatetags/inflection_extras.py
+++ b/CreeDictionary/API/templatetags/inflection_extras.py
@@ -1,9 +1,11 @@
 import logging
 from typing import Union
 
-from API.models import Wordform
 from django import template
 from django.forms import model_to_dict
+from django.template.defaultfilters import stringfilter
+
+from API.models import Wordform
 from utils import crkeng_xml_utils, fst_analysis_parser
 from utils.enums import WordClass
 
@@ -77,3 +79,27 @@ def presentational_pos(wordform: Union[Wordform, dict]) -> str:
         f"can not determine presentational pos for {wordform_dict}, id={wordform_dict['id']}"
     )
     return ""
+
+
+CURRENT_ID = 0
+MAX_ID = 2 ** 32
+
+
+@register.filter
+@stringfilter
+def unique_id(prefix: str) -> str:
+    """
+    Returns a new unique string that can be used as an id="" attribute in HTML.
+
+    >>> tooltip1 = unique_id("tooltip")
+    >>> tooltip2 = unique_id("tooltip")
+    >>> tooltip1 == tooltip2
+    False
+    """
+    # I don't remember the last time I used this keyword... 😖
+    global CURRENT_ID
+
+    generated_id = prefix + str(CURRENT_ID)
+    CURRENT_ID = (CURRENT_ID + 1) % MAX_ID
+
+    return generated_id

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition-title.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition-title.html
@@ -1,0 +1,65 @@
+{% spaceless %}
+
+  {% comment %}
+    ## .definition-title ##
+
+    Example:
+
+      nîminâniwan ℹ️ 🔊
+        ,---------^-------.
+        | nîmiw           |
+        |   action word   |
+        |   ni-/ki- word  |
+        |   now           |
+        |   somebody      |
+        `-----------------'
+
+  {% endcomment %}
+
+  {% load creedictionary_extras %}
+  {% load static %}
+
+  {# First line of the header #}
+  {# TODO: change data-cy=definition-title #}
+  <h2 class="definition-title definition-title--search-result" data-cy="matched-wordform">
+    {# the matched head itself: #}
+    <dfn class="definition__matched-head" data-cy="definition-title">
+      {% if result.is_lemma %}
+        <a data-cy="lemma-link" href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
+      {% else %}
+        {% orth result.matched_cree %}
+      {% endif %}
+    </dfn>
+
+    &#20; {# separate title proper from icons #}
+
+    <span class="definition__icons" data-wordform="{{ result.matched_cree }}">
+      {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
+        <div tabindex="0" class="definition__icon definition-title__tooltip-icon" data-cy="information-mark">
+          <img
+            src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
+            alt="linguistic breakdown">
+        </div>
+
+        <div class="tooltip" role="tooltip">
+          <span
+            data-cy="linguistic-breakdown">{% if result.linguistic_breakdown_head %}
+            {{ result.linguistic_breakdown_head|join:" + " }}
+            + {% endif %}
+            <strong>{{ result.lemma_wordform.text }}:</strong>
+            <ol class="linguistic-breakdown">
+              {% for linguistic_tag in result.linguistic_breakdown_tail %}
+              <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
+                {{ linguistic_tag }}
+              </li>
+              {% endfor %}
+            </ol>
+          </span>
+
+          <div class="tooltip__arrow" data-popper-arrow></div>
+        </div>
+        {# NB: the "Play recording" icon will be appened here #}
+      {% endif %}
+    </span>
+  </h2>
+{% endspaceless %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition-title.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition-title.html
@@ -35,7 +35,7 @@
 
     <span class="definition__icons" data-wordform="{{ result.matched_cree }}">
       {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
-        <div tabindex="0" class="definition__icon definition-title__tooltip-icon" data-cy="information-mark">
+        <div tabindex="0" class="definition__icon definition-title__tooltip-icon" data-has-tooltip data-cy="information-mark">
           <img
             src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
             alt="linguistic breakdown">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
@@ -17,15 +17,6 @@
 
   {# Second line of the header: the elaboration #}
   <p class="definition__elaboration" data-cy="elaboration">
-    {# Show the matched lemma (when this is NOT a lemma. #}
-    {% if not result.is_lemma %}
-      <span class="definition__reference-to-lemma" data-cy="reference-to-lemma">
-        Form of <a
-          class="definition__matched-lemma"
-          href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
-      </span>
-    {% endif %}
-
     {% with help=result.lemma_wordform.wordclass_help %}
       <span class="wordclass" data-cy="word-class">
         (<span class="wordclass__general">{{ result.lemma_wordform|presentational_pos }}</span>{% if help %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
@@ -12,6 +12,9 @@
     Example:
 
       🧑🏽➡️🧑🏽— /like nipâw/
+            ,-------^--------.
+            | verb (VAI)     |
+            `-------^--------'
 
   {% endcomment %}
 
@@ -19,12 +22,23 @@
   {% load inflection_extras %}
 
   {# Second line of the header: the elaboration #}
-  <p class="definition__elaboration" data-cy="elaboration">
-    {% with help=lemma.inflectional_category_plain_english %}
-      <span class="wordclass" data-cy="word-class">
-        <span class="wordclass__emoji">{{ lemma.wordclass_emoji }}</span>{% if help %}
-          <span class="wordclass__help"> — {{ help }}</span>{% endif %}
-      </span>
+  <div class="definition__elaboration" data-cy="elaboration">
+    {% with ic=lemma.inflectional_category_plain_english %}
+      {% if ic %}
+        <button class="wordclass wordclass--described unbutton" data-cy="word-class" data-has-tooltip {# todo: aria-describedby="tooltip:N" #}>
+          <span class="wordclass__emoji">{{ lemma.wordclass_emoji }}</span>
+          <span class="wordclass__help"> — {{ ic }}</span>
+        </button>
+
+        <div class="tooltip" role="tooltip">
+          {{ lemma.inflectional_category_linguistic }} ({{lemma.inflectional_category}})
+          <div class="tooltip__arrow" data-popper-arrow></div>
+        </div>
+      {% else %}
+        <span class="wordclass" data-cy="word-class">
+          <span class="wordclass__emoji">{{ lemma.wordclass_emoji }}</span>
+        </span>
+      {% endif %}
     {% endwith %}
-  </p>
+  </div>
 {% endspaceless %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
@@ -23,18 +23,21 @@
 
   {# Second line of the header: the elaboration #}
   <div class="definition__elaboration" data-cy="elaboration">
-    {% with ic=lemma.inflectional_category_plain_english id=request|unique_id %}
+    {% with ic=lemma.inflectional_category_plain_english emoji=lemma.wordclass_emoji id=request|unique_id %}
       {% if ic %}
         <span class="wordclass wordclass--described" data-cy="word-class" data-has-tooltip tabindex="0" aria-describedby="tooltip:{{ id }}">
-          <span class="wordclass__emoji">{{ lemma.wordclass_emoji }}</span>
-          <span class="wordclass__help"> — {{ ic }}</span>
+          {% if emoji %}
+            <span class="wordclass__emoji">{{ emoji }}</span>
+          {% endif %}
+          {% if emoji and ic %} — {% endif %}
+          <span class="wordclass__help"> {{ ic }}</span>
         </span>
 
         <div id="tooltip:{{ id }}" class="tooltip" role="tooltip">
           {{ lemma.inflectional_category_linguistic }} ({{lemma.inflectional_category}})
           <div class="tooltip__arrow" data-popper-arrow></div>
         </div>
-      {% else %}
+      {% elif emoji %}
         <span class="wordclass" data-cy="word-class">
           <span class="wordclass__emoji">{{ lemma.wordclass_emoji }}</span>
         </span>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
@@ -17,9 +17,9 @@
 
   {# Second line of the header: the elaboration #}
   <p class="definition__elaboration" data-cy="elaboration">
-    {% with help=result.lemma_wordform.wordclass_help %}
+    {% with help=lemma.wordclass_help %}
       <span class="wordclass" data-cy="word-class">
-        (<span class="wordclass__general">{{ result.lemma_wordform|presentational_pos }}</span>{% if help %}
+        (<span class="wordclass__general">{{ lemma|presentational_pos }}</span>{% if help %}
           <span class="wordclass__help"> — {{ help }}</span>{% endif %})
       </span>
     {% endwith %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
@@ -1,7 +1,20 @@
-{% load creedictionary_extras %}
-{% load inflection_extras %}
-
 {% spaceless %}
+
+  {% comment %}
+    ## .definition__elaboration ##
+
+    The line below the lemma that describes the wordclass and the inflectional
+    category.
+
+    Example:
+
+      🧑🏽➡️🧑🏽— /like nipâw/
+
+  {% endcomment %}
+
+  {% load creedictionary_extras %}
+  {% load inflection_extras %}
+
   {# Second line of the header: the elaboration #}
   <p class="definition__elaboration" data-cy="elaboration">
     {# Show the matched lemma (when this is NOT a lemma. #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
@@ -1,0 +1,23 @@
+{% load creedictionary_extras %}
+{% load inflection_extras %}
+
+{% spaceless %}
+  {# Second line of the header: the elaboration #}
+  <p class="definition__elaboration" data-cy="elaboration">
+    {# Show the matched lemma (when this is NOT a lemma. #}
+    {% if not result.is_lemma %}
+      <span class="definition__reference-to-lemma" data-cy="reference-to-lemma">
+        Form of <a
+          class="definition__matched-lemma"
+          href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
+      </span>
+    {% endif %}
+
+    {% with help=result.lemma_wordform.wordclass_help %}
+      <span class="wordclass" data-cy="word-class">
+        (<span class="wordclass__general">{{ result.lemma_wordform|presentational_pos }}</span>{% if help %}
+          <span class="wordclass__help"> — {{ help }}</span>{% endif %})
+      </span>
+    {% endwith %}
+  </p>
+{% endspaceless %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
@@ -3,6 +3,9 @@
   {% comment %}
     ## .definition__elaboration ##
 
+    Paramters
+      - lemma: SerializedWordform
+
     The line below the lemma that describes the wordclass and the inflectional
     category.
 
@@ -17,10 +20,10 @@
 
   {# Second line of the header: the elaboration #}
   <p class="definition__elaboration" data-cy="elaboration">
-    {% with help=lemma.wordclass_help %}
+    {% with help=lemma.inflectional_category_plain_english %}
       <span class="wordclass" data-cy="word-class">
-        (<span class="wordclass__general">{{ lemma|presentational_pos }}</span>{% if help %}
-          <span class="wordclass__help"> — {{ help }}</span>{% endif %})
+        <span class="wordclass__emoji">{{ lemma.wordclass_emoji }}</span>{% if help %}
+          <span class="wordclass__help"> — {{ help }}</span>{% endif %}
       </span>
     {% endwith %}
   </p>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
@@ -23,14 +23,14 @@
 
   {# Second line of the header: the elaboration #}
   <div class="definition__elaboration" data-cy="elaboration">
-    {% with ic=lemma.inflectional_category_plain_english %}
+    {% with ic=lemma.inflectional_category_plain_english id="tooltip"|unique_id %}
       {% if ic %}
-        <span class="wordclass wordclass--described" data-cy="word-class" data-has-tooltip tabindex="0" {# todo: aria-describedby="tooltip:N" #}>
+        <span class="wordclass wordclass--described" data-cy="word-class" data-has-tooltip tabindex="0" aria-describedby="{{ id }}">
           <span class="wordclass__emoji">{{ lemma.wordclass_emoji }}</span>
           <span class="wordclass__help"> — {{ ic }}</span>
         </span>
 
-        <div class="tooltip" role="tooltip">
+        <div id="{{ id }}" class="tooltip" role="tooltip">
           {{ lemma.inflectional_category_linguistic }} ({{lemma.inflectional_category}})
           <div class="tooltip__arrow" data-popper-arrow></div>
         </div>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
@@ -23,14 +23,14 @@
 
   {# Second line of the header: the elaboration #}
   <div class="definition__elaboration" data-cy="elaboration">
-    {% with ic=lemma.inflectional_category_plain_english id="tooltip"|unique_id %}
+    {% with ic=lemma.inflectional_category_plain_english id=request|unique_id %}
       {% if ic %}
-        <span class="wordclass wordclass--described" data-cy="word-class" data-has-tooltip tabindex="0" aria-describedby="{{ id }}">
+        <span class="wordclass wordclass--described" data-cy="word-class" data-has-tooltip tabindex="0" aria-describedby="tooltip:{{ id }}">
           <span class="wordclass__emoji">{{ lemma.wordclass_emoji }}</span>
           <span class="wordclass__help"> — {{ ic }}</span>
         </span>
 
-        <div id="{{ id }}" class="tooltip" role="tooltip">
+        <div id="tooltip:{{ id }}" class="tooltip" role="tooltip">
           {{ lemma.inflectional_category_linguistic }} ({{lemma.inflectional_category}})
           <div class="tooltip__arrow" data-popper-arrow></div>
         </div>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
@@ -25,10 +25,10 @@
   <div class="definition__elaboration" data-cy="elaboration">
     {% with ic=lemma.inflectional_category_plain_english %}
       {% if ic %}
-        <button class="wordclass wordclass--described unbutton" data-cy="word-class" data-has-tooltip {# todo: aria-describedby="tooltip:N" #}>
+        <span class="wordclass wordclass--described" data-cy="word-class" data-has-tooltip tabindex="0" {# todo: aria-describedby="tooltip:N" #}>
           <span class="wordclass__emoji">{{ lemma.wordclass_emoji }}</span>
           <span class="wordclass__help"> — {{ ic }}</span>
-        </button>
+        </span>
 
         <div class="tooltip" role="tooltip">
           {{ lemma.inflectional_category_linguistic }} ({{lemma.inflectional_category}})

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -6,48 +6,7 @@
 <li class="search-results__result" data-cy="search-results">
   <article class="definition box box--rounded" data-cy="search-result">
     <header class="definition__header">
-      {# First line of the header #}
-      {# TODO: change data-cy=definition-title #}
-      <h2 class="definition-title definition-title--search-result" data-cy="matched-wordform">
-        {# the matched head itself: #}
-        <dfn class="definition__matched-head" data-cy="definition-title">
-          {% if result.is_lemma %}
-            <a data-cy="lemma-link" href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
-          {% else %}
-            {% orth result.matched_cree %}
-          {% endif %}
-        </dfn>
-
-        <span class="definition__icons" data-wordform="{{ result.matched_cree }}">
-          {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
-            <div tabindex="0" class="definition__icon definition-title__tooltip-icon" data-cy="information-mark">
-              <img
-                src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
-                alt="linguistic breakdown">
-            </div>
-
-            <div class="tooltip" role="tooltip">
-              <span
-                data-cy="linguistic-breakdown">{% if result.linguistic_breakdown_head %}
-                {{ result.linguistic_breakdown_head|join:" + " }}
-                + {% endif %}
-                <strong>{{ result.lemma_wordform.text }}:</strong>
-                <ol class="linguistic-breakdown">
-                  {% for linguistic_tag in result.linguistic_breakdown_tail %}
-                  <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
-                    {{ linguistic_tag }}
-                  </li>
-                  {% endfor %}
-                </ol>
-              </span>
-
-              <div class="tooltip__arrow" data-popper-arrow></div>
-            </div>
-            {# NB: the "Play recording" icon will be appened here #}
-          {% endif %}
-        </span>
-      </h2>
-
+      {% include './components/_definition-title.html' %}
       {% include './components/_definition__elaboration.html' %}
     </header>
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -48,24 +48,7 @@
         </span>
       </h2>
 
-      {# Second line of the header: the elaboration #}
-      <p class="definition__elaboration" data-cy="elaboration">
-        {# Show the matched lemma (when this is NOT a lemma. #}
-        {% if not result.is_lemma %}
-          <span class="definition__reference-to-lemma" data-cy="reference-to-lemma">
-            Form of <a
-              class="definition__matched-lemma"
-              href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
-          </span>
-        {% endif %}
-
-        {% with help=result.lemma_wordform.wordclass_help %}
-          <span class="wordclass" data-cy="word-class">
-            (<span class="wordclass__general">{{ result.lemma_wordform|presentational_pos }}</span>{% if help %}
-              <span class="wordclass__help"> — {{ help }}</span>{% endif %})
-          </span>
-        {% endwith %}
-      </p>
+      {% include './components/_definition__elaboration.html' %}
     </header>
 
     {# Theses are the definitions for the inflection (non-lemma), could be empty  #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -33,7 +33,7 @@
           </span>
 
           {% if preverb.id %} {# we know the preverb in the database #}
-            <div tabindex="0" class="preverb-breakdown__tooltip-icon" data-cy="information-mark">
+            <div tabindex="0" class="preverb-breakdown__tooltip-icon" data-has-tooltip data-cy="information-mark">
               <img
                 src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
                 alt="preverb breakdown">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -8,7 +8,7 @@
     <header class="definition__header">
       {% include './components/_definition-title.html' %}
       {% if result.is_lemma %}
-        {% include './components/_definition__elaboration.html' %}
+        {% include './components/_definition__elaboration.html' with lemma=result.lemma_wordform %}
       {% endif %}
     </header>
 
@@ -71,6 +71,8 @@
           <dfn class="definition__matched-head" data-cy="definition-title">
             <a href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
           </dfn>
+
+          {% include './components/_definition__elaboration.html' with lemma=result.lemma_wordform %}
         </h2>
       </header>
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -71,9 +71,9 @@
           <dfn class="definition__matched-head" data-cy="definition-title">
             <a href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
           </dfn>
-
-          {% include './components/_definition__elaboration.html' with lemma=result.lemma_wordform %}
         </h2>
+
+        {% include './components/_definition__elaboration.html' with lemma=result.lemma_wordform %}
       </header>
 
       {# Theses are the definitions for the lemma, gauranteed to exist in the database #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -7,7 +7,9 @@
   <article class="definition box box--rounded" data-cy="search-result">
     <header class="definition__header">
       {% include './components/_definition-title.html' %}
-      {% include './components/_definition__elaboration.html' %}
+      {% if result.is_lemma %}
+        {% include './components/_definition__elaboration.html' %}
+      {% endif %}
     </header>
 
     {# Theses are the definitions for the inflection (non-lemma), could be empty  #}
@@ -53,8 +55,14 @@
     </ol>
     {# end preverb breakdown #}
 
+    {# Show the matched lemma (when this is NOT a lemma). #}
     {% if not result.is_lemma %}
-      {# show everything about the lemma #}
+      <p class="definition__reference-to-lemma" data-cy="reference-to-lemma">
+        form of <a
+          class="definition__matched-lemma"
+          href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
+      </p>
+
       <hr class="cleave-inflection-from-lemma">
 
       <header class="definition__header">

--- a/CreeDictionary/res/crk.altlabel.tsv
+++ b/CreeDictionary/res/crk.altlabel.tsv
@@ -100,8 +100,8 @@ FST TAG	LINGUISTIC (SHORT)	LINGUISTIC (LONG)	ENGLISH	NÊHIYAWÊWIN	EMOJI
 5Sg/Pl+3PlO			s/he/they (further) → him/her/them	wiya/wiyawâw (ana/aniki) → wiyawâw	-
 5Sg/Pl+4Sg/PlO			s/he/they (further) → him/her/them	wiya/wiyawâw (nâha/nêki) → wiya/wiyawâw (ana/aniki)	-
 					
-A	Animate	Animate	like: asikan, iyiniw, maskwa	tâpiskôc: asikan, iyiniw, maskwa	🧑🏽
-AI		Animate Intransitive	like: mîcisow, nipâw	tâpiskôc: mîcisow, nipâw	🧑🏽➡️
+A	Animate	Animate	like: asikan, iyiniw, maskwa	tâpiskôc: asikan, iyiniw, maskwa	
+AI		Animate Intransitive	like: mîcisow, nipâw	tâpiskôc: mîcisow, nipâw	
 					
 Arab		Arabic	like: 0, 1, 2, ...	tâpiskôc: 0, 1, 2, ... -	
 CC		Co-ordinating Conjunction	like: êkwa	tâpiskôc: êkwa -	
@@ -109,7 +109,7 @@ CS		Subordinate Conjunction	like: mâka	tâpiskôc: mâka -
 Cnj		Conjunct	ê-/kâ- word	ê-/kâ- itwêwin -	
 Cond		Conditional	when/if something happens	kisik/kîsâspin ê-ispayik -	
 Fut+Cond		Future conditional	when/if something happens	kisik/kîsâspin ê-ispayik -	
-D		Dependent	like: nôhkom, mîpit	tâpiskôc: nôhkom, mîpit	👤
+D		Dependent	like: nôhkom, mîpit	tâpiskôc: nôhkom, mîpit	
 Def		Definite			
 Fut+Def	Future Definite	Future definite tense	something will certainly happen	ka-ispayik nîkânihk/cikêmâ	
 Del		Delayed	later	mwêstas	
@@ -124,16 +124,16 @@ Distr		Distributive	among	âkine
 Err/Orth		(Sub-standard form)			
 Foc		Focus			
 Fut	Future	Future tense	something is happening later on	ê-ispayik mwêstas/nîkânihk	
-I		Inanimate	like: cîmân, wâwi	tâpiskôc: cîmân, wâwi	📦
+I		Inanimate	like: cîmân, wâwi	tâpiskôc: cîmân, wâwi	
 IC		Initial change	Initial change		
-II		Inanimate Intransitive	like: miywâsin, mihkwâw	tâpiskôc: miywâsin, mihkwâw	📦➡️
+II		Inanimate Intransitive	like: miywâsin, mihkwâw	tâpiskôc: miywâsin, mihkwâw	
 INM	Name		like: otôskwanihk	tâpiskôc: otôskwanihk	
-IPC	Particle		like: anohc	tâpiskôc: anohc	
+IPC	Particle		like: anohc	tâpiskôc: anohc	⚡
 IPH	Phrase		like: êkosi pitamâ	tâpiskôc: êkosi pitamâ	
-IPJ	Interjection		like: hay hay	tâpiskôc: hay hay	
-IPN	Prenoun		like: amisko-	tâpiskôc: amisko-	
-IPP	Particle		like: akâmi-	tâpiskîc: akâmi- 	
-IPV	Preverb		like: pê-	tâpiskôc: pê-	
+IPJ	Interjection		like: hay hay	tâpiskôc: hay hay	⚡
+IPN	Prenoun		like: amisko-	tâpiskôc: amisko-	⚡
+IPP	Particle		like: akâmi-	tâpiskîc: akâmi- 	⚡️
+IPV	Preverb		like: pê-	tâpiskôc: pê-	⚡️
 Imm		Immediate	now	mêkwâc/kîsac	
 Imp		Imperative	command/request	nitotamâkêwin	
 Imp+Imm		Immediate imperative	command/request that something happens immediately	nitotamâkêwin piko ka-ispayik	
@@ -144,11 +144,13 @@ Interj		Interjection	Shouting word	têpwêwin-itwêwin
 Ipc		Independent Particle	Connecting word	âniskohtâwin-itwêwin	
 Loc		Locative	in/on/to	pîhci-, tahkoht, ohci	
 Med		Medial	like: ana, anima	tâpiskôc: ana, anima	
+
 N		Noun	Naming word	wîhyowin-itwêwin	
-N+A	Animate noun	Noun - animate	Naming word - like: asikan, iyiniw, maskwa	wîhyowin-itwêwin - tâpiskôc: asikan, iyiniw, maskwa 	
-N+I	Inanimate noun	Noun - inanimate	Naming word - like: cîmân, wâwi	wîhyowin-itwêwin - tâpiskôc: cîmân, wâwi	
-N+A+D	Dependent animate noun	Noun - dependent animate	Naming word - like: nôhkom	wîhyowin-itwêwin - tâpiskôc: nôhkom	
-N+I+D	Dependent inanimate noun	Noun - dependent animate	Naming word - like: mîpit	wîhyowin-itwêwin - tâpiskôc: mîpit	
+N+A	Animate noun	Noun - animate	Naming word - like: asikan, iyiniw, maskwa	wîhyowin-itwêwin - tâpiskôc: asikan, iyiniw, maskwa 	🧑🏽
+N+I	Inanimate noun	Noun - inanimate	Naming word - like: cîmân, wâwi	wîhyowin-itwêwin - tâpiskôc: cîmân, wâwi	💧
+N+A+D	Dependent animate noun	Noun - dependent animate	Naming word - like: nôhkom	wîhyowin-itwêwin - tâpiskôc: nôhkom	👤🧑🏽
+N+I+D	Dependent inanimate noun	Noun - dependent animate	Naming word - like: mîpit	wîhyowin-itwêwin - tâpiskôc: mîpit	👤💧
+
 NA-1	NA-1	Regular animate noun stem	like: pahkwêsikan, asikan	tâpiskôc: pahkwêsikan, asikan	
 NA-2	NA-2	Vowel-glide animate noun stem	like: kihc-ôkiniy, ayapiy	tâpiskôc: kihc-ôkiniy, ayapiy	
 NA-3	NA-3	Consonant-/w/ animate noun stem	like: masinahikanāhtik(w), askihk(w)	tâpiskôc: masinahikanāhtik(w), askihk(w)	
@@ -455,14 +457,14 @@ Sg		Singular	one	pêyak
 					
 					
 					
-TA	Transitive Animate		like: wîcihêw, itêw	tâpiskôc: wîcihêw, itêw	🧑🏽➡️🧑🏽
-TI	Transitive Inaminate		like: nâtam, mîciw	tâpiskôc: nâtam, mîciw	🧑🏽➡️📦
+TA	Transitive Animate		like: wîcihêw, itêw	tâpiskôc: wîcihêw, itêw	
+TI	Transitive Inaminate		like: nâtam, mîciw	tâpiskôc: nâtam, mîciw	
 					
 V	Verb		Action word	ispayin-itwêwin	
-V+II	Inanimate intransitive verb	Verb - inanimate intransitive	Action word - like: miywâsin, mihkwâw	ispayin-itwêwin - tâpiskôc: miywâsin, mihkwâw	
-V+AI	Animate intransitive verb	Verb - animate intransitive	Action word - like: mîcisow, nipâw	ispayin-itwêwin - tâpiskôc: mîcisow, nipâw	
-V+TI	Transitive inanimate verb	Verb - transitive inanimate	Action word - like: nâtam, mîciw	ispayin-itwêwin - tâpiskôc: nâtam, mîciw	
-V+TA	Transitive animate verb	Verb - transitive animate	Action word - like: wîcihêw, itêw	ispayin-itwêwin - tâpiskôc: wîcihêw, itêw	
+V+II	Inanimate intransitive verb	Verb - inanimate intransitive	Action word - like: miywâsin, mihkwâw	ispayin-itwêwin - tâpiskôc: miywâsin, mihkwâw	💧➡️
+V+AI	Animate intransitive verb	Verb - animate intransitive	Action word - like: mîcisow, nipâw	ispayin-itwêwin - tâpiskôc: mîcisow, nipâw	🧑🏽➡️
+V+TI	Transitive inanimate verb	Verb - transitive inanimate	Action word - like: nâtam, mîciw	ispayin-itwêwin - tâpiskôc: nâtam, mîciw	🧑🏽➡️💧
+V+TA	Transitive animate verb	Verb - transitive animate	Action word - like: wîcihêw, itêw	ispayin-itwêwin - tâpiskôc: wîcihêw, itêw	🧑🏽➡️🧑🏽
 					
 Voc	Vocative		call/address	kitowin	
 					

--- a/CreeDictionary/res/crk.altlabel.tsv
+++ b/CreeDictionary/res/crk.altlabel.tsv
@@ -467,6 +467,7 @@ V+TA	Transitive animate verb	Verb - transitive animate	Action word - like: wîci
 Voc	Vocative		call/address	kitowin	
 					
 VAI-1	VAI-1	vowel-final animate intransitive verb	like: nipâw	tâpiskôc: nipâw	
+VAI-v	VAI-v	vowel-final animate intransitive verb	like: nipâw	tâpiskôc: nipâw	
 VAI-2	VAI-2	n-final animate intransitive verb	like: pimisin	tâpiskôc: pimisin	
 VAI-3	VAI-3	VTI-like animate intransitive verb	like: yâhyânam	tâpiskôc: yâhyânam	
 VII-1n	VII-1n	n-final impersonal inanimate intransive verb	like: kimiwan	tâpiskôc: kimiwan	

--- a/CreeDictionary/res/test_db_words.txt
+++ b/CreeDictionary/res/test_db_words.txt
@@ -121,3 +121,9 @@ maskwak
 # https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/429
 # note: kîsikâw exists above, no harm to add it again here
 kîsikâw
+
+# inflected form with definition
+# https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/445
+nîminâniwan
+# ...and its lemma:
+nîmiw

--- a/CreeDictionary/res/test_dictionaries/crkeng.xml
+++ b/CreeDictionary/res/test_dictionaries/crkeng.xml
@@ -3,7 +3,7 @@
 	<source id="CW">
 		
       
-		<title>Cree : Words / nehiyawewin : itwēwina</title>
+		<title>Cree : Words / nēhiyawēwin : itwēwina</title>
 		
    
 	</source>
@@ -17,7 +17,6 @@
    
 	</source>
 	
-
 
 
 	<e>
@@ -6257,6 +6256,21 @@
 			<tg xml:lang="eng">
 				
        
+				<t pos="V" sources="MD">He is here/there. (Animate) E.g. Ekota ki ayaw. He was there.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
 				<t pos="V" sources="CW">it is, it is there</t>
 				
    
@@ -6294,7 +6308,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="V" sources="MD">He owns: he has.</t>
+				<t pos="V" sources="MD">He is here/there. (Animate) E.g. Ekota ki ayaw. He was there.</t>
 				
    
 			</tg>
@@ -6346,7 +6360,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="V" sources="MD">He is here/there. (Animate) E.g. 'êkota kî-ayâw.' He was there.</t>
+				<t pos="V" sources="MD">He is here/there. (Animate) E.g. Ekota ki ayaw. He was there.</t>
 				
    
 			</tg>
@@ -15439,7 +15453,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="MD CW">breakfast</t>
+				<t pos="N" sources="CW">breakfast</t>
 				
    
 			</tg>
@@ -15846,7 +15860,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="V" sources="MD">It is day.</t>
+				<t pos="V" sources="MD">Day; v - It is day.</t>
 				
    
 			</tg>
@@ -15898,7 +15912,22 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="MD CW">day</t>
+				<t pos="N" sources="MD">Day; v - It is day.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">day</t>
 				
    
 			</tg>
@@ -21790,21 +21819,6 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="V" sources="MD">He eats.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
 				<t pos="V" sources="CW">s/he eats, s/he has a meal</t>
 				
    
@@ -21953,21 +21967,6 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="MD">Eating. A meal.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
 				<t pos="N" sources="CW">meal; eating, eating habits, food</t>
 				
    
@@ -22034,21 +22033,6 @@
 			
    
 		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A table.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
 		
    
 		<mg>
@@ -22197,21 +22181,6 @@
 			
    
 		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="N" sources="MD">A lunch. Not a full meal.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
 		
    
 		<mg>
@@ -30727,6 +30696,117 @@
 		<lg>
 			
       
+			<l pos="V">nîminâniwan</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nîmi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">it is a dance, a time of dancing</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">nîmiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>nîmi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he dances</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="N">nîmiwin</l>
+			
+      
+			<lc>NI-1</lc>
+			
+      
+			<stem>nîmiwin-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="N" sources="CW">a dance, a traditional Indian dance</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">nîpâmâyâtan</l>
 			
       
@@ -31703,21 +31783,6 @@
 			
    
 		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He wants to eat.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
 		
    
 		<mg>
@@ -36139,6 +36204,43 @@
 		<lg>
 			
       
+			<l pos="V">otayisiyinîmiw</l>
+			
+      
+			<lc>VAI-v</lc>
+			
+      
+			<stem>otayisiyinîmi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="V" sources="CW">s/he has people (as a chief, leader)</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="V">otâkosin</l>
 			
       
@@ -36305,7 +36407,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="N" sources="MD CW">supper, evening meal</t>
+				<t pos="N" sources="CW">supper, evening meal</t>
 				
    
 			</tg>
@@ -44054,6 +44156,21 @@
 			<tg xml:lang="eng">
 				
        
+				<t pos="N" sources="MD">It is winter.</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
 				<t pos="N" sources="CW">year, winter</t>
 				
    
@@ -46454,7 +46571,7 @@
 			<tg xml:lang="eng">
 				
        
-				<t pos="V" sources="MD CW">s/he sees through s.o.; s/he takes s.o.'s x-ray</t>
+				<t pos="V" sources="CW">s/he sees through s.o.; s/he takes s.o.'s x-ray</t>
 				
    
 			</tg>
@@ -49932,6 +50049,43 @@
 		<lg>
 			
       
+			<l pos="Pron">tânimi</l>
+			
+      
+			<lc>PrI</lc>
+			
+      
+			<stem/>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+       
+				<t pos="Pron" sources="CW">which one</t>
+				
+   
+			</tg>
+			
+   
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
 			<l pos="Ipc">tânisi</l>
 			
       
@@ -52620,21 +52774,6 @@
 			
    
 		</lg>
-		
-   
-		<mg>
-			
-   
-			<tg xml:lang="eng">
-				
-       
-				<t pos="V" sources="MD">He sees him.</t>
-				
-   
-			</tg>
-			
-   
-		</mg>
 		
    
 		<mg>
@@ -72022,6 +72161,43 @@
 				
       
 				<t pos="V" sources="CW">s/he sells something thus, s/he sells something for that amount</t>
+				
+   
+			</tg>
+			
+ 
+		</mg>
+		
+
+	</e>
+	
+
+
+	<e>
+		
+   
+		<lg>
+			
+      
+			<l pos="V">okisêyinîmiw</l>
+			
+      
+			<lc>VAI-1</lc>
+			
+      
+			<stem>okisêyinîmi-</stem>
+			
+   
+		</lg>
+		
+   
+		<mg>
+			
+   
+			<tg xml:lang="eng">
+				
+      
+				<t pos="V" sources="CW">she has (s.o. as) a husband, s/he has a living husband, s/he has (s.o. as) her old man</t>
 				
    
 			</tg>

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -365,11 +365,14 @@ context('Searching', () => {
     })
   })
 
+  // See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/445#:~:text=4.%20Inflected%20form
   describe('display of the header', function () {
-    const lemma = 'wâpamêw'
+    const lemma = 'nîmiw'
     const wordclassEmoji = '➡️' // the arrow is the most consistent thing, which means verb
-    const plainEnglishInflectionalCategory = 'like: wîcihêw'
-    const nonLemmaForm = 'nikî-nitawi-wâpamâw'
+    const plainEnglishInflectionalCategory = 'like: nipâw'
+    const nonLemmaFormWithDefinition = 'nîminâniwan'
+    const nonLemmaFormWithoutDefinition = 'ninîmin'
+    const nonLemmaDefinition = 'it is a dance'
 
     it('should display the match wordform and word class on the same line for lemmas', function () {
       cy.visitSearch(fudgeUpOrthography(lemma))
@@ -388,7 +391,7 @@ context('Searching', () => {
     })
 
     it('should display the matched word form and its lemma/word class on separate lines for non-lemmas', function () {
-      cy.visitSearch(fudgeUpOrthography(nonLemmaForm))
+      cy.visitSearch(fudgeUpOrthography(nonLemmaFormWithoutDefinition))
 
       // make sure we get at least one search result...
       cy.get('[data-cy=search-result]')
@@ -396,7 +399,7 @@ context('Searching', () => {
 
       // now let's make sure the NORMATIZED form is in the search result
       cy.get('@search-result')
-        .contains('header [data-cy="matched-wordform"]', nonLemmaForm)
+        .contains('header [data-cy="matched-wordform"]', nonLemmaFormWithoutDefinition)
 
       // now make sure the 'form of' text is below that
       cy.get('@search-result')
@@ -412,6 +415,42 @@ context('Searching', () => {
         .contains('[data-cy="word-class"]', wordclassEmoji)
       cy.get('@elaboration')
         .contains('[data-cy="word-class"]', plainEnglishInflectionalCategory)
+    })
+
+    // See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/445#:~:text=4.%20Inflected%20form
+    it('should display an inflected form with a definition AND its lemma', function () {
+      cy.visitSearch(fudgeUpOrthography(nonLemmaFormWithDefinition))
+
+      // make sure we get at least one search result...
+      cy.get('[data-cy=search-result]')
+        .as('search-result')
+
+      // make sure the NORMATIZED form is in the search result
+      cy.get('@search-result')
+        .contains('header [data-cy="matched-wordform"]', nonLemmaFormWithDefinition)
+
+      // make sure it has a definition
+      cy.get('@search-result')
+        // TODO: change name of [data-cy="lemma-meaning"] as it's misleading :/
+        .contains('[data-cy="lemma-meaning"]', nonLemmaDefinition)
+
+      // "form of nîmiw"
+      cy.get('@search-result')
+        .get('[data-cy="reference-to-lemma"]')
+        .should('contain', 'form of')
+        .and('contain', lemma)
+
+      cy.get('@search-result')
+        .get('header [data-cy="elaboration"]')
+        .as('elaboration')
+
+      cy.get('@elaboration')
+        .contains('[data-cy="word-class"]', wordclassEmoji)
+      cy.get('@elaboration')
+        .contains('[data-cy="word-class"]', plainEnglishInflectionalCategory)
+
+      // TODO: test inflectional class tooltip
+      // TODO: test linguistic breakdown tooltip
     })
 
     // Regression: it used to display 'Preverb — None' :/

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -432,7 +432,8 @@ context('Searching', () => {
 
       // Open the linguistic breakdown popup
       cy.get('@search-result')
-        .get('[data-cy=information-mark]')
+        .find('[data-cy=information-mark]')
+        .as('information-mark')
         .first()
         .click()
 
@@ -444,6 +445,7 @@ context('Searching', () => {
 
       // Close the tooltip
       cy.get('@information-mark')
+        .first()
         .blur()
 
       // make sure it has a definition

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -442,10 +442,69 @@ context('Searching', () => {
         .should('be.visible')
         .contains('li', 'ni-/ki- word')
 
+      // Close the tooltip
+      cy.get('@information-mark')
+        .blur()
+
       // make sure it has a definition
       cy.get('@search-result')
         // TODO: change name of [data-cy="lemma-meaning"] as it's misleading :/
         .contains('[data-cy="lemma-meaning"]', nonLemmaDefinition)
+
+      // "form of nîmiw"
+      cy.get('@search-result')
+        .get('[data-cy="reference-to-lemma"]')
+        .should('contain', 'form of')
+        .and('contain', lemma)
+
+      cy.get('@search-result')
+        .get('[data-cy="elaboration"]')
+        .as('elaboration')
+
+      cy.get('@elaboration')
+        .get('[data-cy="word-class"]')
+        .should('contain', wordclassEmoji)
+        .and('contain', plainEnglishInflectionalCategory)
+
+      // Inflectional category tool tip
+      cy.get('@elaboration')
+        .get('[data-cy="word-class"]')
+        .first()
+        .click()
+      cy.get('@elaboration')
+        .get('[role="tooltip"]')
+        .should('be.visible')
+        .and('contain', inflectionalCategory)
+    })
+
+    // See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/445#:~:text=5.%20Inflected%20form%20without%20definition
+    it('should display an inflected form and its lemma', function () {
+      cy.visitSearch(fudgeUpOrthography(nonLemmaFormWithoutDefinition))
+
+      // make sure we get at least one search result...
+      cy.get('[data-cy=search-result]')
+        .as('search-result')
+
+      // make sure the NORMATIZED form is in the search result
+      cy.get('@search-result')
+        .contains('header [data-cy="matched-wordform"]', nonLemmaFormWithoutDefinition)
+
+      // Open the linguistic breakdown popup
+      cy.get('@search-result')
+        .get('[data-cy=information-mark]')
+        .first()
+        .as('information-mark')
+        .click()
+
+      // See the linguistic breakdown as an ordered list
+      cy.get('[data-cy=linguistic-breakdown]')
+        .first()
+        .should('be.visible')
+        .contains('li', 'ni-/ki- word')
+
+      // Close the tooltip
+      cy.get('@information-mark')
+        .blur()
 
       // "form of nîmiw"
       cy.get('@search-result')

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -1,91 +1,4 @@
 context('Searching', () => {
-  describe('A tooltip should show up when the user click/focus on the i icon beside the matched wordform', () => {
-    it('should show tooltip when the user focuses on the i icon beside ê-wâpamat', () => {
-      cy.visit('/')
-      cy.get('[data-cy=search]')
-        .type('ewapamat')
-
-      // not visible at the start
-      cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
-        .and('contain', 'wâpamêw') // lemma
-        .and('contain', 'Action word') // verb
-
-      cy.get('[data-cy=information-mark]').first().focus()
-
-      cy.get('[data-cy=linguistic-breakdown]').should('be.visible')
-    })
-
-    it('should show tooltip when the user clicks on the i icon beside ê-wâpamat', () => {
-      cy.visit('/')
-      cy.get('[data-cy=search]')
-        .type('ewapamat')
-
-      // not visible at the start
-      cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
-
-      // has to use force: true since div is not clickable
-      cy.get('[data-cy=information-mark]').first().click({force:true})
-
-      cy.get('[data-cy=linguistic-breakdown]').should('be.visible')
-        // NOTE: this depends on Antti's relabellings; if they change,
-        // this assertion has to change :/
-        .and('contain', 'wâpamêw') // lemma
-        .and('contain', 'Action word') // verb
-        .and('contain', 'you (one) → him/her') // 3Sg -> 4Sg/PlO
-    })
-
-    it('should show linguistic breakdowns as an ordered list when the user clicks on the ? icon beside a word', () => {
-      // begin from the homepage
-      cy.visit('/')
-
-      // lock onto the searchbar
-      cy.get('[data-cy=search]')
-      // get a word (nipaw)
-        .type('nipaw')
-
-      // tab through the elements to force the tooltip to pop up
-      cy.get('[data-cy=information-mark]').first().click()
-
-      // see the linguistic breakdown as an ordered list
-      cy.get('[data-cy=linguistic-breakdown]').contains('li', 'Action word')
-
-    })
-
-    it('should allow the tooltip to be focused on when the user tabs through it', () => {
-      // goodness, that's a mouthful and should _probably_ be worded better.
-      // begin from the homepage
-      cy.visit('/')
-      // lock onto the searchbar
-      cy.get('[data-cy=search]')
-      // get a word (use nipaw)
-        .type('nipaw')
-
-      // tab through the page elements until arriving on the '?' icon
-      cy.get('[data-cy=information-mark]').first().click()
-
-      // it should trigger the focus icon's outline's focused state
-      cy.get('[data-cy=information-mark]').first().focus().should('have.css', 'outline')
-    })
-
-    it('should not overlap other page elements when being displayed in the page', () => {
-      // begin from the homepage
-      cy.visit('/')
-
-      // lock onto the searchbar
-      cy.get('[data-cy=search]')
-      // get a word (Eddie's comment used a very long word in `e-ki-nitawi-kah-kimoci-kotiskaweyahk`, so we will use that!)
-        .type('e-ki-nitawi-kah-kimoci-kotiskaweyahk')
-
-      // force the tooltip to appear
-      cy.get('[data-cy=information-mark]').first().click({force:true})
-
-      // check that the z-index of the tooltip is greater than that of all other page elements
-      cy.get('[data-cy=information-mark]').first().focus().next().should('have.css', 'z-index', '1') // not a fan of this because of how verbose it is – if there's amore concise way of selecting for a non-focusable element, I'm all ears!
-
-    })
-
-  })
-
   describe('I want to know what a Cree word means in English', () => {
     // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/120
     it('should search for an exact lemma', () => {
@@ -102,6 +15,44 @@ context('Searching', () => {
 
       cy.get('[data-cy=search-results]')
         .should('contain', 'cat')
+    })
+  })
+
+  describe('When I type at the search bar, I should see results instantly', function () {
+    it('should display results in the page', function () {
+      cy.visit('/')
+
+      cy.get('[data-cy=search]')
+        .type('niya')
+
+      cy.location('pathname')
+        .should('contain', '/search')
+      cy.location('search')
+        .and('contain', 'q=niya')
+    })
+
+    it('should not change location upon pressing enter', function () {
+      let originalPathname, originalSearch
+      cy.visit('/')
+
+      cy.get('[data-cy=search]')
+        .type('niya')
+
+      cy.location().should((loc) => {
+        originalPathname = loc.pathname
+        originalSearch = loc.search
+        expect(loc.pathname).to.eq('/search')
+        expect(loc.search).to.contain('q=niya')
+      })
+
+      // Press ENTER!
+      cy.get('[data-cy=search]')
+        .type('{Enter}')
+
+      cy.location().should(loc => {
+        expect(loc.pathname).to.eq(originalPathname)
+        expect(loc.search).to.eq(originalSearch)
+      })
     })
   })
 
@@ -181,8 +132,6 @@ context('Searching', () => {
       cy.get('[data-cy=search]')
         .type(searchTerm)
 
-
-
       cy.get('[data-cy=search-results]')
         .contains('[data-cy=search-result]', /Form of/i)
         .as('searchResult')
@@ -206,7 +155,6 @@ context('Searching', () => {
   })
 
   it('should do prefix search and suffix search', () => {
-
     cy.visitSearch('nipaw')
 
     cy.get('[data-cy=search-results]')
@@ -287,12 +235,12 @@ context('Searching', () => {
   })
 
 
-  describe('When I perform a search, I should see the \'info\' icon on corresponding entries', () => {
+  describe("When I perform a search, I should see the 'info' icon on corresponding entries", () => {
     // Right – this is the test for issue #239 (https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/239).
 
     // At present, I want to target the definition's title, then look at the children to see if the the 'i' icon is
     // there. There's probably a more elegant way to do this but I think that'll come as I become more comfortable with the codebase.
-    it('should show the \'info\' icon to allow users to access additional information', () => {
+    it("should show the 'info' icon to allow users to access additional information", () => {
       // borrowed the following four lines from above and used 'nipaw' for testing purposes.
       const searchTerm = 'niya'
       cy.visit('/')
@@ -303,41 +251,87 @@ context('Searching', () => {
     })
   })
 
-  describe('When I type at the search bar, I should see results instantly', function () {
-    it('should display results in the page', function () {
+  describe('A tooltip should show up when the user click/focus on the i icon beside the matched wordform', () => {
+    it('should show tooltip when the user focuses on the i icon beside ê-wâpamat', () => {
       cy.visit('/')
-
       cy.get('[data-cy=search]')
-        .type('niya')
+        .type('ewapamat')
 
-      cy.location('pathname')
-        .should('contain', '/search')
-      cy.location('search')
-        .and('contain', 'q=niya')
+      // not visible at the start
+      cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
+        .and('contain', 'wâpamêw') // lemma
+        .and('contain', 'Action word') // verb
+
+      cy.get('[data-cy=information-mark]').first().focus()
+
+      cy.get('[data-cy=linguistic-breakdown]').should('be.visible')
     })
 
-    it('should not change location upon pressing enter', function () {
-      let originalPathname, originalSearch
+    it('should show tooltip when the user clicks on the i icon beside ê-wâpamat', () => {
+      cy.visit('/')
+      cy.get('[data-cy=search]')
+        .type('ewapamat')
+
+      // not visible at the start
+      cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
+
+      // has to use force: true since div is not clickable
+      cy.get('[data-cy=information-mark]').first().click({force:true})
+
+      cy.get('[data-cy=linguistic-breakdown]').should('be.visible')
+        // NOTE: this depends on Antti's relabellings; if they change,
+        // this assertion has to change :/
+        .and('contain', 'wâpamêw') // lemma
+        .and('contain', 'Action word') // verb
+        .and('contain', 'you (one) → him/her') // 3Sg -> 4Sg/PlO
+    })
+
+    it('should show linguistic breakdowns as an ordered list when the user clicks on the ? icon beside a word', () => {
+      // begin from the homepage
       cy.visit('/')
 
+      // lock onto the searchbar
       cy.get('[data-cy=search]')
-        .type('niya')
+      // get a word (nipaw)
+        .type('nipaw')
 
-      cy.location().should((loc) => {
-        originalPathname = loc.pathname
-        originalSearch = loc.search
-        expect(loc.pathname).to.eq('/search')
-        expect(loc.search).to.contain('q=niya')
-      })
+      // tab through the elements to force the tooltip to pop up
+      cy.get('[data-cy=information-mark]').first().click()
 
-      // Press ENTER!
+      // see the linguistic breakdown as an ordered list
+      cy.get('[data-cy=linguistic-breakdown]').contains('li', 'Action word')
+    })
+
+    it('should allow the tooltip to be focused on when the user tabs through it', () => {
+      // goodness, that's a mouthful and should _probably_ be worded better.
+      // begin from the homepage
+      cy.visit('/')
+      // lock onto the searchbar
       cy.get('[data-cy=search]')
-        .type('{Enter}')
+      // get a word (use nipaw)
+        .type('nipaw')
 
-      cy.location().should(loc => {
-        expect(loc.pathname).to.eq(originalPathname)
-        expect(loc.search).to.eq(originalSearch)
-      })
+      // tab through the page elements until arriving on the '?' icon
+      cy.get('[data-cy=information-mark]').first().click()
+
+      // it should trigger the focus icon's outline's focused state
+      cy.get('[data-cy=information-mark]').first().focus().should('have.css', 'outline')
+    })
+
+    it('should not overlap other page elements when being displayed in the page', () => {
+      // begin from the homepage
+      cy.visit('/')
+
+      // lock onto the searchbar
+      cy.get('[data-cy=search]')
+      // get a word (Eddie's comment used a very long word in `e-ki-nitawi-kah-kimoci-kotiskaweyahk`, so we will use that!)
+        .type('e-ki-nitawi-kah-kimoci-kotiskaweyahk')
+
+      // force the tooltip to appear
+      cy.get('[data-cy=information-mark]').first().click({force:true})
+
+      // check that the z-index of the tooltip is greater than that of all other page elements
+      cy.get('[data-cy=information-mark]').first().focus().next().should('have.css', 'z-index', '1') // not a fan of this because of how verbose it is – if there's amore concise way of selecting for a non-focusable element, I'm all ears!
     })
   })
 
@@ -438,5 +432,3 @@ context('Searching', () => {
     }
   })
 })
-
-

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -369,6 +369,7 @@ context('Searching', () => {
   describe('display of the header', function () {
     const lemma = 'nîmiw'
     const wordclassEmoji = '➡️' // the arrow is the most consistent thing, which means verb
+    const inflectionalCategory = 'VAI-v'
     const plainEnglishInflectionalCategory = 'like: nipâw'
     const nonLemmaFormWithDefinition = 'nîminâniwan'
     const nonLemmaFormWithoutDefinition = 'ninîmin'
@@ -418,7 +419,7 @@ context('Searching', () => {
     })
 
     // See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/445#:~:text=4.%20Inflected%20form
-    it('should display an inflected form with a definition AND its lemma', function () {
+    it.only('should display an inflected form with a definition AND its lemma', function () {
       cy.visitSearch(fudgeUpOrthography(nonLemmaFormWithDefinition))
 
       // make sure we get at least one search result...
@@ -441,15 +442,24 @@ context('Searching', () => {
         .and('contain', lemma)
 
       cy.get('@search-result')
-        .get('header [data-cy="elaboration"]')
+        .get('[data-cy="elaboration"]')
         .as('elaboration')
 
       cy.get('@elaboration')
-        .contains('[data-cy="word-class"]', wordclassEmoji)
-      cy.get('@elaboration')
-        .contains('[data-cy="word-class"]', plainEnglishInflectionalCategory)
+        .get('[data-cy="word-class"]')
+        .should('contain', wordclassEmoji)
+        .and('contain', plainEnglishInflectionalCategory)
 
-      // TODO: test inflectional class tooltip
+      // Inflectional category tool tip
+      cy.get('@elaboration')
+        .get('[data-cy="word-class"]')
+        .first()
+        .click()
+      cy.get('@elaboration')
+        .get('[role="tooltip"]')
+        .should('be.visible')
+        .and('contain', inflectionalCategory)
+
       // TODO: test linguistic breakdown tooltip
     })
 

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -594,6 +594,18 @@ context('Searching', () => {
         .should('not.contain', 'None')
     })
 
+    // Regression: it used to display 'like — pê-' :/
+    it('should not display wordclass emoji if it does not exist', function () {
+      // Preverbs do not have an elaboration (right now)
+      const preverb = 'nitawi-'
+      cy.visitSearch(preverb)
+
+      cy.get('[data-cy=search-result]')
+        .first()
+        .find('[data-cy=word-class]')
+        .should('contain', 'like: pê-')
+        .and('not.contain', 'None')
+    })
     /**
      * @returns {string} the wordform, as if you typed very quickly on your niece's peanut butter-smeared iPad
      */

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -532,6 +532,55 @@ context('Searching', () => {
         .and('contain', inflectionalCategory)
     })
 
+    // See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/445#:~:text=6.%20Lemma%20definition
+    it('should display an inflected form and its lemma', function () {
+      cy.visitSearch(fudgeUpOrthography(lemma))
+
+      // make sure we get at least one search result...
+      cy.get('[data-cy=search-result]')
+        .as('search-result')
+
+      // make sure the NORMATIZED form is in the search result
+      cy.get('@search-result')
+        .contains('header [data-cy="matched-wordform"]', lemma)
+
+      // Open the linguistic breakdown popup
+      cy.get('@search-result')
+        .get('[data-cy=information-mark]')
+        .first()
+        .as('information-mark')
+        .click()
+
+      // See the linguistic breakdown as an ordered list
+      cy.get('[data-cy=linguistic-breakdown]')
+        .first()
+        .should('be.visible')
+        .contains('li', 'ni-/ki- word')
+
+      // Close the tooltip
+      cy.get('@information-mark')
+        .blur()
+
+      cy.get('@search-result')
+        .get('[data-cy="elaboration"]')
+        .as('elaboration')
+
+      cy.get('@elaboration')
+        .get('[data-cy="word-class"]')
+        .should('contain', wordclassEmoji)
+        .and('contain', plainEnglishInflectionalCategory)
+
+      // Inflectional category tool tip
+      cy.get('@elaboration')
+        .get('[data-cy="word-class"]')
+        .first()
+        .click()
+      cy.get('@elaboration')
+        .get('[role="tooltip"]')
+        .should('be.visible')
+        .and('contain', inflectionalCategory)
+    })
+
     // Regression: it used to display 'Preverb — None' :/
     it('should not display wordclass help if it does not exist', function () {
       // Preverbs do not have an elaboration (right now)

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -367,8 +367,8 @@ context('Searching', () => {
 
   describe('display of the header', function () {
     const lemma = 'wâpamêw'
-    const wordclass = 'Verb'
-    const wordclassHelp = 'like: wîcihêw'
+    const wordclassEmoji = '➡️' // the arrow is the most consistent thing, which means verb
+    const plainEnglishInflectionalCategory = 'like: wîcihêw'
     const nonLemmaForm = 'nikî-nitawi-wâpamâw'
 
     it('should display the match wordform and word class on the same line for lemmas', function () {
@@ -382,9 +382,9 @@ context('Searching', () => {
       cy.get('@search-result')
         .contains('header [data-cy="matched-wordform"]', lemma)
       cy.get('@search-result')
-        .contains('header [data-cy="word-class"]', wordclass)
+        .contains('header [data-cy="word-class"]', wordclassEmoji)
       cy.get('@search-result')
-        .contains('header [data-cy="word-class"]', wordclassHelp)
+        .contains('header [data-cy="word-class"]', plainEnglishInflectionalCategory)
     })
 
     it('should display the matched word form and its lemma/word class on separate lines for non-lemmas', function () {
@@ -405,12 +405,13 @@ context('Searching', () => {
 
       cy.get('@elaboration')
         .get('[data-cy="reference-to-lemma"]')
-        .should('contain', 'Form of')
+        // TODO: should we be testing for this exact text?
+        .should('contain', 'form of')
         .and('contain', lemma)
       cy.get('@elaboration')
-        .contains('[data-cy="word-class"]', wordclass)
+        .contains('[data-cy="word-class"]', wordclassEmoji)
       cy.get('@elaboration')
-        .contains('[data-cy="word-class"]', wordclassHelp)
+        .contains('[data-cy="word-class"]', plainEnglishInflectionalCategory)
     })
 
     // Regression: it used to display 'Preverb — None' :/

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -419,7 +419,7 @@ context('Searching', () => {
     })
 
     // See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/445#:~:text=4.%20Inflected%20form
-    it.only('should display an inflected form with a definition AND its lemma', function () {
+    it('should display an inflected form with a definition AND its lemma', function () {
       cy.visitSearch(fudgeUpOrthography(nonLemmaFormWithDefinition))
 
       // make sure we get at least one search result...
@@ -429,6 +429,18 @@ context('Searching', () => {
       // make sure the NORMATIZED form is in the search result
       cy.get('@search-result')
         .contains('header [data-cy="matched-wordform"]', nonLemmaFormWithDefinition)
+
+      // Open the linguistic breakdown popup
+      cy.get('@search-result')
+        .get('[data-cy=information-mark]')
+        .first()
+        .click()
+
+      // See the linguistic breakdown as an ordered list
+      cy.get('[data-cy=linguistic-breakdown]')
+        .first()
+        .should('be.visible')
+        .contains('li', 'ni-/ki- word')
 
       // make sure it has a definition
       cy.get('@search-result')
@@ -459,8 +471,6 @@ context('Searching', () => {
         .get('[role="tooltip"]')
         .should('be.visible')
         .and('contain', inflectionalCategory)
-
-      // TODO: test linguistic breakdown tooltip
     })
 
     // Regression: it used to display 'Preverb — None' :/

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -4,6 +4,7 @@
 @import "./vendor/notosanscanadianaboriginal.css";
 @import "./variables.css";
 @import "./_tooltip.css";
+@import "./utilities.css";
 
 /**
  * Preliminary styles for the application.
@@ -1173,46 +1174,6 @@ a.menu-choice__label:active {
  */
 .explainer {
   font-weight: var(--strong-font-weight);
-}
-
-/******************************** UTILITIES *********************************/
-
-/* Links to features we have not implemented yet ¯\_(ツ)_/¯ */
-.feature-unavailable {
-  display: none;
-}
-
-/**
- * ELEMENT sr-only
- *
- * Let something be part of the accessiblity tree without showing it to
- * screens and print.
- */
-.sr-only {
-  position: absolute;
-
-  width: 1px;
-  height: 1px;
-
-  overflow: hidden;
-  clip: rect(1px, 1px, 1px, 1px);
-  -webkit-clip-path: inset(1px 1px 1px 1px);
-  clip-path: inset(1px 1px 1px 1px);
-  pointer-events: none;
-}
-
-/**
- * Makes a <button> look like a link.
- */
-.unbutton {
-  border: 0;
-
-  text-align: inherit;
-
-  color: inherit;
-  background: transparent;
-
-  cursor: pointer;
 }
 
 /**

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -537,6 +537,17 @@ html {
 }
 
 /**
+ * MODIFIER described
+ *
+ * This wordclass is described by a tooltip
+ */
+.wordclass--described {
+  text-decoration: underline dotted;
+
+  cursor: help;
+}
+
+/**
  * BLOCK cleave-inflection-from-lemma
  *
  * Separates the info for the matched wordform/inflection

--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -27,6 +27,7 @@
  */
 .unbutton {
   border: 0;
+  padding: 0;
 
   text-align: inherit;
 

--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -1,0 +1,37 @@
+/* Links to features we have not implemented yet ¯\_(ツ)_/¯ */
+.feature-unavailable {
+  display: none;
+}
+
+/**
+ * ELEMENT sr-only
+ *
+ * Let something be part of the accessiblity tree without showing it to
+ * screens and print.
+ */
+.sr-only {
+  position: absolute;
+
+  width: 1px;
+  height: 1px;
+
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  -webkit-clip-path: inset(1px 1px 1px 1px);
+  clip-path: inset(1px 1px 1px 1px);
+  pointer-events: none;
+}
+
+/**
+ * Makes a <button> look like a link.
+ */
+.unbutton {
+  border: 0;
+
+  text-align: inherit;
+
+  color: inherit;
+  background: transparent;
+
+  cursor: pointer;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ function loadRecordingsForAllSearchResults(searchResultsList) {
 function prepareTooltips(searchResultsList) {
   // attach handlers for tooltip icon at preverb breakdown
   let tooltips = searchResultsList
-    .querySelectorAll('.definition-title__tooltip-icon, .preverb-breakdown__tooltip-icon')
+    .querySelectorAll('[data-has-tooltip]')
   for (let icon of tooltips) {
     let tooltip = icon.nextElementSibling
     if (!tooltip.classList.contains('tooltip')) {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -3,6 +3,7 @@ import {createPopper} from '@popperjs/core/dist/esm/popper'
 
 const showEvents = ['mouseenter', 'focus']
 const hideEvents = ['mouseleave', 'blur']
+const toggleEvents = ['touchstart']
 
 let popperInstance = null
 
@@ -48,6 +49,18 @@ export function createTooltip(icon, popup) {
     icon.addEventListener(event, () => {
       popup.removeAttribute('data-show')
       destroy()
+    })
+  }
+
+  for (let event of toggleEvents) {
+    icon.addEventListener(event, () => {
+      if (popup.hasAttribute('data-show')) {
+        popup.removeAttribute('data-show')
+        destroy()
+      } else {
+        popup.setAttribute('data-show', '')
+        create(icon, popup)
+      }
     })
   }
 }

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -3,7 +3,6 @@ import {createPopper} from '@popperjs/core/dist/esm/popper'
 
 const showEvents = ['mouseenter', 'focus']
 const hideEvents = ['mouseleave', 'blur']
-const toggleEvents = ['touchstart']
 
 let popperInstance = null
 
@@ -49,18 +48,6 @@ export function createTooltip(icon, popup) {
     icon.addEventListener(event, () => {
       popup.removeAttribute('data-show')
       destroy()
-    })
-  }
-
-  for (let event of toggleEvents) {
-    icon.addEventListener(event, () => {
-      if (popup.hasAttribute('data-show')) {
-        popup.removeAttribute('data-show')
-        destroy()
-      } else {
-        popup.setAttribute('data-show', '')
-        create(icon, popup)
-      }
     })
   }
 }


### PR DESCRIPTION
This tackles the following:

 - [x] emoji for specific wordclass (closes #358)
 - [x] replaces English wordclass with English inflectional category (closes #434)
 - [x] popup for inflectional category (closes #447 )
 - [x] Updates layout to match latest mockups (closes #445)

---

**EDIT**: it's ready! Here are some screenshots:

non-lemma form with definition:
![Screen Shot 2020-06-18 at 11 22 42 AM](https://user-images.githubusercontent.com/2294397/85052528-4fa8fc80-b156-11ea-967b-ff6dd7d79d68.png)

its linguistic breakdown pop-up:
![Screen Shot 2020-06-18 at 11 26 13 AM](https://user-images.githubusercontent.com/2294397/85052675-9e569680-b156-11ea-93c1-8cb8ac22a867.png)

its inflectional category pop-up:
![Screen Shot 2020-06-18 at 11 26 44 AM](https://user-images.githubusercontent.com/2294397/85052689-a31b4a80-b156-11ea-9c9c-4c633074cfad.png)

non-lemma:
![Screen Shot 2020-06-18 at 11 23 05 AM](https://user-images.githubusercontent.com/2294397/85052708-a9112b80-b156-11ea-88fe-4a1e8a14afcf.png)

lemma:
![Screen Shot 2020-06-18 at 11 23 19 AM](https://user-images.githubusercontent.com/2294397/85052731-af9fa300-b156-11ea-96a7-ce1f991ceefc.png)
