### PR TITLE
refactor: move orthography related things to morphodict

### DIFF
--- a/CreeDictionary/CreeDictionary/orthography.py
+++ b/CreeDictionary/CreeDictionary/orthography.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""
+Orthography conversion utilities.
+"""
+
+
+CIRCUMFLEX_TO_MACRON = str.maketrans("êîôâ", "ēīōā")
+
+
+def to_macrons(sro_circumflex: str) -> str:
+    """
+    Transliterate SRO to macrons.
+    """
+    return sro_circumflex.translate(CIRCUMFLEX_TO_MACRON)

--- a/CreeDictionary/CreeDictionary/orthography.py
+++ b/CreeDictionary/CreeDictionary/orthography.py
@@ -5,6 +5,7 @@
 Orthography conversion utilities.
 """
 
+from cree_sro_syllabics import sro2syllabics
 
 CIRCUMFLEX_TO_MACRON = str.maketrans("êîôâ", "ēīōā")
 
@@ -14,3 +15,11 @@ def to_macrons(sro_circumflex: str) -> str:
     Transliterate SRO to macrons.
     """
     return sro_circumflex.translate(CIRCUMFLEX_TO_MACRON)
+
+
+def to_syllabics(sro_circumflex: str) -> str:
+    """
+    Transliterate SRO to syllabics.
+    """
+    # Get rid of - after prefixes, like nôhte-/ᓄᐦᑌ
+    return sro2syllabics(sro_circumflex).rstrip("-")

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -162,7 +162,10 @@ MORPHODICT_ORTHOGRAPHY = {
             "name": "SRO (ēīōā)",
             "converter": "CreeDictionary.orthography.to_macrons",
         },
-        "Cans": {"name": "Syllabics", "converter": "cree_sro_syllabics.sro2syllabics",},
+        "Cans": {
+            "name": "Syllabics",
+            "converter": "CreeDictionary.orthography.to_syllabics",
+        },
     },
 }
 

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -152,11 +152,23 @@ AUTH_PASSWORD_VALIDATORS = [
 
 ############################### Morphodict configuration ###############################
 
-# Configure the orthographies
+# The ISO 639-1 code is used in the lang="" attributes in HTML.
+MORPHODICT_ISO_639_1_CODE = "cr"
+
+# What orthographies -- writing systems -- are available
+# Plains Cree has two primary orthographies:
+#  - standard Roman orthography (e.g., nêhiyawêwin)
+#  - syllabics (e.g., ᓀᐦᐃᔭᐍᐏᐣ)
+#
+# There may be further sub-variants of each orthography.
+#
+# Morphodict assumes that the `text` of all Wordform are written in the default
+# orthography.
 MORPHODICT_ORTHOGRAPHY = {
-    # 'Latn' is Okimāsis/Wolvegrey's SRO
+    # All entries in Wordform should be written in SRO (êîôâ)
     "default": "Latn",
     "available": {
+        # 'Latn' is Okimāsis/Wolvegrey's SRO
         "Latn": {"name": "SRO (êîôâ)"},
         "Latn-x-macron": {
             "name": "SRO (ēīōā)",

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -150,6 +150,19 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 
+############################### Morphodict configuration ###############################
+
+# Configure the orthographies
+MORPHODICT_ORTHOGRAPHY = {
+    # 'Latn' is Okimāsis/Wolvegrey's SRO
+    "default": "Latn",
+    "available": {
+        "Latn": {"name": "SRO (êîôâ)"},
+        "Latn-x-macron": {"name": "SRO (ēīōā)"},
+        "Cans": {"name": "Syllabics"},
+    },
+}
+
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/
 

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -158,8 +158,11 @@ MORPHODICT_ORTHOGRAPHY = {
     "default": "Latn",
     "available": {
         "Latn": {"name": "SRO (êîôâ)"},
-        "Latn-x-macron": {"name": "SRO (ēīōā)"},
-        "Cans": {"name": "Syllabics"},
+        "Latn-x-macron": {
+            "name": "SRO (ēīōā)",
+            "converter": "CreeDictionary.orthography.to_macrons",
+        },
+        "Cans": {"name": "Syllabics", "converter": "cree_sro_syllabics.sro2syllabics",},
     },
 }
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/about.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/about.html
@@ -1,6 +1,6 @@
 {% extends 'CreeDictionary/base.html' %}
 {% load static %}
-{% load creedictionary_extras %}
+{% load morphodict_orth %}
 
 {% block prose %}
   <section id="source-materials" class="prose box box--spaced">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition-title.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition-title.html
@@ -16,7 +16,7 @@
 
   {% endcomment %}
 
-  {% load creedictionary_extras %}
+  {% load morphodict_orth %}
   {% load static %}
 
   {# First line of the header #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/header.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/header.html
@@ -1,4 +1,3 @@
-{% load creedictionary_extras %}
 {% load morphodict_orth %}
 
 <div class="top-bar app__header">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/header.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/header.html
@@ -1,4 +1,5 @@
 {% load creedictionary_extras %}
+{% load morphodict_orth %}
 
 <div class="top-bar app__header">
   <header class="branding top-bar__logo"><a href="{% url 'cree-dictionary-index' %}">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
@@ -13,7 +13,7 @@
 
   {% endcomment %}
 
-  {% load creedictionary_extras %}
+  {% load morphodict_orth %}
 
   <section class="definition__paradigm paradigm" data-cy="paradigm">
     {# XXX: we should find a better way to contain all the data in the table :/ #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
@@ -2,6 +2,7 @@
 
 {% load static %}
 {% load creedictionary_extras %}
+{% load morphodict_orth %}
 
 {% block prose %}
 <article class="prose box"{% if did_search or lemma_id %} style="display:none"{% endif %}>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
@@ -7,7 +7,7 @@ This should be included or placed dynamical within <main>
 
 {% load static %}
 {% load inflection_extras %}
-{% load creedictionary_extras %}
+{% load morphodict_orth %}
 
 {% spaceless %}
   <article class="definition" id="paradigm">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -1,5 +1,6 @@
 {% load inflection_extras %}
 {% load creedictionary_extras %}
+{% load morphodict_orth %}
 {% load static %}
 
 {% for result in search_results %}

--- a/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
+++ b/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
@@ -5,39 +5,15 @@
 Template tags related to the Cree Dictionary specifically.
 """
 
