### PR TITLE
feat: cree_example tag to properly render "like: itwêwin" in the current orthography

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition__elaboration.html
@@ -30,7 +30,7 @@
             <span class="wordclass__emoji">{{ emoji }}</span>
           {% endif %}
           {% if emoji and ic %} — {% endif %}
-          <span class="wordclass__help"> {{ ic }}</span>
+          <span class="wordclass__help">{% cree_example ic %}</span>
         </span>
 
         <div id="tooltip:{{ id }}" class="tooltip" role="tooltip">

--- a/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
+++ b/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
@@ -6,9 +6,10 @@ Template tags related to the Cree Dictionary specifically.
 """
 
 from cree_sro_syllabics import sro2syllabics
-from CreeDictionary.utils import url_for_query
 from django import template
 from django.utils.html import format_html
+
+from CreeDictionary.utils import url_for_query
 from utils import ORTHOGRAPHY_NAME
 from utils.vars import DEFAULT_ORTHOGRAPHY
 
@@ -38,6 +39,31 @@ def orth_tag(context, sro_original):
     # Determine the currently requested orthography:
     request_orth = context.request.COOKIES.get("orth", DEFAULT_ORTHOGRAPHY)
     return orth(sro_original, orthography=request_orth)
+
+
+@register.simple_tag(takes_context=True)
+def cree_example(context, example):
+    """
+    Similart to {% orth %}, but does not convert the 'like: ' prefix.
+    This should be used for the examples given in crk.altlabel.tsv.
+
+    e.g.,
+
+        {% cree_example 'like: wâpamew' %}
+
+    Yields:
+
+        like: <span lang="cr" data-orth
+              data-orth-latn="wâpamêw"
+              data-orth-latn-x-macron="wāpamēw"
+              data-orth-cans="ᐚᐸᒣᐤ">wâpamêw</span>
+    """
+    if not example.startswith("like: "):
+        # Do nothing if it doesn't look like an example
+        return example
+
+    _like, _sp, cree = example.partition(" ")
+    return format_html("{}{}", "like: ", orth_tag(context, cree))
 
 
 @register.simple_tag(takes_context=True)

--- a/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
+++ b/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
@@ -49,7 +49,7 @@ def cree_example(context, example):
 
     e.g.,
 
-        {% cree_example 'like: wâpamew' %}
+        {% cree_example 'like: wâpamêw' %}
 
     Yields:
 
@@ -63,7 +63,7 @@ def cree_example(context, example):
         return example
 
     _like, _sp, cree = example.partition(" ")
-    return format_html("{}{}", "like: ", orth_tag(context, cree))
+    return format_html("like: {}", orth_tag(context, cree))
 
 
 @register.simple_tag(takes_context=True)

--- a/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
@@ -115,7 +115,6 @@ def test_cree_example():
     """
     Test the {% cree_example 'like: itwêwin' %} tag.
     """
-
     request = HttpRequest()
     request.COOKIES["orth"] = "Cans"
 

--- a/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
@@ -112,16 +112,17 @@ def test_orth_template_tag(orth, inner_text):
 
 
 def test_cree_example():
-    context = Context({"example": "like: wâpamêw"})
-    template = Template("{% load creedictionary_extras %}" "{% cree_example example %}")
+    """
+    Test the {% cree_example 'like: itwêwin' %} tag.
+    """
 
     request = HttpRequest()
     request.COOKIES["orth"] = "Cans"
 
     context = RequestContext(request, {"example": "like: wâpamêw"})
-
+    template = Template("{% load creedictionary_extras %}" "{% cree_example example %}")
     rendered = template.render(context)
-    print(rendered)
+
     assertInHTML(
         f"""
         like: <span lang="cr" data-orth

--- a/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
@@ -2,10 +2,11 @@
 # -*- coding: UTF-8 -*-
 
 import pytest
-from CreeDictionary.templatetags.creedictionary_extras import orth
 from django.http import HttpRequest
 from django.template import Context, RequestContext, Template
 from pytest_django.asserts import assertInHTML
+
+from CreeDictionary.templatetags.creedictionary_extras import orth
 
 
 def test_orth_requires_two_arguments():
@@ -105,6 +106,28 @@ def test_orth_template_tag(orth, inner_text):
               data-orth-Latn="wâpamêw"
               data-orth-latn-x-macron="wāpamēw"
               data-orth-Cans="ᐚᐸᒣᐤ">{inner_text}</span>
+        """,
+        rendered,
+    )
+
+
+def test_cree_example():
+    context = Context({"example": "like: wâpamêw"})
+    template = Template("{% load creedictionary_extras %}" "{% cree_example example %}")
+
+    request = HttpRequest()
+    request.COOKIES["orth"] = "Cans"
+
+    context = RequestContext(request, {"example": "like: wâpamêw"})
+
+    rendered = template.render(context)
+    print(rendered)
+    assertInHTML(
+        f"""
+        like: <span lang="cr" data-orth
+              data-orth-Latn="wâpamêw"
+              data-orth-latn-x-macron="wāpamēw"
+              data-orth-Cans="ᐚᐸᒣᐤ">ᐚᐸᒣᐤ</span>
         """,
         rendered,
     )

--- a/cypress/integration/orthography.spec.js
+++ b/cypress/integration/orthography.spec.js
@@ -105,6 +105,5 @@ describe('Orthography selection', function () {
       cy.visitSearch('ᓃᒥᓈᓂᐘᐣ')
       cy.contains('[data-cy=word-class]', 'like: ᓂᐹᐤ')
     })
-
   })
 })

--- a/cypress/integration/orthography.spec.js
+++ b/cypress/integration/orthography.spec.js
@@ -97,5 +97,14 @@ describe('Orthography selection', function () {
       cy.get('[data-cy=language-selector]')
         .contains('Syllabics')
     })
+
+    it('should display Cree examples in syllabics', function () {
+      cy.setCookie('orth', 'Cans')
+
+      // Visiting a page should be in syllabics
+      cy.visitSearch('ᓃᒥᓈᓂᐘᐣ')
+      cy.contains('[data-cy=word-class]', 'like: ᓂᐹᐤ')
+    })
+
   })
 })


### PR DESCRIPTION
Renders this part properly:

![Screen Shot 2020-06-19 at 10 13 10 AM](https://user-images.githubusercontent.com/2294397/85155090-8b56cb80-b215-11ea-9a55-3cfec0b059ef.png)
