### PR TITLE
Improve paradigm button styles

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -642,6 +642,7 @@ html {
   display: block;
   width: 100%;
   border: 0;
+  padding-top: var(--small-pad);
   padding-bottom: var(--border-radius);
 
   /* Color */
@@ -658,6 +659,12 @@ html {
    * way. */
   --tighter-br: calc(var(--border-radius) - 2px);
   border-radius: 0 0 var(--tighter-br) var(--tighter-br);
+
+  cursor: pointer;
+}
+
+.paradigm__size-toggle-button:hover {
+  background-color: var(--paradigm-button-color-hover);
 }
 
 .paradigm__size-toggle-plus-minus {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -664,7 +664,24 @@ html {
 }
 
 .paradigm__size-toggle-button:hover {
-  background-color: var(--paradigm-button-color-hover);
+  background-color: var(--paradigm-button-color-alt);
+}
+
+.paradigm__size-toggle-button--loading {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    var(--paradigm-button-color),
+    var(--paradigm-button-color) 10px,
+    var(--paradigm-button-color-alt) 10px,
+    var(--paradigm-button-color-alt) 20px
+  );
+
+  animation: paradigm-button-slider 1s linear infinite;
+}
+
+@keyframes paradigm-button-slider {
+    0% { background-position-x: 0px }
+    100% { background-position-x: 30px }
 }
 
 .paradigm__size-toggle-plus-minus {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -663,7 +663,8 @@ html {
   cursor: pointer;
 }
 
-.paradigm__size-toggle-button:hover {
+.paradigm__size-toggle-button:hover,
+.paradigm__size-toggle-button:focus {
   background-color: var(--paradigm-button-color-alt);
 }
 

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -35,7 +35,7 @@
   --box-bg-color:           #FFFDFD; /* Background color of "boxes" */
   --menu-caption-color:     #626262; /* Color of text for menu captions. */
   --paradigm-button-color:  #283C95; /* Color of the paradigm "show more" button. */
-  --paradigm-button-color-hover:  #5A6FCC; /* ... when hovered */
+  --paradigm-button-color-alt:  #5A6FCC; /* ... when hovered or active */
   --paradigm-border-color:  #828A95; /* Color of the paradigm border and button. */
   --prose-heading-color:    #283C95;
   --prose-title-color:      #1D2D72; /* For BIG section titles. */

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -35,6 +35,7 @@
   --box-bg-color:           #FFFDFD; /* Background color of "boxes" */
   --menu-caption-color:     #626262; /* Color of text for menu captions. */
   --paradigm-button-color:  #283C95; /* Color of the paradigm "show more" button. */
+  --paradigm-button-color-hover:  #5A6FCC; /* ... when hovered */
   --paradigm-border-color:  #828A95; /* Color of the paradigm border and button. */
   --prose-heading-color:    #283C95;
   --prose-title-color:      #1D2D72; /* For BIG section titles. */

--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,9 @@ function setupParadigmSizeToggleButton() {
 
   const nextParadigmSize = getNextParadigmSize(paradigmSize)
   toggleButton.addEventListener('click', () => {
+    // Make it look like it's loading:
+    toggleButton.classList.add('paradigm__size-toggle-button--loading')
+
     fetch(Urls['cree-dictionary-lemma-detail']() + `?lemma-id=${lemmaId}&paradigm-size=${nextParadigmSize}`).then(r => {
       if (r.ok) {
         return r.text()


### PR DESCRIPTION
Now it looks like this when it's loading:

![paradigm-loading-button](https://user-images.githubusercontent.com/2294397/85190789-09988980-b279-11ea-89b6-964a0a16e6d0.gif)