-from cree_sro_syllabics import sro2syllabics
-from CreeDictionary.utils import url_for_query
 from django import template
 from django.utils.html import format_html
+
+from CreeDictionary.utils import url_for_query
+from morphodict.templatetags.morphodict_orth import orth_tag
 from utils import ORTHOGRAPHY_NAME
 from utils.vars import DEFAULT_ORTHOGRAPHY
 
-CIRCUMFLEX_TO_MACRON = str.maketrans("êîôâ", "ēīōā")
-
 register = template.Library()
-
-
-@register.simple_tag(name="orth", takes_context=True)
-def orth_tag(context, sro_original):
-    """
-    Tag that generates a <span> with multiple orthographical representations
-    of the given text, in SRO. The inner text is determined by the
-    orth= cookie in the HTTP request.
-
-    e.g.,
-
-        {% orth 'wâpamew' %}
-
-    Yields:
-
-        <span lang="cr" data-orth
-              data-orth-latn="wâpamêw"
-              data-orth-latn-x-macron="wāpamēw"
-              data-orth-cans="ᐚᐸᒣᐤ">wâpamêw</span>
-    """
-    # Determine the currently requested orthography:
-    request_orth = context.request.COOKIES.get("orth", DEFAULT_ORTHOGRAPHY)
-    return orth(sro_original, orthography=request_orth)
 
 
 @register.simple_tag(takes_context=True)
@@ -76,49 +52,6 @@ def current_orthography_name(context):
     return ORTHOGRAPHY_NAME[request_orth]
 
 
-@register.filter
-def orth(sro_original: str, orthography):
-    """
-    Filter that generates a <span> with multiple orthographical representations
-    of the given text.
-
-    e.g.,
-
-        {{ 'wâpamêw'|orth }}
-
-    Yields:
-
-        <span lang="cr" data-orth
-              data-orth-latn="wâpamêw"
-              data-orth-latn-x-macron="wāpamēw"
-              data-orth-cans="ᐚᐸᒣᐤ">wâpamêw</span>
-    """
-
-    sro_circumflex = sro_original
-    sro_macrons = to_macrons(sro_original)
-    # Strip "-" from either end of the syllabics.
-    syllabics = sro2syllabics(sro_original).strip("-")
-
-    assert orthography in ORTHOGRAPHY_NAME
-    if orthography == "Latn":
-        inner_text = sro_circumflex
-    elif orthography == "Latn-x-macron":
-        inner_text = sro_macrons
-    elif orthography == "Cans":
-        inner_text = syllabics
-
-    return format_html(
-        '<span lang="cr" data-orth '
-        'data-orth-Latn="{}" '
-        'data-orth-Latn-x-macron="{}" '
-        'data-orth-Cans="{}">{}</span>',
-        sro_circumflex,
-        sro_macrons,
-        syllabics,
-        inner_text,
-    )
-
-
 @register.simple_tag(name="url_for_query")
 def url_for_query_tag(user_query: str) -> str:
     """
@@ -133,10 +66,3 @@ def url_for_query_tag(user_query: str) -> str:
         /search?q=w%C3%A2pam%C3%AAw
     """
     return url_for_query(user_query)
-
-
-def to_macrons(sro_circumflex: str) -> str:
-    """
-    Transliterate SRO to macrons.
-    """
-    return sro_circumflex.translate(CIRCUMFLEX_TO_MACRON)

--- a/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
+++ b/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
@@ -10,8 +10,6 @@ from django.utils.html import format_html
 
 from CreeDictionary.utils import url_for_query
 from morphodict.templatetags.morphodict_orth import orth_tag
