### PR TITLE
Each prefix feature is on its own line

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition-title.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition-title.html
@@ -43,16 +43,17 @@
 
         <div class="tooltip" role="tooltip">
           <span
-            data-cy="linguistic-breakdown">{% if result.linguistic_breakdown_head %}
-            {{ result.linguistic_breakdown_head|join:" + " }}
-            + {% endif %}
+            data-cy="linguistic-breakdown">
+            {# TODO: this should be the STEM: #}
             <strong>{{ result.lemma_wordform.text }}:</strong>
             <ol class="linguistic-breakdown">
-              {% for linguistic_tag in result.linguistic_breakdown_tail %}
-              <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
-                {{ linguistic_tag }}
-              </li>
-              {% endfor %}
+              {% with tags=result.linguistic_breakdown_head|add:result.linguistic_breakdown_tail %}
+                {% for linguistic_tag in tags %}
+                  <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
+                    {{ linguistic_tag }}
+                  </li>
+                {% endfor %}
+              {% endwith %}
             </ol>
           </span>
 

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -260,6 +260,7 @@ context('Searching', () => {
       // not visible at the start
       cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
         .and('contain', 'wâpamêw') // lemma
+        .and('contain', 'complementizer') // preververb
         .and('contain', 'Action word') // verb
 
       cy.get('[data-cy=information-mark]').first().focus()


### PR DESCRIPTION
~~Blocked by #462~~

Looks like this:

<img width="1000" alt="Screen Shot 2020-06-18 at 2 45 52 PM" src="https://user-images.githubusercontent.com/2294397/85070133-82f98480-b172-11ea-90da-5833f9f7ec05.png">

There's probably a better way to present ALL of this, but this is better than how it used to be! 😄 

Fixes: #373 