### PR TITLE
Fix bad reformat action/Refactor util imports

### DIFF
--- a/.github/workflows/reformat.yml
+++ b/.github/workflows/reformat.yml
@@ -13,10 +13,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.head_ref }}
-    - name: Set up Python 3.8
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.6
     - name: Reformat
       run: ./libexec/altlabel_utils.py format
     - name: Git Auto Commit
@@ -32,10 +32,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.head_ref }}
-    - name: Set up Python 3.8
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.6
     - name: Install dependencies
       run: "pip install 'isort[pyproject]==4.3.21' black"
     - name: Reformat Python

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -21,8 +21,6 @@ from urllib.parse import quote
 
 import attr
 from attr import attrs
-
-import CreeDictionary.hfstol as temp_hfstol
 from cree_sro_syllabics import syllabics2sro
 from django.conf import settings
 from django.db import models, transaction
@@ -30,13 +28,12 @@ from django.db.models import Max, Q, QuerySet
 from django.forms import model_to_dict
 from django.urls import reverse
 from django.utils.functional import cached_property
+from sortedcontainers import SortedSet
+
+import CreeDictionary.hfstol as temp_hfstol
 from paradigm import Layout
 from shared import paradigm_filler
-from sortedcontainers import SortedSet
 from utils import (
-    ConcatAnalysis,
-    FSTTag,
-    Label,
     Language,
     ParadigmSize,
     PartOfSpeech,
@@ -46,6 +43,7 @@ from utils import (
 )
 from utils.cree_lev_dist import remove_cree_diacritics
 from utils.fst_analysis_parser import LABELS, partition_analysis
+from utils.types import ConcatAnalysis, FSTTag, Label
 
 from .affix_search import AffixSearcher
 from .schema import SerializedDefinition, SerializedSearchResult, SerializedWordform

--- a/CreeDictionary/DatabaseManager/xml_entry_lemma_finder.py
+++ b/CreeDictionary/DatabaseManager/xml_entry_lemma_finder.py
@@ -16,8 +16,9 @@ from DatabaseManager.xml_consistency_checker import (
     does_inflectional_category_match_xml_entry,
 )
 from shared import strict_analyzer
-from utils import ConcatAnalysis, FSTLemma, WordClass, shared_res_dir, XMLEntry
+from utils import WordClass, XMLEntry, shared_res_dir
 from utils.crkeng_xml_utils import IndexedXML
+from utils.types import ConcatAnalysis, FSTLemma
 
 init()  # for windows compatibility
 

--- a/CreeDictionary/DatabaseManager/xml_entry_lemma_finder.py
+++ b/CreeDictionary/DatabaseManager/xml_entry_lemma_finder.py
@@ -10,14 +10,15 @@ from typing import Dict, List, Optional, Set, Tuple
 from colorama import Fore, init
 from typing_extensions import Literal
 
-import utils
+import utils.fst_analysis_parser
 from DatabaseManager.log import DatabaseManagerLogger
 from DatabaseManager.xml_consistency_checker import (
     does_inflectional_category_match_xml_entry,
 )
 from shared import strict_analyzer
-from utils import WordClass, XMLEntry, shared_res_dir
+from utils import WordClass, shared_res_dir
 from utils.crkeng_xml_utils import IndexedXML
+from utils.data_classes import XMLEntry
 from utils.types import ConcatAnalysis, FSTLemma
 
 init()  # for windows compatibility
@@ -96,7 +97,7 @@ def identify_entries(
         ConcatAnalysis, Tuple[FSTLemma, WordClass]
     ] = dict()
     for fst_analysis in chain.from_iterable(l_to_analyses.values()):
-        x = utils.extract_lemma_text_and_word_class(fst_analysis)
+        x = utils.fst_analysis_parser.extract_lemma_text_and_word_class(fst_analysis)
         assert x is not None
         produced_lemma, wc = x
         fst_analysis_to_fst_lemma_wc[fst_analysis] = produced_lemma, wc
@@ -108,7 +109,7 @@ def identify_entries(
     ] = strict_analyzer.feed_in_bulk_fast(produced_extra_lemmas)
 
     for fst_analysis in chain.from_iterable(produced_extra_lemma_to_analysis.values()):
-        x = utils.extract_lemma_text_and_word_class(fst_analysis)
+        x = utils.fst_analysis_parser.extract_lemma_text_and_word_class(fst_analysis)
         assert x is not None
         produced_lemma, wc = x
         fst_analysis_to_fst_lemma_wc[fst_analysis] = produced_lemma, wc
@@ -143,7 +144,9 @@ def identify_entries(
                 fst_lemma_analyses = all_lemma_to_analysis[fst_lemma]
 
                 for fst_lemma_analysis in fst_lemma_analyses:
-                    x = utils.extract_lemma_text_and_word_class(fst_lemma_analysis)
+                    x = utils.fst_analysis_parser.extract_lemma_text_and_word_class(
+                        fst_lemma_analysis
+                    )
                     assert x is not None
                     wordform, wc = x
                     if wc is wc and wordform == fst_lemma:

--- a/CreeDictionary/DatabaseManager/xml_importer.py
+++ b/CreeDictionary/DatabaseManager/xml_importer.py
@@ -2,14 +2,7 @@ import re
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 from pathlib import Path
-from typing import (
-    DefaultDict,
-    Dict,
-    List,
-    NamedTuple,
-    Set,
-    Tuple,
-)
+from typing import DefaultDict, Dict, List, NamedTuple, Set, Tuple
 
 from colorama import init
 
@@ -20,15 +13,12 @@ from DatabaseManager.log import DatabaseManagerLogger
 from DatabaseManager.xml_consistency_checker import (
     does_inflectional_category_match_xml_entry,
 )
-from utils import (
-    PartOfSpeech,
-    fst_analysis_parser,
-    XMLEntry,
-)
+from utils import PartOfSpeech, fst_analysis_parser
 from utils.crkeng_xml_utils import (
-    convert_xml_inflectional_category_to_word_class,
     IndexedXML,
+    convert_xml_inflectional_category_to_word_class,
 )
+from utils.data_classes import XMLEntry
 from utils.profiling import timed
 
 init()  # for windows compatibility

--- a/CreeDictionary/tests/DatabaseManager_tests/xml_entry_lemma_finder_test.py
+++ b/CreeDictionary/tests/DatabaseManager_tests/xml_entry_lemma_finder_test.py
@@ -1,12 +1,12 @@
+from io import StringIO
 from textwrap import dedent
 from typing import List, Tuple
 
 import pytest
-from DatabaseManager.xml_entry_lemma_finder import identify_entries
-from utils import XMLEntry, XMLTranslation
-from io import StringIO
 
+from DatabaseManager.xml_entry_lemma_finder import identify_entries
 from utils.crkeng_xml_utils import IndexedXML
+from utils.data_classes import XMLEntry, XMLTranslation
 
 
 def _xml_translation_to_str(xml_translation: XMLTranslation) -> str:

--- a/CreeDictionary/tests/utils_tests/test_general.py
+++ b/CreeDictionary/tests/utils_tests/test_general.py
@@ -5,8 +5,10 @@ todo: delete this file
 import xml.etree.ElementTree as ET
 
 import pytest
-from utils import WordClass, extract_word_class, fst_analysis_parser
+
+from utils import WordClass
 from utils.crkeng_xml_utils import extract_l_str
+from utils.fst_analysis_parser import extract_lemma, extract_word_class
 
 
 @pytest.mark.parametrize(
@@ -24,7 +26,7 @@ from utils.crkeng_xml_utils import extract_l_str
     ],
 )
 def test_hfstol_analysis_lemma_extraction(analysis, real_lemma):
-    claimed = fst_analysis_parser.extract_lemma(analysis)
+    claimed = extract_lemma(analysis)
     assert claimed == real_lemma
 
 

--- a/CreeDictionary/utils/__init__.py
+++ b/CreeDictionary/utils/__init__.py
@@ -3,5 +3,4 @@ from .data_classes import *
 from .enums import *
 from .fst_analysis_parser import extract_lemma_text_and_word_class, extract_word_class
 from .shared_res_dir import shared_res_dir
-from .types import *
 from .vars import *

--- a/CreeDictionary/utils/__init__.py
+++ b/CreeDictionary/utils/__init__.py
@@ -1,6 +1,4 @@
 from .cree_lev_dist import get_modified_distance
-from .data_classes import *
 from .enums import *
-from .fst_analysis_parser import extract_lemma_text_and_word_class, extract_word_class
 from .shared_res_dir import shared_res_dir
 from .vars import *

--- a/CreeDictionary/utils/crkeng_xml_utils.py
+++ b/CreeDictionary/utils/crkeng_xml_utils.py
@@ -21,7 +21,8 @@ from typing import (
 from xml.dom import minidom
 from xml.etree import ElementTree as ET
 
-from utils import WordClass, XMLEntry, XMLTranslation
+from utils import WordClass
+from utils.data_classes import XMLEntry, XMLTranslation
 from utils.types import HashableNamedTupleFieldValue, NamedTupleFieldName
 
 logger = logging.getLogger(__name__)

--- a/CreeDictionary/utils/crkeng_xml_utils.py
+++ b/CreeDictionary/utils/crkeng_xml_utils.py
@@ -4,31 +4,25 @@ from collections import defaultdict
 from itertools import chain
 from pathlib import Path
 from typing import (
-    Iterable,
-    Optional,
+    DefaultDict,
     Dict,
-    Tuple,
-    Set,
+    Hashable,
+    Iterable,
     Iterator,
     List,
-    Hashable,
-    cast,
-    DefaultDict,
-    Union,
     NamedTuple,
+    Optional,
+    Set,
     TextIO,
+    Tuple,
+    Union,
+    cast,
 )
+from xml.dom import minidom
 from xml.etree import ElementTree as ET
 
-from xml.dom import minidom
-
-from utils import (
-    WordClass,
-    XMLEntry,
-    NamedTupleFieldName,
-    HashableNamedTupleFieldValue,
-    XMLTranslation,
-)
+from utils import WordClass, XMLEntry, XMLTranslation
+from utils.types import HashableNamedTupleFieldValue, NamedTupleFieldName
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The GitHub action now:

  - [x] uses the same Python as the rest of the project :joy:

The `util` module:

 - [x] no longer star imports anything that may import a non-default module (e.g., `typing_extensions`)