-from utils import ORTHOGRAPHY_NAME
-from utils.vars import DEFAULT_ORTHOGRAPHY
 
 register = template.Library()
 
@@ -39,17 +37,6 @@ def cree_example(context, example):
 
     _like, _sp, cree = example.partition(" ")
     return format_html("like: {}", orth_tag(context, cree))
-
-
-@register.simple_tag(takes_context=True)
-def current_orthography_name(context):
-    """
-    Returns a pretty string of the currently active orthography.
-    The orthography is determined by the orth= cookie in the HTTP request.
-    """
-    # Determine the currently requested orthography:
-    request_orth = context.request.COOKIES.get("orth", DEFAULT_ORTHOGRAPHY)
-    return ORTHOGRAPHY_NAME[request_orth]
 
 
 @register.simple_tag(name="url_for_query")

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -1,8 +1,6 @@
 """
 Definition of urls for CreeDictionary.
 """
-import API.views as api_views
-from CreeDictionary import views
 from django.conf import settings
 from django.conf.urls import url
 from django.conf.urls.static import static
@@ -10,6 +8,9 @@ from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
 from django_js_reverse.views import urls_js
+
+import API.views as api_views
+from CreeDictionary import views
 
 # 2019/May/21 Matt Yan:
 
@@ -63,11 +64,7 @@ _urlpatterns = [
         "cree-dictionary-word-translation-api",
     ),
     ("admin/", admin.site.urls, "admin"),
-    (
-        "change-orthography",
-        views.ChangeOrthography.as_view(),
-        "cree-dictionary-change-orthography",
-    ),
+    ("", include("morphodict.urls"), "cree-dictionary-change-orthography",),
 ]
 
 # XXX: ugly hack to make this work on a local instance and on Sapir

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -1,12 +1,14 @@
 from http import HTTPStatus
 
-from API.models import Wordform
-from CreeDictionary.forms import WordSearchForm
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
 from django.shortcuts import redirect, render
 from django.views import View
 from django.views.decorators.http import require_GET
-from utils import ORTHOGRAPHY_NAME, ParadigmSize
+
+from API.models import Wordform
+from CreeDictionary.forms import WordSearchForm
+from morphodict.orthography import ORTHOGRAPHY
+from utils import ParadigmSize
 
 from .utils import url_for_query
 
@@ -183,13 +185,13 @@ class ChangeOrthography(View):
     Supports only POST requests for now.
     """
 
-    AVAILABLE_ORTHOGRAPHIES = tuple(ORTHOGRAPHY_NAME.keys())
+    # TODO: move to morphodict
 
     def post(self, request):
         orth = request.POST.get("orth")
 
         # Tried to set to an unsupported orthography
-        if orth not in self.AVAILABLE_ORTHOGRAPHIES:
+        if orth not in ORTHOGRAPHY.available:
             return HttpResponse(status=HTTPStatus.BAD_REQUEST)
 
         response = HttpResponse(status=HTTPStatus.NO_CONTENT)

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -2,12 +2,10 @@ from http import HTTPStatus
 
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
 from django.shortcuts import redirect, render
-from django.views import View
 from django.views.decorators.http import require_GET
 
 from API.models import Wordform
 from CreeDictionary.forms import WordSearchForm
-from morphodict.orthography import ORTHOGRAPHY
 from utils import ParadigmSize
 
 from .utils import url_for_query
@@ -168,35 +166,6 @@ def contact_us(request):  # pragma: no cover
     Contact us page.
     """
     return render(request, "CreeDictionary/contact-us.html")
-
-
-class ChangeOrthography(View):
-    """
-    Sets the orth= cookie, which affects the default rendered orthography.
-
-        > POST /change-orthography HTTP/1.1
-        > Cookie: orth=Latn
-        >
-        > orth=Cans
-
-        < HTTP/1.1 204 No Content
-        < Set-Cookie: orth=Cans
-
-    Supports only POST requests for now.
-    """
-
-    # TODO: move to morphodict
-
-    def post(self, request):
-        orth = request.POST.get("orth")
-
-        # Tried to set to an unsupported orthography
-        if orth not in ORTHOGRAPHY.available:
-            return HttpResponse(status=HTTPStatus.BAD_REQUEST)
-
-        response = HttpResponse(status=HTTPStatus.NO_CONTENT)
-        response.set_cookie("orth", orth)
-        return response
 
 
 def redirect_search(request, query_string: str):

--- a/CreeDictionary/morphodict/orthography.py
+++ b/CreeDictionary/morphodict/orthography.py
@@ -14,7 +14,9 @@ from django.conf import settings
 class Orthography:
     class _Converter:
         def __getitem__(self, code: str) -> Callable[[str], str]:
-            path = settings.MORPHODICT_ORTHOGRAPHY["available"].get("converter", None)
+            path = settings.MORPHODICT_ORTHOGRAPHY["available"][code].get(
+                "converter", None
+            )
             if path is None:
                 return lambda text: text
 

