### PR TITLE
Use paradigm filler in cree_inflection_generator

### DIFF
--- a/CreeDictionary/DatabaseManager/cree_inflection_generator.py
+++ b/CreeDictionary/DatabaseManager/cree_inflection_generator.py
@@ -27,7 +27,8 @@ def expand_inflections(
 
     analyses = list(analyses)
     to_generated: Dict[str, List[str]] = {}
-    fat_generated_analyses = []
+    # We'll generate all of the forms for analyses enqueued here in one fell swoop.
+    analysis_queue = []
 
     for analysis in analyses:
         lemma_category = fst_analysis_parser.extract_lemma_text_and_word_class(analysis)
@@ -40,13 +41,13 @@ def expand_inflections(
             generated_analyses = [analysis]
 
         to_generated[analysis] = generated_analyses
-        fat_generated_analyses.extend(generated_analyses)
+        analysis_queue.extend(generated_analyses)
 
     logger.info("Generating inflections using %d processes..." % multi_processing)
 
     # optimized for efficiency by calling hfstol once and for all
     generated_analyses_to_inflections = normative_generator.feed_in_bulk_fast(
-        fat_generated_analyses, multi_processing
+        analysis_queue, multi_processing
     )
 
     logger.info("Done generating inflections")

--- a/CreeDictionary/DatabaseManager/cree_inflection_generator.py
+++ b/CreeDictionary/DatabaseManager/cree_inflection_generator.py
@@ -11,30 +11,7 @@ from typing import Dict, Iterable, List, Set, Tuple
 from DatabaseManager.log import DatabaseManagerLogger
 from shared import normative_generator
 from utils import WordClass, fst_analysis_parser
-
-
-def import_flattened_prefilled_layouts(
-    layout_file_dir: Path,
-) -> Dict[WordClass, List[str]]:
-    """
-    >>> import_flattened_prefilled_layouts(Path(dirname(__file__)) / '..' / 'res' / 'prefilled_layouts')[WordClass.NID]
-    ['{{ lemma }}+N+I+D+PxX+Sg', '{{ lemma }}+N+I+D+PxX+Pl', '{{ lemma }}+N+I+D+PxX+Loc', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+PxX+Sg', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+PxX+Pl', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+PxX+Loc', '{{ lemma }}+N+I+D+Px1Sg+Sg', '{{ lemma }}+N+I+D+Px1Sg+Pl', '{{ lemma }}+N+I+D+Px1Sg+Loc', '{{ lemma }}+N+I+D+Px2Sg+Sg', '{{ lemma }}+N+I+D+Px2Sg+Pl', '{{ lemma }}+N+I+D+Px2Sg+Loc', '{{ lemma }}+N+I+D+Px3Sg+Sg', '{{ lemma }}+N+I+D+Px3Sg+Pl', '{{ lemma }}+N+I+D+Px3Sg+Loc', '{{ lemma }}+N+I+D+Px1Pl+Sg', '{{ lemma }}+N+I+D+Px1Pl+Pl', '{{ lemma }}+N+I+D+Px1Pl+Loc', '{{ lemma }}+N+I+D+Px12Pl+Sg', '{{ lemma }}+N+I+D+Px12Pl+Pl', '{{ lemma }}+N+I+D+Px12Pl+Loc', '{{ lemma }}+N+I+D+Px2Pl+Sg', '{{ lemma }}+N+I+D+Px2Pl+Pl', '{{ lemma }}+N+I+D+Px2Pl+Loc', '{{ lemma }}+N+I+D+Px3Pl+Sg', '{{ lemma }}+N+I+D+Px3Pl+Pl', '{{ lemma }}+N+I+D+Px3Pl+Loc', '{{ lemma }}+N+I+D+Px4Sg/Pl+Sg', '{{ lemma }}+N+I+D+Px4Sg/Pl+Pl', '{{ lemma }}+N+I+D+Px4Sg/Pl+Loc', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px1Sg+Sg', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px1Sg+Pl', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px1Sg+Loc', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px2Sg+Sg', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px2Sg+Pl', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px2Sg+Loc', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px3Sg+Sg', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px3Sg+Pl', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px3Sg+Loc', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px1Pl+Sg', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px1Pl+Pl', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px1Pl+Loc', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px12Pl+Sg', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px12Pl+Pl', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px12Pl+Loc', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px2Pl+Sg', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px2Pl+Pl', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px2Pl+Loc', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px3Pl+Sg', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px3Pl+Pl', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px3Pl+Loc', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px4Sg/Pl+Sg', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px4Sg/Pl+Pl', '{{ lemma }}+N+I+D+Der/Dim+N+I+D+Px4Sg/Pl+Loc']
-    """
-    flattened_layouts = dict()
-    files = glob.glob(str(layout_file_dir / "*-linguistic*.tsv"))
-    for file in files:
-
-        name_wo_extension = str(path.split(file)[1]).split(".")[0]
-
-        with open(file, "r") as f:
-
-            reader = csv.reader(f, delimiter="\t", quotechar="'")
-            flattened_layout = [
-                cell for row in reader for cell in row if '"' not in cell and cell != ""
-            ]
-            ic_str, size_str = name_wo_extension.split("-")
-            flattened_layouts[WordClass(ic_str.upper())] = flattened_layout
-    return flattened_layouts
+from utils.paradigm_filler import ParadigmFiller
 
 
 def expand_inflections(
@@ -46,41 +23,38 @@ def expand_inflections(
     """
     logger = DatabaseManagerLogger(__name__, verbose)
 
-    # optimized for efficiency by calling hfstol once and for all
-    flattened_layouts = import_flattened_prefilled_layouts(
-        Path(dirname(__file__)) / ".." / "res" / "prefilled_layouts"
-    )
-    fat_generated_analyses = []
+    paradigm_filler = ParadigmFiller.default_filler()
 
     analyses = list(analyses)
-
-    to_generated = dict()  # type: Dict[str, List[str]]
+    to_generated: Dict[str, List[str]] = {}
+    fat_generated_analyses = []
 
     for analysis in analyses:
         lemma_category = fst_analysis_parser.extract_lemma_text_and_word_class(analysis)
         assert lemma_category is not None
         lemma, category = lemma_category
-        if category.is_verb() or category.is_noun():
-            generated_analyses = [
-                generated_analysis.replace("{{ lemma }}", lemma)
-                for generated_analysis in flattened_layouts[category]
-            ]
+
+        if category.has_inflections():
+            generated_analyses = list(paradigm_filler.expand_analyses(lemma, category))
         else:
             generated_analyses = [analysis]
+
         to_generated[analysis] = generated_analyses
         fat_generated_analyses.extend(generated_analyses)
 
     logger.info("Generating inflections using %d processes..." % multi_processing)
+
+    # optimized for efficiency by calling hfstol once and for all
     generated_analyses_to_inflections = normative_generator.feed_in_bulk_fast(
         fat_generated_analyses, multi_processing
     )
 
     logger.info("Done generating inflections")
 
-    expanded = dict()
+    expanded = {}
 
     for analysis in analyses:
-        pooled_generated_words = list()
+        pooled_generated_words = []
         for generated_analysis in to_generated[analysis]:
             pooled_generated_words.append(
                 (

--- a/CreeDictionary/tests/utils_tests/data/layouts/noun-nid-full.layout
+++ b/CreeDictionary/tests/utils_tests/data/layouts/noun-nid-full.layout
@@ -24,7 +24,7 @@ tooltips:
 | "someone's"               | =N+I+D+PxX+Sg            | =N+I+D+PxX+Pl           | =N+I+D+PxX+Loc             |
 | "my"                      | =N+I+D+Px1Sg+Sg          | =N+I+D+Px1Sg+Pl         | =N+I+D+Px1Sg+Loc           |
 | "your (one)"              | =N+I+D+Px2Sg+Sg          | =N+I+D+Px2Sg+Pl         | =N+I+D+Px2Sg+Loc           |
-| "his/her"                 |                          |                         | =N+I+D+Px3Sg+Loc           |
+| "his/her"                 | =N+I+D+Px3Sg+Sg          | =N+I+D+Px3Sg+Pl         | =N+I+D+Px3Sg+Loc           |
 | "our (but not your)"      | =N+I+D+Px1Pl+Sg          | =N+I+D+Px1Pl+Pl         | =N+I+D+Px1Pl+Loc           |
 | "your and our"            | =N+I+D+Px12Pl+Sg         | =N+I+D+Px12Pl+Pl        | =N+I+D+Px12Pl+Loc          |
 | "your (all)"              | =N+I+D+Px2Pl+Sg          | =N+I+D+Px2Pl+Pl         | =N+I+D+Px2Pl+Loc           |

--- a/CreeDictionary/tests/utils_tests/test_paradigm_filler.py
+++ b/CreeDictionary/tests/utils_tests/test_paradigm_filler.py
@@ -125,6 +125,14 @@ def test_fill_NA_Full(
     )
 
 
+def test_fill_VTA_full(paradigm_filler) -> None:
+    lemma = "wâpamêw"
+    wordclass = WordClass.VTA
+    lower_bound = 2  # TODO: not really sure what to set this as
+    forms = paradigm_filler.inflect_all(lemma, wordclass)
+    assert len(forms) > 2
+
+
 @pytest.fixture
 def paradigm_filler(shared_datadir) -> ParadigmFiller:
     """

--- a/CreeDictionary/tests/utils_tests/test_paradigm_filler.py
+++ b/CreeDictionary/tests/utils_tests/test_paradigm_filler.py
@@ -146,6 +146,29 @@ def test_inflect_all(
     assert examples <= forms
 
 
+def test_inflect_all_with_analyses(paradigm_filler) -> None:
+    """
+    Smoke test for inflect_all_with_analyses()
+    """
+
+    lemma = "wâpamêw"
+    stem = "wâpam"
+    inflections = paradigm_filler.inflect_all_with_analyses(lemma, WordClass.VTA)
+
+    assert len(inflections.keys()) >= 1
+
+    analysis = next(iter(inflections.keys()))
+    assert lemma in analysis
+    assert "+" in analysis, "expected to find the tag separator in the analysis"
+
+    all_forms = [form for inflection in inflections.values() for form in inflection]
+    assert len(all_forms) >= len(inflections)
+    random_form = all_forms[0]
+    assert (
+        stem in random_form
+    ), f"could not find stem {stem} in regular inflection {random_form}"
+
+
 @pytest.fixture
 def paradigm_filler(shared_datadir) -> ParadigmFiller:
     """

--- a/CreeDictionary/tests/utils_tests/test_paradigm_filler.py
+++ b/CreeDictionary/tests/utils_tests/test_paradigm_filler.py
@@ -117,16 +117,23 @@ def test_import_prefilled_layouts(shared_datadir) -> None:
     ],
 )
 def test_fill_NA_Full(
-    shared_datadir, lemma, inflection_category, paradigm_size, expected_table
+    paradigm_filler, lemma, inflection_category, paradigm_size, expected_table
 ):
-    # these layout, paradigm, and hfstol files are pinned test data
-    # the real files in use are hosted under res/ folder
-    paradigm_filler = ParadigmFiller(
-        shared_datadir / "layouts",
-        shared_datadir / "paradigms",
-        shared_datadir / "crk-normative-generator.hfstol",
-    )
     assert (
         paradigm_filler.fill_paradigm(lemma, inflection_category, paradigm_size)
         == expected_table
+    )
+
+
+@pytest.fixture
+def paradigm_filler(shared_datadir) -> ParadigmFiller:
+    """
+    hese layout, paradigm, and hfstol files are **pinned** test data;
+    the real files in use are hosted under res/ folder, and should not
+    be used in tests!
+    """
+    return ParadigmFiller(
+        shared_datadir / "layouts",
+        shared_datadir / "paradigms",
+        shared_datadir / "crk-normative-generator.hfstol",
     )

--- a/CreeDictionary/tests/utils_tests/test_paradigm_filler.py
+++ b/CreeDictionary/tests/utils_tests/test_paradigm_filler.py
@@ -133,8 +133,7 @@ def test_fill_NA_Full(
         ("wâpahtam", WordClass.VTI, {"niwâpahtên", "kiwâpahtên", "ê-wâpahtahk"}),
         ("nîpin", WordClass.VII, {"ê-nîpihk"}),
         ("nôhkom", WordClass.NAD, {"kôhkom", "ohkoma", "nôhkomak"}),
-        # TODO: wîpit should be in this set, but it's not?
-        ("mîpit", WordClass.NID, {"nîpit", "kîpit"}),
+        ("mîpit", WordClass.NID, {"nîpit", "kîpit", "wîpit"}),
         ("maskwa", WordClass.NA, {"maskwak", "maskos"}),
         ("nipiy", WordClass.NI, {"nipiya", "nipîhk"}),
     ],
@@ -145,14 +144,6 @@ def test_inflect_all(
     forms = paradigm_filler.inflect_all(lemma, wordclass)
     assert lemma in forms
     assert examples <= forms
-
-
-@pytest.mark.xfail
-def test_wîpit_regression(paradigm_filler):
-    """
-    For whatever reason, the +Px3Sg inflections are missing from this paradigm.
-    """
-    assert "wîpit" in paradigm_filler.inflect_all("mîpit", WordClass.NID)
 
 
 @pytest.fixture

--- a/CreeDictionary/tests/utils_tests/test_paradigm_filler.py
+++ b/CreeDictionary/tests/utils_tests/test_paradigm_filler.py
@@ -125,12 +125,20 @@ def test_fill_NA_Full(
     )
 
 
-def test_fill_VTA_full(paradigm_filler) -> None:
-    lemma = "wâpamêw"
-    wordclass = WordClass.VTA
-    lower_bound = 2  # TODO: not really sure what to set this as
+@pytest.mark.parametrize(
+    "lemma,wordclass,examples",
+    [
+        ("wâpamêw", WordClass.VTA, {"kiwâpamitin", "kiwâpamin", "ê-wâpamit", "wâpam"}),
+        ("mîcisow", WordClass.VAI, {"nimîcison", "kimîcison", "ê-mîcisot"}),
+    ],
+)
+def test_inflect_all(
+    paradigm_filler, lemma: str, wordclass: WordClass, examples: set
+) -> None:
     forms = paradigm_filler.inflect_all(lemma, wordclass)
-    assert len(forms) > 2
+    # The lemma should ALWAYS be a part of the inflections!
+    examples = {lemma} | examples
+    assert examples <= forms
 
 
 @pytest.fixture

--- a/CreeDictionary/tests/utils_tests/test_paradigm_filler.py
+++ b/CreeDictionary/tests/utils_tests/test_paradigm_filler.py
@@ -130,15 +130,29 @@ def test_fill_NA_Full(
     [
         ("wâpamêw", WordClass.VTA, {"kiwâpamitin", "kiwâpamin", "ê-wâpamit", "wâpam"}),
         ("mîcisow", WordClass.VAI, {"nimîcison", "kimîcison", "ê-mîcisot"}),
+        ("wâpahtam", WordClass.VTI, {"niwâpahtên", "kiwâpahtên", "ê-wâpahtahk"}),
+        ("nîpin", WordClass.VII, {"ê-nîpihk"}),
+        ("nôhkom", WordClass.NAD, {"kôhkom", "ohkoma", "nôhkomak"}),
+        # TODO: wîpit should be in this set, but it's not?
+        ("mîpit", WordClass.NID, {"nîpit", "kîpit"}),
+        ("maskwa", WordClass.NA, {"maskwak", "maskos"}),
+        ("nipiy", WordClass.NI, {"nipiya", "nipîhk"}),
     ],
 )
 def test_inflect_all(
     paradigm_filler, lemma: str, wordclass: WordClass, examples: set
 ) -> None:
     forms = paradigm_filler.inflect_all(lemma, wordclass)
-    # The lemma should ALWAYS be a part of the inflections!
-    examples = {lemma} | examples
+    assert lemma in forms
     assert examples <= forms
+
+
+@pytest.mark.xfail
+def test_wîpit_regression(paradigm_filler):
+    """
+    For whatever reason, the +Px3Sg inflections are missing from this paradigm.
+    """
+    assert "wîpit" in paradigm_filler.inflect_all("mîpit", WordClass.NID)
 
 
 @pytest.fixture

--- a/CreeDictionary/utils/paradigm_filler.py
+++ b/CreeDictionary/utils/paradigm_filler.py
@@ -5,7 +5,7 @@ import csv
 from copy import deepcopy
 from os.path import dirname
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Set, Tuple
 
 import hfstol
 from paradigm import Cell, EmptyRow, Layout, StaticCell, TitleRow, rows_to_layout
@@ -118,3 +118,25 @@ class ParadigmFiller:
             row[col_ind] = " / ".join(results_for_cell)
 
         return tables
+
+    def inflect_all(self, lemma: str, wordclass: WordClass) -> Set[str]:
+        """
+        Return a set of all inflections for a particular lemma.
+        """
+
+        paradigm = self.fill_paradigm(lemma, wordclass, ParadigmSize.FULL)
+
+        def find_all_inflections():
+            for table in paradigm:
+                for row in table:
+                    if not isinstance(row, list):
+                        continue
+                    for cell in row:
+                        if not isinstance(cell, str):
+                            continue
+                        if cell == "":
+                            continue
+                        # Assume this is an inflection
+                        yield cell
+
+        return set(find_all_inflections())

--- a/CreeDictionary/utils/paradigm_filler.py
+++ b/CreeDictionary/utils/paradigm_filler.py
@@ -123,17 +123,34 @@ class ParadigmFiller:
     def inflect_all_with_analyses(
         self, lemma: str, wordclass: WordClass
     ) -> Dict[ConcatAnalysis, Sequence[str]]:
+        """
+        Produces all known forms of a given word. Returns a mapping of analyses to their
+        forms. Some analyses may have multiple forms. Some analyses may not generate a
+        form.
+        """
+        analyses = self.expand_analyses(lemma, wordclass)
+        return self._generator.feed_in_bulk_fast(analyses)
+
+    def inflect_all(self, lemma: str, wordclass: WordClass) -> Set[str]:
+        """
+        Return a set of all inflections for a particular lemma.
+        """
+        all_inflections = self.inflect_all_with_analyses(lemma, wordclass).values()
+        return set(form for word in all_inflections for form in word)
+
+    def expand_analyses(self, lemma: str, wordclass: WordClass) -> Set[ConcatAnalysis]:
+        """
+        Given a lemma and its word class, return a set of all analyses that we could
+        generate, but do not actually generate anything!
+        """
         # I just copy-pasted the code from fill_paradigm() and edited it.
         # I'm sure we could refactor using the Template Method pattern or even Visitor
         # pattern to reduce code duplication, but I honestly think it's not worth it in
         # this situation.
-        layout_table = deepcopy(
-            self._layout_tables[(wordclass, ParadigmSize.LINGUISTIC)]
-        )
-
-        analyses = set()
+        layout_table = self._layout_tables[(wordclass, ParadigmSize.LINGUISTIC)]
 
         # Find all of the analyses strings in the table:
+        analyses: Set[ConcatAnalysis] = set()
         for row in layout_table:
             if row is EmptyRow or isinstance(row, TitleRow):
                 continue
@@ -145,13 +162,7 @@ class ParadigmFiller:
 
                 # It's a inflection form pattern
                 assert '"' not in cell
-                analyses.add(cell.replace("{{ lemma }}", lemma))
+                analysis = ConcatAnalysis(cell.replace("{{ lemma }}", lemma))
+                analyses.add(analysis)
 
-        return self._generator.feed_in_bulk_fast(analyses)
-
-    def inflect_all(self, lemma: str, wordclass: WordClass) -> Set[str]:
-        """
-        Return a set of all inflections for a particular lemma.
-        """
-        all_inflections = self.inflect_all_with_analyses(lemma, wordclass).values()
-        return set(form for word in all_inflections for form in word)
+        return analyses

--- a/CreeDictionary/utils/paradigm_filler.py
+++ b/CreeDictionary/utils/paradigm_filler.py
@@ -124,7 +124,7 @@ class ParadigmFiller:
         Return a set of all inflections for a particular lemma.
         """
 
-        paradigm = self.fill_paradigm(lemma, wordclass, ParadigmSize.FULL)
+        paradigm = self.fill_paradigm(lemma, wordclass, ParadigmSize.LINGUISTIC)
 
         def find_all_inflections():
             for table in paradigm:


### PR DESCRIPTION
We used to have duplicated code with regards to "expanding" analyses given an existing analysis. In particular, the `cree_inflection_generator` module that is used in the dictionary importer was not updated to use the updated paradigm filler.

This PR did a few refactorings, added a few tests, and uses the default paradigm filler in the `cree_inflection_generator()`.

@Madoshakalaka: how does this PR affect your JIT branch?