### PR TITLE
Added paradigm layout files for personal and demonstrative pronouns

### DIFF
--- a/CreeDictionary/res/layouts/pronoun-demonstrative-basic.layout.tsv
+++ b/CreeDictionary/res/layouts/pronoun-demonstrative-basic.layout.tsv
@@ -1,0 +1,20 @@
+	"Demonstrative pronouns"
+	: "like: nâpêw, iskwêwak"
+	: "One"
+"this"	awa+Pron+Dem+Prox+A+Sg
+"that"	awa+Pron+Dem+Med+A+Sg
+"that yonder"	awa+Pron+Dem+Dist+A+Sg
+	"Many"
+"these"	awa+Pron+Dem+Prox+A+Pl
+"those"	awa+Pron+Dem+Med+A+Pl
+"those yonder"	awa+Pron+Dem+Dist+A+Pl
+	
+	: "like: cimân, wâwa"
+	: "One"
+"this"	ôma+Pron+Dem+Prox+I+Sg
+"that"	ôma+Pron+Dem+Med+I+Sg
+"that yonder"	ôma+Pron+Dem+Dist+I+Sg
+	"Many"
+"these"	ôma+Pron+Dem+Prox+I+Pl
+"those"	ôma+Pron+Dem+Med+I+Pl
+"those yonder"	ôma+Pron+Dem+Dist+I+Pl

--- a/CreeDictionary/res/layouts/pronoun-personal-basic.layout.tsv
+++ b/CreeDictionary/res/layouts/pronoun-personal-basic.layout.tsv
@@ -1,0 +1,10 @@
+	"Personal pronouns"
+	: "One"
+"I/me/my"	niya
+"you (one)/your"	kiya
+"s/he/it/him/her/his/her/its"	wiya
+	: "Many"
+"we (but not you)/us/our"	niyanân
+"you and we/us/our"	kiyânaw
+"you (all)/your"	kiyawâw
+"they/them/their"	wiyawâw


### PR DESCRIPTION
Fixes #164
Blocked by #513

> These follow two strategies:
> 1. Personal pronouns are not generated but merely spelled out (not in quotes, in contrast to labels);
> 2. Demonstrative pronouns are generated based on their linguistic feature specifications (similar to nouns and verbs).
> 
> — @aarppe