--- a/CreeDictionary/morphodict/orthography.py
+++ b/CreeDictionary/morphodict/orthography.py
@@ -7,24 +7,23 @@ Handling of the writing system of the language.
 
 from typing import Set
 
-from utils import ORTHOGRAPHY_NAME as _ORTHOGRAPHY_NAME
-from utils.vars import DEFAULT_ORTHOGRAPHY as _DEFAULT_ORTHOGRAPHY
+from django.conf import settings
 
 
 class Orthography:
-    # TODO: get from settings
-    default = _DEFAULT_ORTHOGRAPHY
+    @property
+    def default(self) -> str:
+        return settings.MORPHODICT_ORTHOGRAPHY["default"]
 
     @property
     def available(self) -> Set[str]:
-        # TODO: get from settings
-        return set(_ORTHOGRAPHY_NAME.keys())
+        return set(settings.MORPHODICT_ORTHOGRAPHY["available"].keys())
 
     def name_of(self, code: str) -> str:
         """
         Get the plain English name of the given orthography code.
         """
-        return _ORTHOGRAPHY_NAME[code]
+        return settings.MORPHODICT_ORTHOGRAPHY["available"][code]["name"]
 
 
 ORTHOGRAPHY = Orthography()

--- a/CreeDictionary/morphodict/orthography.py
+++ b/CreeDictionary/morphodict/orthography.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""
+Handling of the writing system of the language.
+"""
+
+from typing import Set
+
+from utils import ORTHOGRAPHY_NAME as _ORTHOGRAPHY_NAME
+from utils.vars import DEFAULT_ORTHOGRAPHY as _DEFAULT_ORTHOGRAPHY
+
+
+class Orthography:
+    # TODO:
+    default = _DEFAULT_ORTHOGRAPHY
+
+    @property
+    def available(self) -> Set[str]:
+        return set(_ORTHOGRAPHY_NAME.keys())
+
+
+ORTHOGRAPHY = Orthography()

--- a/CreeDictionary/morphodict/orthography.py
+++ b/CreeDictionary/morphodict/orthography.py
@@ -5,12 +5,25 @@
 Handling of the writing system of the language.
 """
 
-from typing import Set
+from importlib import import_module
+from typing import Callable, Set
 
 from django.conf import settings
 
 
 class Orthography:
+    class _Converter:
+        def __getitem__(self, code: str) -> Callable[[str], str]:
+            path = settings.MORPHODICT_ORTHOGRAPHY["available"].get("converter", None)
+            if path is None:
+                return lambda text: text
+
+            *module_path, callable_name = path.split(".")
+            module = import_module(".".join(module_path))
+            return getattr(module, callable_name)
+
+    converter = _Converter()
+
     @property
     def default(self) -> str:
         return settings.MORPHODICT_ORTHOGRAPHY["default"]

--- a/CreeDictionary/morphodict/orthography.py
+++ b/CreeDictionary/morphodict/orthography.py
@@ -20,5 +20,11 @@ class Orthography:
         # TODO: get from settings
         return set(_ORTHOGRAPHY_NAME.keys())
 
+    def name_of(self, code: str) -> str:
+        """
+        Get the plain English name of the given orthography code.
+        """
+        return _ORTHOGRAPHY_NAME[code]
+
 
 ORTHOGRAPHY = Orthography()

--- a/CreeDictionary/morphodict/orthography.py
+++ b/CreeDictionary/morphodict/orthography.py
@@ -12,11 +12,12 @@ from utils.vars import DEFAULT_ORTHOGRAPHY as _DEFAULT_ORTHOGRAPHY
 
 
 class Orthography:
-    # TODO:
+    # TODO: get from settings
     default = _DEFAULT_ORTHOGRAPHY
 
     @property
     def available(self) -> Set[str]:
+        # TODO: get from settings
         return set(_ORTHOGRAPHY_NAME.keys())
 
 

--- a/CreeDictionary/morphodict/templatetags/morphodict_orth.py
+++ b/CreeDictionary/morphodict/templatetags/morphodict_orth.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-

--- a/CreeDictionary/morphodict/templatetags/morphodict_orth.py
+++ b/CreeDictionary/morphodict/templatetags/morphodict_orth.py
@@ -10,7 +10,7 @@ register = template.Library()
 
 
 @register.simple_tag(name="orth", takes_context=True)
-def orth_tag(context, sro_original: str) -> str:
+def orth_tag(context, original_text: str) -> str:
     """
     Tag that generates a <span> with multiple orthographical representations
     of the given text, in SRO. The inner text is determined by the
@@ -29,11 +29,11 @@ def orth_tag(context, sro_original: str) -> str:
     """
     # Determine the currently requested orthography:
     request_orth = context.request.COOKIES.get("orth", ORTHOGRAPHY.default)
-    return orth(sro_original, orthography=request_orth)
+    return orth(original_text, orthography=request_orth)
 
 
 @register.filter
-def orth(sro_original: str, orthography: str):
+def orth(original_text: str, orthography: str):
     """
     Filter that generates a <span> with multiple orthographical representations
     of the given text.
@@ -51,7 +51,7 @@ def orth(sro_original: str, orthography: str):
     """
 
     conversions = {
-        code: ORTHOGRAPHY.converter[code](sro_original)
+        code: ORTHOGRAPHY.converter[code](original_text)
         for code in ORTHOGRAPHY.available
     }
     inner_text = conversions[orthography]

--- a/CreeDictionary/morphodict/templatetags/morphodict_orth.py
+++ b/CreeDictionary/morphodict/templatetags/morphodict_orth.py
@@ -2,6 +2,7 @@
 # -*- coding: UTF-8 -*-
 
 from django import template
+from django.conf import settings
 from django.utils.html import format_html
 
 from ..orthography import ORTHOGRAPHY
@@ -58,9 +59,11 @@ def orth(original_text: str, orthography: str):
     data_attributes = " ".join(f'data-orth-{code}="{{}}"' for code in conversions)
     values = tuple(conversions.values()) + (inner_text,)
 
+    language_tag = settings.MORPHODICT_ISO_639_1_CODE
+
     return format_html(
-        # TODO: do not hardcode lang="cr" here
-        '<span lang="cr" data-orth ' + data_attributes + ">{}</span>",
+        '<span lang="{}" data-orth ' + data_attributes + ">{}</span>",
+        language_tag,
         *values,
     )
 

--- a/CreeDictionary/morphodict/templatetags/morphodict_orth.py
+++ b/CreeDictionary/morphodict/templatetags/morphodict_orth.py
@@ -6,11 +6,11 @@ from cree_sro_syllabics import sro2syllabics
 from django import template
 from django.utils.html import format_html
 
+from CreeDictionary.orthography import to_macrons
+
 from ..orthography import ORTHOGRAPHY
 
 register = template.Library()
-
-CIRCUMFLEX_TO_MACRON = str.maketrans("êîôâ", "ēīōā")
 
 
 @register.simple_tag(name="orth", takes_context=True)
@@ -77,13 +77,6 @@ def orth(sro_original: str, orthography):
         syllabics,
         inner_text,
     )
-
-
-def to_macrons(sro_circumflex: str) -> str:
-    """
-    Transliterate SRO to macrons.
-    """
-    return sro_circumflex.translate(CIRCUMFLEX_TO_MACRON)
 
 
 @register.simple_tag(takes_context=True)

--- a/CreeDictionary/morphodict/templatetags/morphodict_orth.py
+++ b/CreeDictionary/morphodict/templatetags/morphodict_orth.py
@@ -6,9 +6,6 @@ from cree_sro_syllabics import sro2syllabics
 from django import template
 from django.utils.html import format_html
 
-# TODO: get rid of this import
-from utils import ORTHOGRAPHY_NAME
-
 from ..orthography import ORTHOGRAPHY
 
 register = template.Library()
@@ -97,4 +94,4 @@ def current_orthography_name(context):
     """
     # Determine the currently requested orthography:
     request_orth = context.request.COOKIES.get("orth", ORTHOGRAPHY.default)
-    return ORTHOGRAPHY_NAME[request_orth]
+    return ORTHOGRAPHY.name_of(request_orth)

--- a/CreeDictionary/morphodict/templatetags/morphodict_orth.py
+++ b/CreeDictionary/morphodict/templatetags/morphodict_orth.py
@@ -1,2 +1,88 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
+
+# TODO: remove this import:
+from cree_sro_syllabics import sro2syllabics
+from django import template
+from django.utils.html import format_html
+
+# TODO: remove this import:
+from utils import ORTHOGRAPHY_NAME
+from utils.vars import DEFAULT_ORTHOGRAPHY
+
+register = template.Library()
+
+CIRCUMFLEX_TO_MACRON = str.maketrans("êîôâ", "ēīōā")
+
+
+@register.simple_tag(name="orth", takes_context=True)
+def orth_tag(context, sro_original: str) -> str:
+    """
+    Tag that generates a <span> with multiple orthographical representations
+    of the given text, in SRO. The inner text is determined by the
+    orth= cookie in the HTTP request.
+
+    e.g.,
+
+        {% orth 'wâpamew' %}
+
+    Yields:
+
+        <span lang="cr" data-orth
+              data-orth-latn="wâpamêw"
+              data-orth-latn-x-macron="wāpamēw"
+              data-orth-cans="ᐚᐸᒣᐤ">wâpamêw</span>
+    """
+    # Determine the currently requested orthography:
+    request_orth = context.request.COOKIES.get("orth", DEFAULT_ORTHOGRAPHY)
+    return orth(sro_original, orthography=request_orth)
+
+
+@register.filter
+def orth(sro_original: str, orthography):
+    """
+    Filter that generates a <span> with multiple orthographical representations
+    of the given text.
+
+    e.g.,
+
+        {{ 'wâpamêw'|orth }}
+
+    Yields:
+
+        <span lang="cr" data-orth
+              data-orth-latn="wâpamêw"
+              data-orth-latn-x-macron="wāpamēw"
+              data-orth-cans="ᐚᐸᒣᐤ">wâpamêw</span>
+    """
+
+    sro_circumflex = sro_original
+    sro_macrons = to_macrons(sro_original)
+    # Strip "-" from either end of the syllabics.
+    syllabics = sro2syllabics(sro_original).strip("-")
+
+    assert orthography in ORTHOGRAPHY_NAME
+    if orthography == "Latn":
+        inner_text = sro_circumflex
+    elif orthography == "Latn-x-macron":
+        inner_text = sro_macrons
+    elif orthography == "Cans":
+        inner_text = syllabics
+
+    return format_html(
+        '<span lang="cr" data-orth '
+        'data-orth-Latn="{}" '
+        'data-orth-Latn-x-macron="{}" '
+        'data-orth-Cans="{}">{}</span>',
+        sro_circumflex,
+        sro_macrons,
+        syllabics,
+        inner_text,
+    )
+
+
+def to_macrons(sro_circumflex: str) -> str:
+    """
+    Transliterate SRO to macrons.
+    """
+    return sro_circumflex.translate(CIRCUMFLEX_TO_MACRON)

--- a/CreeDictionary/morphodict/templatetags/morphodict_orth.py
+++ b/CreeDictionary/morphodict/templatetags/morphodict_orth.py
@@ -6,6 +6,9 @@ from cree_sro_syllabics import sro2syllabics
 from django import template
 from django.utils.html import format_html
 
+# TODO: get rid of this import
+from utils import ORTHOGRAPHY_NAME
+
 from ..orthography import ORTHOGRAPHY
 
 register = template.Library()
@@ -84,3 +87,14 @@ def to_macrons(sro_circumflex: str) -> str:
     Transliterate SRO to macrons.
     """
     return sro_circumflex.translate(CIRCUMFLEX_TO_MACRON)
+
+
+@register.simple_tag(takes_context=True)
+def current_orthography_name(context):
+    """
+    Returns a pretty string of the currently active orthography.
+    The orthography is determined by the orth= cookie in the HTTP request.
+    """
+    # Determine the currently requested orthography:
+    request_orth = context.request.COOKIES.get("orth", ORTHOGRAPHY.default)
+    return ORTHOGRAPHY_NAME[request_orth]

--- a/CreeDictionary/morphodict/templatetags/morphodict_orth.py
+++ b/CreeDictionary/morphodict/templatetags/morphodict_orth.py
@@ -6,9 +6,7 @@ from cree_sro_syllabics import sro2syllabics
 from django import template
 from django.utils.html import format_html
 
-# TODO: remove this import:
-from utils import ORTHOGRAPHY_NAME
-from utils.vars import DEFAULT_ORTHOGRAPHY
+from ..orthography import ORTHOGRAPHY
 
 register = template.Library()
 
@@ -34,7 +32,7 @@ def orth_tag(context, sro_original: str) -> str:
               data-orth-cans="ᐚᐸᒣᐤ">wâpamêw</span>
     """
     # Determine the currently requested orthography:
-    request_orth = context.request.COOKIES.get("orth", DEFAULT_ORTHOGRAPHY)
+    request_orth = context.request.COOKIES.get("orth", ORTHOGRAPHY.default)
     return orth(sro_original, orthography=request_orth)
 
 
@@ -61,7 +59,7 @@ def orth(sro_original: str, orthography):
     # Strip "-" from either end of the syllabics.
     syllabics = sro2syllabics(sro_original).strip("-")
 
-    assert orthography in ORTHOGRAPHY_NAME
+    assert orthography in ORTHOGRAPHY.available
     if orthography == "Latn":
         inner_text = sro_circumflex
     elif orthography == "Latn-x-macron":

--- a/CreeDictionary/morphodict/tests/test_orth_templatetags.py
+++ b/CreeDictionary/morphodict/tests/test_orth_templatetags.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+import pytest
+
+from morphodict.templatetags.morphodict_orth import orth
+
+
+def test_orth_requires_two_arguments():
+    """
+    orth() original only took one argument, but now it must take two.
+    """
+    with pytest.raises(TypeError):
+        orth("wâpamêw")

--- a/CreeDictionary/morphodict/urls.py
+++ b/CreeDictionary/morphodict/urls.py
@@ -6,4 +6,10 @@ from django.urls import path
 from . import views
 
 app_name = "morphodict"
-urlpatterns = [path("change-orthography", views.ChangeOrthography.as_view())]
+urlpatterns = [
+    path(
+        "change-orthography",
+        views.ChangeOrthography.as_view(),
+        name="change-orthography",
+    ),
+]

--- a/CreeDictionary/morphodict/urls.py
+++ b/CreeDictionary/morphodict/urls.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from django.urls import path
+
+from . import views
+
+app_name = "morphodict"
+urlpatterns = [path("change-orthography", views.ChangeOrthography.as_view())]

--- a/CreeDictionary/morphodict/views.py
+++ b/CreeDictionary/morphodict/views.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from django.views import View
+
+from .orthography import ORTHOGRAPHY
+
+
+class ChangeOrthography(View):
+    """
+    Sets the orth= cookie, which affects the default rendered orthography.
+
+        > POST /change-orthography HTTP/1.1
+        > Cookie: orth=Latn
+        >
+        > orth=Cans
+
+        < HTTP/1.1 204 No Content
+        < Set-Cookie: orth=Cans
+
+    Supports only POST requests for now.
+    """
+
+    # TODO: move to morphodict
+
+    def post(self, request):
+        orth = request.POST.get("orth")
+
+        # Tried to set to an unsupported orthography
+        if orth not in ORTHOGRAPHY.available:
+            return HttpResponse(status=HTTPStatus.BAD_REQUEST)
+
+        response = HttpResponse(status=HTTPStatus.NO_CONTENT)
+        response.set_cookie("orth", orth)
+        return response

--- a/CreeDictionary/morphodict/views.py
+++ b/CreeDictionary/morphodict/views.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
+from http import HTTPStatus
+
+from django.http import HttpResponse
 from django.views import View
 
 from .orthography import ORTHOGRAPHY
@@ -20,8 +23,6 @@ class ChangeOrthography(View):
 
     Supports only POST requests for now.
     """
-
-    # TODO: move to morphodict
 
     def post(self, request):
         orth = request.POST.get("orth")

--- a/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
@@ -136,9 +136,7 @@ def test_current_orthography_name_tag(orth, name):
         request.COOKIES["orth"] = orth
 
     context = RequestContext(request)
-    template = Template(
-        "{% load creedictionary_extras %}" "{% current_orthography_name %}"
-    )
+    template = Template("{% load morphodict_orth %}" "{% current_orthography_name %}")
     rendered_html = template.render(context)
     assert name in rendered_html
 

--- a/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
@@ -2,23 +2,14 @@
 # -*- coding: UTF-8 -*-
 
 import pytest
-from CreeDictionary.templatetags.creedictionary_extras import orth
 from django.http import HttpRequest
 from django.template import Context, RequestContext, Template
 from pytest_django.asserts import assertInHTML
 
 
-def test_orth_requires_two_arguments():
-    """
-    orth() original only took one argument, but now it must take two.
-    """
-    with pytest.raises(TypeError):
-        orth("wâpamêw")
-
-
 def test_produces_correct_markup():
     context = Context({"wordform": "wâpamêw"})
-    template = Template("{% load creedictionary_extras %}" "{{ wordform|orth:'Latn' }}")
+    template = Template("{% load morphodict_orth %}" "{{ wordform|orth:'Latn' }}")
 
     rendered = template.render(context)
     assert 'lang="cr"' in rendered
@@ -42,7 +33,7 @@ def test_naughty_html():
     """
 
     context = Context({"wordform": '<img alt="tâpwêw">'})
-    template = Template("{% load creedictionary_extras %}" "{{ wordform|orth:'Latn' }}")
+    template = Template("{% load morphodict_orth %}" "{{ wordform|orth:'Latn' }}")
 
     rendered = template.render(context)
     assertInHTML(
@@ -63,7 +54,7 @@ def test_naughty_html():
 def test_provide_orthograpy(orth, inner_text):
     context = Context({"wordform": "wâpamêw"})
     template = Template(
-        "{% load creedictionary_extras %}" "{{ wordform|orth:" + repr(orth) + " }}"
+        "{% load morphodict_orth %}" "{{ wordform|orth:" + repr(orth) + " }}"
     )
 
     rendered = template.render(context)
@@ -96,7 +87,7 @@ def test_orth_template_tag(orth, inner_text):
         request.COOKIES["orth"] = orth
 
     context = RequestContext(request, {"wordform": "wâpamêw"})
-    template = Template("{% load creedictionary_extras %}" "{% orth wordform %}")
+    template = Template("{% load morphodict_orth %}" "{% orth wordform %}")
     rendered = template.render(context)
 
     assertInHTML(
@@ -159,7 +150,7 @@ def test_no_hyphens_in_syllabics():
     See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/314
     """
     context = Context({"wordform": "nôhtê-"})
-    template = Template("{% load creedictionary_extras %}" "{{ wordform|orth:'Cans' }}")
+    template = Template("{% load morphodict_orth %}" "{{ wordform|orth:'Cans' }}")
 
     rendered = template.render(context)
     assertInHTML(

--- a/CreeDictionary/tests/CreeDictionary_tests/test_orth_cookie.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_orth_cookie.py
@@ -61,4 +61,4 @@ def test_no_orthography(client, change_orth_url):
 
 @pytest.fixture
 def change_orth_url():
-    return reverse("cree-dictionary-change-orthography")
+    return reverse("morphodict:change-orthography")

--- a/CreeDictionary/tests/test_usage_of_morphodict.py
+++ b/CreeDictionary/tests/test_usage_of_morphodict.py
@@ -20,3 +20,4 @@ def test_morphodict_orthography():
 )
 def test_each_orthography(code, name):
     assert name in ORTHOGRAPHY.name_of(code)
+    assert callable(ORTHOGRAPHY.converter[code])

--- a/CreeDictionary/tests/test_usage_of_morphodict.py
+++ b/CreeDictionary/tests/test_usage_of_morphodict.py
@@ -2,7 +2,7 @@
 # -*- coding: UTF-8 -*-
 
 """
-Integration test of settings.py and morphodict application.
+Test the integration of itwêwina's settings.py against the morphodict application.
 """
 
 import pytest

--- a/CreeDictionary/tests/test_usage_of_morphodict.py
+++ b/CreeDictionary/tests/test_usage_of_morphodict.py
@@ -16,8 +16,15 @@ def test_morphodict_orthography():
 
 
 @pytest.mark.parametrize(
-    "code,name", [("Latn", "SRO"), ("Latn-x-macron", "SRO"), ("Cans", "Syllabics"),]
+    "code,name,example",
+    [
+        ("Latn", "SRO", "amiskwaciy-wâskahikanihk"),
+        ("Latn-x-macron", "SRO", "amiskwaciy-wāskahikanihk"),
+        ("Cans", "Syllabics", "ᐊᒥᐢᑿᒋᐩ ᐚᐢᑲᐦᐃᑲᓂᕽ"),
+    ],
 )
-def test_each_orthography(code, name):
+def test_each_orthography(code, name, example):
+    internal_text = "amiskwaciy-wâskahikanihk"
     assert name in ORTHOGRAPHY.name_of(code)
     assert callable(ORTHOGRAPHY.converter[code])
+    assert ORTHOGRAPHY.converter[code](internal_text) == example

--- a/CreeDictionary/tests/test_usage_of_morphodict.py
+++ b/CreeDictionary/tests/test_usage_of_morphodict.py
@@ -7,3 +7,6 @@ from morphodict.orthography import ORTHOGRAPHY
 def test_morphodict_orthography():
     assert ORTHOGRAPHY.default == "Latn"
     assert {"Latn", "Cans", "Latn-x-macron"} <= set(ORTHOGRAPHY.available)
+    assert "SRO" in ORTHOGRAPHY.name_of("Latn")
+    assert "SRO" in ORTHOGRAPHY.name_of("Latn-x-macron")
+    assert "Syllabics" in ORTHOGRAPHY.name_of("Cans")

--- a/CreeDictionary/tests/test_usage_of_morphodict.py
+++ b/CreeDictionary/tests/test_usage_of_morphodict.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from morphodict.orthography import ORTHOGRAPHY
+
+
+def test_morphodict_orthography():
+    assert ORTHOGRAPHY.default == "Latn"
+    assert {"Latn", "Cans", "Latn-x-macron"} <= set(ORTHOGRAPHY.available)

--- a/CreeDictionary/tests/test_usage_of_morphodict.py
+++ b/CreeDictionary/tests/test_usage_of_morphodict.py
@@ -1,12 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
+"""
+Integration test of settings.py and morphodict application.
+"""
+
+import pytest
+
 from morphodict.orthography import ORTHOGRAPHY
 
 
 def test_morphodict_orthography():
     assert ORTHOGRAPHY.default == "Latn"
     assert {"Latn", "Cans", "Latn-x-macron"} <= set(ORTHOGRAPHY.available)
-    assert "SRO" in ORTHOGRAPHY.name_of("Latn")
-    assert "SRO" in ORTHOGRAPHY.name_of("Latn-x-macron")
-    assert "Syllabics" in ORTHOGRAPHY.name_of("Cans")
+
+
+@pytest.mark.parametrize(
+    "code,name", [("Latn", "SRO"), ("Latn-x-macron", "SRO"), ("Cans", "Syllabics"),]
+)
+def test_each_orthography(code, name):
+    assert name in ORTHOGRAPHY.name_of(code)

--- a/CreeDictionary/utils/vars.py
+++ b/CreeDictionary/utils/vars.py
@@ -1,6 +1,1 @@
-DEFAULT_ORTHOGRAPHY = "Latn"
-ORTHOGRAPHY_NAME = {
-    "Latn": "SRO (êîôâ)",
-    "Latn-x-macron": "SRO (ēīōā)",
-    "Cans": "Syllabics",
-}
+# Place global variables here!

--- a/src/orthography.js
+++ b/src/orthography.js
@@ -107,7 +107,7 @@ function updateCookies(orth) {
     throw new Error('djangoCSRFToken is unset!')
   }
 
-  let changeOrthURL = window.Urls['cree-dictionary-change-orthography']()
+  let changeOrthURL = window.Urls['morphodict:change-orthography']()
   fetch(changeOrthURL, {
     method: 'POST',
     body: new URLSearchParams({


### PR DESCRIPTION
This leaves Cree-specific orthography stuff in `CreeDictionary.orthography` and refactors language-agnostic stuff to the `morphodict` app. `morphodict` is configured in `settings.py`.