### PR TITLE
Deprecate engcrk.xml

### DIFF
--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -42,6 +42,7 @@ from utils import (
     get_modified_distance,
 )
 from utils.cree_lev_dist import remove_cree_diacritics
+from utils.english_keyword_extraction import stem_keywords
 from utils.fst_analysis_parser import LABELS, partition_analysis
 from utils.types import ConcatAnalysis, FSTTag, Label
 
@@ -534,11 +535,11 @@ class Wordform(models.Model):
         # todo: allow inflected forms to be searched through English. (requires database migration
         #  since now EnglishKeywords are bound to lemmas)
         english_results: Set[EnglishResult] = set()
-        if " " not in user_query:  # a whole word
+        for stemmed_keyword in stem_keywords(user_query):
 
             # this requires database to be changed as currently EnglishKeyword are associated with lemmas
             lemma_ids = EnglishKeyword.objects.filter(
-                text__iexact=user_query, **extra_constraints
+                text__iexact=stemmed_keyword, **extra_constraints
             ).values("lemma__id")
             for wordform in Wordform.objects.filter(
                 id__in=lemma_ids, as_is=False, **extra_constraints

--- a/CreeDictionary/DatabaseManager/__main__.py
+++ b/CreeDictionary/DatabaseManager/__main__.py
@@ -29,7 +29,7 @@ subparsers.required = True
 
 import_parser = subparsers.add_parser(
     "import",
-    help="Import from specified engcrk.xml and crkeng.xml. This assumes the database is at migration 0001",
+    help="Import from specified crkeng.xml. This assumes the database is at migration 0001",
 )
 
 build_test_db_parser = subparsers.add_parser(
@@ -38,7 +38,7 @@ build_test_db_parser = subparsers.add_parser(
 add_multi_processing_argument(build_test_db_parser)
 
 import_parser.add_argument(
-    "xml_directory_name", help="The directory that has crkeng.xml and engcrk.xml"
+    "xml_directory_name", help="The directory that has crkeng.xml"
 )
 
 add_multi_processing_argument(import_parser)

--- a/CreeDictionary/DatabaseManager/cree_inflection_generator.py
+++ b/CreeDictionary/DatabaseManager/cree_inflection_generator.py
@@ -1,16 +1,11 @@
 """
 EXPAND lemma with inflections from xml according to an fst and paradigm/layout files
 """
-import csv
-import glob
-from os import path
-from os.path import dirname
-from pathlib import Path
 from typing import Dict, Iterable, List, Set, Tuple
 
 from DatabaseManager.log import DatabaseManagerLogger
 from shared import normative_generator
-from utils import WordClass, fst_analysis_parser
+from utils import fst_analysis_parser
 from utils.paradigm_filler import ParadigmFiller
 
 

--- a/CreeDictionary/DatabaseManager/english_keyword_extraction.py
+++ b/CreeDictionary/DatabaseManager/english_keyword_extraction.py
@@ -1,0 +1,19 @@
+from typing import Set
+import re
+
+word_pattern = re.compile(r"[\w.\-/']+")
+
+stop_words = {"a", "an", "the", "s/he", "s.o.", "s.t."}
+
+
+def extract_keywords(translation: str) -> Set[str]:
+    """
+    returns lowercased keywords from the translation, by stripping stop words like a/an s/he s.o. s.t.
+
+    >>> extract_keywords("s/he is of a that kind (previously mentioned)") == {'is', 'of', 'that', 'kind', 'previously', 'mentioned'}
+    True
+    """
+    words = set(word_pattern.findall(translation.lower()))
+
+    # .strip('.') is because of the trailing periods in some translation
+    return {word.strip(".") for word in words if word not in stop_words}

--- a/CreeDictionary/DatabaseManager/english_keyword_extraction.py
+++ b/CreeDictionary/DatabaseManager/english_keyword_extraction.py
@@ -1,19 +1,27 @@
-from typing import Set
 import re
+from typing import List
+
+import snowballstemmer
 
 word_pattern = re.compile(r"[\w.\-/']+")
 
 stop_words = {"a", "an", "the", "s/he", "s.o.", "s.t."}
 
+stemmer = snowballstemmer.EnglishStemmer()
 
-def extract_keywords(translation: str) -> Set[str]:
+
+def extract_keywords(translation: str) -> List[str]:
     """
     returns lowercased keywords from the translation, by stripping stop words like a/an s/he s.o. s.t.
 
-    >>> extract_keywords("s/he is of a that kind (previously mentioned)") == {'is', 'of', 'that', 'kind', 'previously', 'mentioned'}
-    True
+    returned list has no duplicates
+
+    >>> sorted(extract_keywords("s/he is of a that kind (previously mentioned)"))
+    ['is', 'kind', 'mention', 'of', 'previous', 'that']
     """
     words = set(word_pattern.findall(translation.lower()))
 
     # .strip('.') is because of the trailing periods in some translation
-    return {word.strip(".") for word in words if word not in stop_words}
+    return stemmer.stemWords(
+        {word.strip(".") for word in words if word not in stop_words}
+    )

--- a/CreeDictionary/DatabaseManager/readme.md
+++ b/CreeDictionary/DatabaseManager/readme.md
@@ -6,7 +6,7 @@ If installed as a package, command `manage-db` will be added to python environme
 
 ## Examples
 
-- Unlink the database and import crkeng.xml and engcrk.xml to the database (migrations will also be applied)
+- Unlink the database and import crkeng.xml to the database (migrations will also be applied)
 
     `manage-db import /res/dictionaries/`
     

--- a/CreeDictionary/DatabaseManager/xml_importer.py
+++ b/CreeDictionary/DatabaseManager/xml_importer.py
@@ -1,14 +1,13 @@
 import re
 import xml.etree.ElementTree as ET
-from collections import defaultdict
 from pathlib import Path
-from typing import DefaultDict, Dict, List, NamedTuple, Set, Tuple
+from typing import Dict, List, Set
 
 from API.models import Definition, DictionarySource, EnglishKeyword, Wordform
 from colorama import init
 from DatabaseManager import xml_entry_lemma_finder
 from DatabaseManager.cree_inflection_generator import expand_inflections
-from DatabaseManager.english_keyword_extraction import extract_keywords
+from utils.english_keyword_extraction import stem_keywords
 from DatabaseManager.log import DatabaseManagerLogger
 from DatabaseManager.xml_consistency_checker import (
     does_inflectional_category_match_xml_entry,
@@ -175,7 +174,7 @@ def import_xmls(dir_name: Path, multi_processing: int = 1, verbose=True):
         )
 
         for translation in entry.translations:
-            for english_keyword in extract_keywords(translation.text):
+            for english_keyword in stem_keywords(translation.text):
                 db_keywords.append(
                     EnglishKeyword(
                         id=keyword_counter, text=english_keyword, lemma=db_wordform
@@ -257,7 +256,7 @@ def import_xmls(dir_name: Path, multi_processing: int = 1, verbose=True):
                     db_lemma = db_wordform
                     # as inflections sometimes bear definition with them
                     for translation in entry.translations:
-                        for english_keyword in extract_keywords(translation.text):
+                        for english_keyword in stem_keywords(translation.text):
                             db_keywords.append(
                                 EnglishKeyword(
                                     id=keyword_counter,

--- a/CreeDictionary/DatabaseManager/xml_importer.py
+++ b/CreeDictionary/DatabaseManager/xml_importer.py
@@ -8,6 +8,7 @@ from API.models import Definition, DictionarySource, EnglishKeyword, Wordform
 from colorama import init
 from DatabaseManager import xml_entry_lemma_finder
 from DatabaseManager.cree_inflection_generator import expand_inflections
+from DatabaseManager.english_keyword_extraction import extract_keywords
 from DatabaseManager.log import DatabaseManagerLogger
 from DatabaseManager.xml_consistency_checker import (
     does_inflectional_category_match_xml_entry,
@@ -88,114 +89,15 @@ def format_element_error(msg: str, element: ET.Element) -> str:
     return f"{msg} \n {ET.tostring(element, encoding='unicode')}"
 
 
-class EngcrkCree(NamedTuple):
-    """
-    A cree word extracted from engcrk.xml.
-    The corresponding wordform in the database is to be determined later
-    """
-
-    wordform: str
-    pos: PartOfSpeech
-
-
-def load_engcrk_xml(filename: Path) -> DefaultDict[EngcrkCree, List[str]]:
-    """
-    :return: Dict[EngcrkCree , [english1, english2, english3 ...]] pos is in uppercase
-    """
-
-    # The structure in engcrk.xml
-
-    """
-        <e>
-
-            <lg xml:lang="eng">
-                <l pos="N">August</l>
-            </lg>
-
-            <mg>
-                <tg xml:lang="crk">
-                    <trunc sources="MD">august. [The flying month].</trunc>
-                    <t pos="N" rank="1.0">Ohpahow-pisim</t>
-                </tg>
-            </mg>
-
-            <mg>
-                <tg xml:lang="crk">
-                    <trunc sources="CW">Flying-Up Moon; August</trunc>
-                    <t pos="N" rank="1.0">ohpahowi-pîsim</t>
-                </tg>
-            </mg>
-        </e>
-    """
-
-    filename = Path(filename)
-
-    assert filename.exists(), "%s does not exist" % filename
-
-    res: DefaultDict[EngcrkCree, List[str]] = defaultdict(list)
-
-    root = ET.parse(str(filename)).getroot()
-    elements = root.findall(".//e")
-
-    for element in elements:
-        l_element = element.find("lg/l")
-        if l_element is None:
-            logger.debug(
-                format_element_error(f"<e> lacks an <l> in file {filename}", element)
-            )
-            continue
-
-        if l_element.text is None:
-            logger.debug(format_element_error("<l> does not have text", element))
-            continue
-
-        t_elements = element.findall("mg/tg/t")
-
-        if not t_elements:
-            logger.debug(
-                format_element_error(f"<e> lacks <t> in file {filename}", element)
-            )
-            continue
-
-        for t_element in t_elements:
-            if t_element.text is None:
-                logger.debug(
-                    format_element_error(
-                        f"<t> does not have text in file {filename}", element
-                    )
-                )
-                continue
-            cree_word = t_element.text
-            pos_str = t_element.get("pos")
-            assert pos_str is not None
-            try:
-                pos = PartOfSpeech(pos_str.upper())
-            except ValueError:
-                logger.debug(
-                    format_element_error(
-                        f"Cree word {cree_word} has a unrecognizable pos {pos_str}",
-                        element,
-                    )
-                )
-                continue
-
-            res[EngcrkCree(cree_word, pos)].append(l_element.text)
-
-    return res
-
-
-def find_latest_xml_files(dir_name: Path) -> Tuple[Path, Path]:
+def find_latest_xml_file(dir_name: Path) -> Path:
     """
     Find the latest timestamped xml files, with un-timestamped files as a fallback if no timestamped file is found
 
     :raise FileNotFoundError: if either file can't be found
     """
-    name_pattern = re.compile(
-        r"^(?P<direction>(crkeng|engcrk)).*?(?P<timestamp>\d{6})?\.xml$"
-    )
+    name_pattern = re.compile(r"^crkeng.*?(?P<timestamp>\d{6})?\.xml$")
 
     crkeng_file_path_to_timestamp: Dict[Path, str] = {}
-    engcrk_file_path_to_timestamp: Dict[Path, str] = {}
 
     for file in dir_name.glob("*.xml"):
         res = re.match(name_pattern, file.name)
@@ -203,43 +105,32 @@ def find_latest_xml_files(dir_name: Path) -> Tuple[Path, Path]:
             timestamp = "000000"
             if res.group("timestamp") is not None:
                 timestamp = res.group("timestamp")
-            if res.group("direction") == "crkeng":
-                crkeng_file_path_to_timestamp[file] = timestamp
-            else:  # engcrk
-                engcrk_file_path_to_timestamp[file] = timestamp
+            crkeng_file_path_to_timestamp[file] = timestamp
     if len(crkeng_file_path_to_timestamp) == 0:
         raise FileNotFoundError(f"No legal xml files for crkeng found under {dir_name}")
-    if len(engcrk_file_path_to_timestamp) == 0:
-        raise FileNotFoundError(f"No legal xml files for engcrk found under {dir_name}")
 
-    return (
-        max(
-            crkeng_file_path_to_timestamp, key=crkeng_file_path_to_timestamp.__getitem__
-        ),
-        max(
-            engcrk_file_path_to_timestamp, key=engcrk_file_path_to_timestamp.__getitem__
-        ),
+    return max(
+        crkeng_file_path_to_timestamp, key=crkeng_file_path_to_timestamp.__getitem__
     )
 
 
 @timed()
 def import_xmls(dir_name: Path, multi_processing: int = 1, verbose=True):
     """
-    Import from crkeng and engcrk files, `dir_name` can host a series of xml files. The latest timestamped files will be
+    Import from crkeng files, `dir_name` can host a series of xml files. The latest timestamped files will be
     used, with un-timestamped files as a fallback.
 
     :param multi_processing: Use multiple hfstol processes to speed up importing
-    :param dir_name: the directory that has pattern (crkeng|engcrk).*?(?P<timestamp>\d{6})?\.xml
-    (e.g. engcrk_cw_md_200319.xml or engcrk.xml) files, beware the timestamp has format yymmdd
+    :param dir_name: the directory that has pattern crkeng.*?(?P<timestamp>\d{6})?\.xml
+    (e.g. crkeng_cw_md_200319.xml or crkeng.xml) files, beware the timestamp has format yymmdd
     :param verbose: print to stdout or not
     """
     logger.set_print_info_on_console(verbose)
 
-    crkeng_file_path, engcrk_file_path = find_latest_xml_files(dir_name)
+    crkeng_file_path = find_latest_xml_file(dir_name)
     logger.info(f"using crkeng file: {crkeng_file_path}")
-    logger.info(f"using engcrk file: {engcrk_file_path}")
 
-    assert crkeng_file_path.exists() and engcrk_file_path.exists()
+    assert crkeng_file_path.exists()
 
     with open(crkeng_file_path) as f:
         crkeng_xml = IndexedXML.from_xml_file(f)
@@ -251,10 +142,6 @@ def import_xmls(dir_name: Path, multi_processing: int = 1, verbose=True):
         src = DictionarySource(abbrv=source_abbreviation)
         src.save()
         logger.info("Created source: %s", source_abbreviation)
-
-    logger.info("Loading English keywords...")
-    engcrk_cree_to_keywords = load_engcrk_xml(engcrk_file_path)
-    logger.info("English keywords loaded")
 
     # these two will be imported to the database
     (
@@ -287,13 +174,11 @@ def import_xmls(dir_name: Path, multi_processing: int = 1, verbose=True):
             as_is=True,
         )
 
-        if upper_pos in RECOGNIZABLE_POS:
-            for english_keywords in engcrk_cree_to_keywords[
-                EngcrkCree(entry.l, PartOfSpeech(upper_pos))
-            ]:
+        for translation in entry.translations:
+            for english_keyword in extract_keywords(translation.text):
                 db_keywords.append(
                     EnglishKeyword(
-                        id=keyword_counter, text=english_keywords, lemma=db_wordform
+                        id=keyword_counter, text=english_keyword, lemma=db_wordform
                     )
                 )
 
@@ -371,18 +256,17 @@ def import_xmls(dir_name: Path, multi_processing: int = 1, verbose=True):
                 if is_lemma:
                     db_lemma = db_wordform
                     # as inflections sometimes bear definition with them
-                    for english_keywords in engcrk_cree_to_keywords[
-                        EngcrkCree(generated_wordform_text, generated_pos)
-                    ]:
-                        db_keywords.append(
-                            EnglishKeyword(
-                                id=keyword_counter,
-                                text=english_keywords,
-                                lemma=db_wordform,
+                    for translation in entry.translations:
+                        for english_keyword in extract_keywords(translation.text):
+                            db_keywords.append(
+                                EnglishKeyword(
+                                    id=keyword_counter,
+                                    text=english_keyword,
+                                    lemma=db_wordform,
+                                )
                             )
-                        )
 
-                        keyword_counter += 1
+                            keyword_counter += 1
 
                 # now we create definition for all (possibly non-lemma) entries in the xml that are forms of this lemma.
 

--- a/CreeDictionary/res/dictionaries/README.md
+++ b/CreeDictionary/res/dictionaries/README.md
@@ -1,7 +1,10 @@
-dictionary files are stored on Sapir as the following absolute path:
+dictionary files are stored in altlab repo at the following place:
 
-crkeng: `/data/texts/crk/dicts/itwewina/crkeng_cw_md_200314.xml`
+`altlab/crk/dicts/crkeng.xml`
 
-engcrk: `/data/texts/crk/dicts/itwewina/engcrk_cw_md_200317.xml`
+
+It's was also used to be stored on Sapir server with a timestamp like the following
+
+`crkeng_cw_md_200314.xml`
 
 The last six digits is a timestamp of when this file is built, in the format of yymmdd.

--- a/CreeDictionary/res/test_dictionaries/crkeng.xml
+++ b/CreeDictionary/res/test_dictionaries/crkeng.xml
@@ -140,7 +140,7 @@
 			<l pos="V">acâhkosiwiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>acâhkosiwi-</stem>
@@ -214,7 +214,7 @@
 			<l pos="V">ahcahkowan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>ahcahkowan-</stem>
@@ -288,7 +288,7 @@
 			<l pos="V">ahcahkowiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ahcahkowi-</stem>
@@ -436,7 +436,7 @@
 			<l pos="V">ahpîhcimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ahpîhcimo-</stem>
@@ -584,7 +584,7 @@
 			<l pos="V">akocimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>akocimo-</stem>
@@ -621,7 +621,7 @@
 			<l pos="V">akocin</l>
 			
       
-			<lc>VAI-2</lc>
+			<lc>VAI-n</lc>
 			
       
 			<stem>akocin-</stem>
@@ -710,7 +710,7 @@
 			<l pos="V">akohcin</l>
 			
       
-			<lc>VAI-2</lc>
+			<lc>VAI-n</lc>
 			
       
 			<stem>akohcin-</stem>
@@ -747,7 +747,7 @@
 			<l pos="V">akwamow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>akwamo-</stem>
@@ -1302,7 +1302,7 @@
 			<l pos="V">amiskowiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>amiskowi-</stem>
@@ -2021,7 +2021,7 @@
 			<l pos="V">asawâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>asawâpi-</stem>
@@ -2147,7 +2147,7 @@
 			<l pos="V">asêtâcimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>asêtâcimo-</stem>
@@ -2310,7 +2310,7 @@
 			<l pos="V">atamiskâtowak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>atamiskâto-</stem>
@@ -2384,7 +2384,7 @@
 			<l pos="V">atamiskotâtowak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>atamiskotâto-</stem>
@@ -2513,7 +2513,7 @@
 			<l pos="V">atâhkowiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>atâhkowi-</stem>
@@ -2661,7 +2661,7 @@
 			<l pos="V">atoskêwi-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>atoskêwi-kîsikâ-</stem>
@@ -2824,7 +2824,7 @@
 			<l pos="V">awahkêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>awahkê-</stem>
@@ -3079,7 +3079,7 @@
 			<l pos="V">awasêwêmakan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>awasêwêmakan-</stem>
@@ -3116,7 +3116,7 @@
 			<l pos="V">awasêwêpahtâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>awasêwêpahtâ-</stem>
@@ -3153,7 +3153,7 @@
 			<l pos="V">awasêwêpayihow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>awasêwêpayiho-</stem>
@@ -3227,7 +3227,7 @@
 			<l pos="V">awasêwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>awasêwê-</stem>
@@ -3738,7 +3738,7 @@
 			<l pos="V">awasitêw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>awasitê-</stem>
@@ -3812,7 +3812,7 @@
 			<l pos="V">awasow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>awaso-</stem>
@@ -3960,7 +3960,7 @@
 			<l pos="V">awâsisîwiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>awâsisîwi-</stem>
@@ -4256,7 +4256,7 @@
 			<l pos="V">ayamihâwi-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>ayamihâwi-kîsikâ-</stem>
@@ -4293,7 +4293,7 @@
 			<l pos="V">ayamihêwi-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>ayamihêwi-kîsikâ-</stem>
@@ -4367,7 +4367,7 @@
 			<l pos="V">ayâniwiw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>ayâniwi-</stem>
@@ -4404,7 +4404,7 @@
 			<l pos="V">ayâtan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>ayâtan-</stem>
@@ -4441,7 +4441,7 @@
 			<l pos="V">ayâw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>ayâ-</stem>
@@ -4530,7 +4530,7 @@
 			<l pos="V">ayâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ayâ-</stem>
@@ -4782,7 +4782,7 @@
 			<l pos="V">ayênânêwopiponêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ayênânêwopiponê-</stem>
@@ -4819,7 +4819,7 @@
 			<l pos="V">ayinânêwopiponêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ayinânêwopiponê-</stem>
@@ -5093,7 +5093,7 @@
 			<l pos="V">aywêpiwi-kîsikâw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>aywêpiwi-kîsikâ-</stem>
@@ -5182,7 +5182,7 @@
 			<l pos="V">âcimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>âcimo-</stem>
@@ -5286,7 +5286,7 @@
 			<l pos="V">âhci-ayâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>âhci-ayâ-</stem>
@@ -5323,7 +5323,7 @@
 			<l pos="V">âkawaskwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>âkawaskwê-</stem>
@@ -5360,7 +5360,7 @@
 			<l pos="V">âkwâ-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>âkwâ-kîsikâ-</stem>
@@ -5545,7 +5545,7 @@
 			<l pos="V">âpihtâ-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>âpihtâ-kîsikâ-</stem>
@@ -5582,7 +5582,7 @@
 			<l pos="V">âpihtâ-kîsikâwi-mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>âpihtâ-kîsikâwi-mîciso-</stem>
@@ -5656,7 +5656,7 @@
 			<l pos="V">âpihtâ-nîpin</l>
 			
       
-			<lc>VII-1n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>âpihtâ-nîpin-</stem>
@@ -5693,7 +5693,7 @@
 			<l pos="V">âpihtâ-pipon</l>
 			
       
-			<lc>VII-1n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>âpihtâ-pipon-</stem>
@@ -5767,7 +5767,7 @@
 			<l pos="V">âpihtâ-tipiskâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>âpihtâ-tipiskâ-</stem>
@@ -5804,7 +5804,7 @@
 			<l pos="V">âpihtâwi-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>âpihtâwi-kîsikâ-</stem>
@@ -5878,7 +5878,7 @@
 			<l pos="V">âstê-ayâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>âstê-ayâ-</stem>
@@ -5915,7 +5915,7 @@
 			<l pos="V">âstê-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>âstê-kîsikâ-</stem>
@@ -6063,7 +6063,7 @@
 			<l pos="V">cahcahkâyôskâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>cahcahkâyôskâ-</stem>
@@ -6177,7 +6177,7 @@
 			<l pos="V">cimihtawakêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>cimihtawakê-</stem>
@@ -6251,7 +6251,7 @@
 			<l pos="V">cîwêhtawakêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>cîwêhtawakê-</stem>
@@ -6873,7 +6873,7 @@
 			<l pos="V">ihkatawahkâw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>ihkatawahkâ-</stem>
@@ -6910,7 +6910,7 @@
 			<l pos="V">isi-ayâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>isi-ayâ-</stem>
@@ -6947,7 +6947,7 @@
 			<l pos="V">isitâcimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>isitâcimo-</stem>
@@ -6984,7 +6984,7 @@
 			<l pos="V">iskwâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>iskwâpi-</stem>
@@ -7058,7 +7058,7 @@
 			<l pos="V">itahtopiponêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>itahtopiponê-</stem>
@@ -7095,7 +7095,7 @@
 			<l pos="V">itahtopiponwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>itahtopiponwê-</stem>
@@ -7221,7 +7221,7 @@
 			<l pos="V">îkatêtâcimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>îkatêtâcimo-</stem>
@@ -7295,7 +7295,7 @@
 			<l pos="V">kakihcimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kakihcimo-</stem>
@@ -7547,7 +7547,7 @@
 			<l pos="V">kaskawan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>kaskawan-</stem>
@@ -7584,7 +7584,7 @@
 			<l pos="V">kaskawanipêscâsin</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>kaskawanipêscâsin-</stem>
@@ -7621,7 +7621,7 @@
 			<l pos="V">kaskawanipêstâw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>kaskawanipêstâ-</stem>
@@ -7658,7 +7658,7 @@
 			<l pos="V">kaski-tipiskâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>kaski-tipiskâ-</stem>
@@ -7747,7 +7747,7 @@
 			<l pos="V">katawasisin</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>katawasisin-</stem>
@@ -7784,7 +7784,7 @@
 			<l pos="V">katawasisiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>katawasisi-</stem>
@@ -7977,7 +7977,7 @@
 			<l pos="V">kawacihkwamiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kawacihkwami-</stem>
@@ -8014,7 +8014,7 @@
 			<l pos="V">kawacipayiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kawacipayi-</stem>
@@ -8066,7 +8066,7 @@
 			<l pos="V">kawaciw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kawaci-</stem>
@@ -8170,7 +8170,7 @@
 			<l pos="V">kawaciyawêpayiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kawaciyawêpayi-</stem>
@@ -8259,7 +8259,7 @@
 			<l pos="V">kawahikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kawahikê-</stem>
@@ -8452,7 +8452,7 @@
 			<l pos="V">kawatâpâwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kawatâpâwê-</stem>
@@ -8578,7 +8578,7 @@
 			<l pos="V">kawatimisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kawatimiso-</stem>
@@ -8615,7 +8615,7 @@
 			<l pos="V">kawatin</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>kawatin-</stem>
@@ -8985,7 +8985,7 @@
 			<l pos="V">kâkîsimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kâkîsimo-</stem>
@@ -9259,7 +9259,7 @@
 			<l pos="V">kêtayiwinisêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kêtayiwinisê-</stem>
@@ -9370,7 +9370,7 @@
 			<l pos="V">kihci-kîsikâw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>kihci-kîsikâ-</stem>
@@ -9533,7 +9533,7 @@
 			<l pos="V">kinohtawakêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kinohtawakê-</stem>
@@ -9659,7 +9659,7 @@
 			<l pos="V">kipihtawakêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kipihtawakê-</stem>
@@ -9896,7 +9896,7 @@
 			<l pos="V">kisîhkwasiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kisîhkwasi-</stem>
@@ -9933,7 +9933,7 @@
 			<l pos="V">kisîmow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kisîmo-</stem>
@@ -9970,7 +9970,7 @@
 			<l pos="V">kisîpêkinayiwinisêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kisîpêkinayiwinisê-</stem>
@@ -10007,7 +10007,7 @@
 			<l pos="V">kiskimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kiskimo-</stem>
@@ -10118,7 +10118,7 @@
 			<l pos="V">kiskinowâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kiskinowâpi-</stem>
@@ -10155,7 +10155,7 @@
 			<l pos="V">kiskinwahamâkosiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kiskinwahamâkosi-</stem>
@@ -10296,7 +10296,7 @@
 			<l pos="V">kistâpawacikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kistâpawacikê-</stem>
@@ -10370,7 +10370,7 @@
 			<l pos="V">kistâpawayow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kistâpawayo-</stem>
@@ -10555,7 +10555,7 @@
 			<l pos="V">kitohcikanihkêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kitohcikanihkê-</stem>
@@ -10592,7 +10592,7 @@
 			<l pos="V">kitohcikêsiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kitohcikêsi-</stem>
@@ -10629,7 +10629,7 @@
 			<l pos="V">kitohcikêskiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kitohcikêski-</stem>
@@ -10666,7 +10666,7 @@
 			<l pos="V">kitohcikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kitohcikê-</stem>
@@ -10740,7 +10740,7 @@
 			<l pos="V">kiyakihtawakêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kiyakihtawakê-</stem>
@@ -10955,7 +10955,7 @@
 			<l pos="V">kîkisêpâ-mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kîkisêpâ-mîciso-</stem>
@@ -11229,7 +11229,7 @@
 			<l pos="V">kîsi-mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kîsi-mîciso-</stem>
@@ -11266,7 +11266,7 @@
 			<l pos="V">kîsi-tipiskâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>kîsi-tipiskâ-</stem>
@@ -11303,7 +11303,7 @@
 			<l pos="V">kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>kîsikâ-</stem>
@@ -11469,7 +11469,7 @@
 			<l pos="V">kîsikâwihkwâmiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kîsikâwihkwâmi-</stem>
@@ -11580,7 +11580,7 @@
 			<l pos="V">kîskihtawakayêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kîskihtawakayê-</stem>
@@ -11654,7 +11654,7 @@
 			<l pos="V">kîsopwêni-pipon</l>
 			
       
-			<lc>VII-1n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>kîsopwêni-pipon-</stem>
@@ -12239,7 +12239,7 @@
 			<l pos="V">kwêskîmow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>kwêskîmo-</stem>
@@ -12313,7 +12313,7 @@
 			<l pos="V">maci-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>maci-kîsikâ-</stem>
@@ -12387,7 +12387,7 @@
 			<l pos="V">mahkihtawakêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mahkihtawakê-</stem>
@@ -12439,7 +12439,7 @@
 			<l pos="V">mamihcisiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mamihcisi-</stem>
@@ -12580,7 +12580,7 @@
 			<l pos="V">manitowi-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>manitowi-kîsikâ-</stem>
@@ -12654,7 +12654,7 @@
 			<l pos="V">maskawacistin</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>maskawacistin-</stem>
@@ -12691,7 +12691,7 @@
 			<l pos="V">maskawahcâw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>maskawahcâ-</stem>
@@ -12728,7 +12728,7 @@
 			<l pos="V">maskawahkâw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>maskawahkâ-</stem>
@@ -13032,7 +13032,7 @@
 			<l pos="V">matwê-nipâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>matwê-nipâ-</stem>
@@ -13069,7 +13069,7 @@
 			<l pos="V">mawapiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mawapi-</stem>
@@ -13180,7 +13180,7 @@
 			<l pos="V">mâci-mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mâci-mîciso-</stem>
@@ -13217,7 +13217,7 @@
 			<l pos="V">mâci-nipâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mâci-nipâ-</stem>
@@ -13365,7 +13365,7 @@
 			<l pos="V">mâmawapiwak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mâmawapi-</stem>
@@ -13439,7 +13439,7 @@
 			<l pos="V">mâmawaskitêwa</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>mâmawaskitê-</stem>
@@ -13476,7 +13476,7 @@
 			<l pos="V">mâmawatoskêwak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mâmawatoskê-</stem>
@@ -13513,7 +13513,7 @@
 			<l pos="V">mâmawi-mîcisowak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mâmawi-mîciso-</stem>
@@ -13550,7 +13550,7 @@
 			<l pos="V">mâmawi-nipâwak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mâmawi-nipâ-</stem>
@@ -13698,7 +13698,7 @@
 			<l pos="V">mâtinawê-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>mâtinawê-kîsikâ-</stem>
@@ -13735,7 +13735,7 @@
 			<l pos="V">mâtinawi-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>mâtinawi-kîsikâ-</stem>
@@ -13824,7 +13824,7 @@
 			<l pos="V">mâyâcimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mâyâcimo-</stem>
@@ -13913,7 +13913,7 @@
 			<l pos="V">mâyi-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>mâyi-kîsikâ-</stem>
@@ -13965,7 +13965,7 @@
 			<l pos="V">mâyi-pipon</l>
 			
       
-			<lc>VII-1n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>mâyi-pipon-</stem>
@@ -14165,7 +14165,7 @@
 			<l pos="V">mêkwâ-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>mêkwâ-kîsikâ-</stem>
@@ -14202,7 +14202,7 @@
 			<l pos="V">mêkwâ-pimâtisiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mêkwâ-pimâtisi-</stem>
@@ -14254,7 +14254,7 @@
 			<l pos="V">mêkwâ-tipiskâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>mêkwâ-tipiskâ-</stem>
@@ -14365,7 +14365,7 @@
 			<l pos="V">mêskotayiwinisêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mêskotayiwinisê-</stem>
@@ -14439,7 +14439,7 @@
 			<l pos="V">mihkawakîw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mihkawakî-</stem>
@@ -14728,7 +14728,7 @@
 			<l pos="N">mistahi-maskwa</l>
 			
       
-			<lc>NA-4w</lc>
+			<lc>NA-3</lc>
 			
       
 			<stem>mistahi-maskw-</stem>
@@ -14913,7 +14913,7 @@
 			<l pos="V">miyo-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>miyo-kîsikâ-</stem>
@@ -14965,7 +14965,7 @@
 			<l pos="V">miyo-tipiskâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>miyo-tipiskâ-</stem>
@@ -15002,7 +15002,7 @@
 			<l pos="V">miyonâkohcikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>miyonâkohcikê-</stem>
@@ -15091,7 +15091,7 @@
 			<l pos="V">mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mîciso-</stem>
@@ -15143,7 +15143,7 @@
 			<l pos="V">mîcisowamahcihow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mîcisowamahciho-</stem>
@@ -15432,7 +15432,7 @@
 			<l pos="V">mîcisowinâhtikohkêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mîcisowinâhtikohkê-</stem>
@@ -15469,7 +15469,7 @@
 			<l pos="V">mîcisowinihkêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mîcisowinihkê-</stem>
@@ -15847,7 +15847,7 @@
 			<l pos="V">mîskotayiwinisêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mîskotayiwinisê-</stem>
@@ -16262,7 +16262,7 @@
 			<l pos="V">mônisôniyâwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mônisôniyâwê-</stem>
@@ -16299,7 +16299,7 @@
 			<l pos="V">môniyâhkâsow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>môniyâhkâso-</stem>
@@ -16662,7 +16662,7 @@
 			<l pos="V">môniyâwi-itwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>môniyâwi-itwê-</stem>
@@ -16736,7 +16736,7 @@
 			<l pos="V">môniyâwiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>môniyâwi-</stem>
@@ -16847,7 +16847,7 @@
 			<l pos="V">nahikohtâkanêmow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nahikohtâkanêmo-</stem>
@@ -16936,7 +16936,7 @@
 			<l pos="V">namiskwêyiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>namiskwêyi-</stem>
@@ -17173,7 +17173,7 @@
 			<l pos="V">nanamiskwêyiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nanamiskwêyi-</stem>
@@ -17336,7 +17336,7 @@
 			<l pos="V">nanâtawâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nanâtawâpi-</stem>
@@ -17758,7 +17758,7 @@
 			<l pos="V">nawacîhisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawacîhiso-</stem>
@@ -17832,7 +17832,7 @@
 			<l pos="V">nawacîstamâsow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawacîstamâso-</stem>
@@ -17906,7 +17906,7 @@
 			<l pos="V">nawacîw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawacî-</stem>
@@ -18032,7 +18032,7 @@
 			<l pos="V">nawakapiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawakapi-</stem>
@@ -18084,7 +18084,7 @@
 			<l pos="V">nawakipahtâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawakipahtâ-</stem>
@@ -18121,7 +18121,7 @@
 			<l pos="V">nawakipayihow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawakipayiho-</stem>
@@ -18195,7 +18195,7 @@
 			<l pos="V">nawakiskwêpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawakiskwêpi-</stem>
@@ -18247,7 +18247,7 @@
 			<l pos="V">nawakiskwêyiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawakiskwêyi-</stem>
@@ -18336,7 +18336,7 @@
 			<l pos="V">nawakîw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawakî-</stem>
@@ -18388,7 +18388,7 @@
 			<l pos="V">nawasawâpamow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawasawâpamo-</stem>
@@ -18640,7 +18640,7 @@
 			<l pos="V">nawasônikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawasônikê</stem>
@@ -18744,7 +18744,7 @@
 			<l pos="V">nawaswâsiwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawaswâsiwê-</stem>
@@ -18885,7 +18885,7 @@
 			<l pos="V">nawaswâtitowak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawaswâtito-</stem>
@@ -18922,7 +18922,7 @@
 			<l pos="V">nawaswêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawaswê-</stem>
@@ -19070,7 +19070,7 @@
 			<l pos="V">nawatâskitêw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>nawatâskitê-</stem>
@@ -19263,7 +19263,7 @@
 			<l pos="V">nayawapiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nayawapi-</stem>
@@ -19300,7 +19300,7 @@
 			<l pos="V">nâh-nanamiskwêkâpawiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nanamiskwêkâpawi-</stem>
@@ -19337,7 +19337,7 @@
 			<l pos="V">nâh-nawaswâtitowak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nawaswâtito-</stem>
@@ -19522,7 +19522,7 @@
 			<l pos="V">nânitawâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nânitawâpi-</stem>
@@ -19670,7 +19670,7 @@
 			<l pos="V">nâtisôniyâhkêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nâtisôniyâhkê-</stem>
@@ -19707,7 +19707,7 @@
 			<l pos="V">nâtisôniyâwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nâtisôniyâwê-</stem>
@@ -19848,7 +19848,7 @@
 			<l pos="V">nêhiyawascikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nêhiyawascikê-</stem>
@@ -19922,7 +19922,7 @@
 			<l pos="V">nêhiyawasinahikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nêhiyawasinahikê-</stem>
@@ -20033,7 +20033,7 @@
 			<l pos="V">nêhiyawi-kiskinwahamâkosiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nêhiyawi-kiskinwahamâkosi-</stem>
@@ -20174,7 +20174,7 @@
 			<l pos="V">nêmow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nêmo-</stem>
@@ -20300,7 +20300,7 @@
 			<l pos="V">nêwo-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>nêwo-kîsikâ-</stem>
@@ -20485,7 +20485,7 @@
 			<l pos="V">nihtâ-kitohcikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nihtâ-kitohcikê-</stem>
@@ -20537,7 +20537,7 @@
 			<l pos="V">nihtâ-mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nihtâ-mîciso-</stem>
@@ -20574,7 +20574,7 @@
 			<l pos="V">nikamômakan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>nikamômakan-</stem>
@@ -20611,7 +20611,7 @@
 			<l pos="V">nikotwâsiko-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>nikotwâsiko-kîsikâ-</stem>
@@ -20648,7 +20648,7 @@
 			<l pos="V">nikotwâso-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>nikotwâso-kîsikâ-</stem>
@@ -20833,7 +20833,7 @@
 			<l pos="V">nipâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nipâ-</stem>
@@ -21048,7 +21048,7 @@
 			<l pos="V">nipowâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nipowâpi-</stem>
@@ -21085,7 +21085,7 @@
 			<l pos="V">nipômakan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>nipômakan-</stem>
@@ -21455,7 +21455,7 @@
 			<l pos="V">nisto-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>nisto-kîsikâ-</stem>
@@ -21529,7 +21529,7 @@
 			<l pos="V">nisto-tipiskwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nisto-tipiskwê-</stem>
@@ -21603,7 +21603,7 @@
 			<l pos="V">nistohkwâmiwak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nistohkwâmi-</stem>
@@ -21692,7 +21692,7 @@
 			<l pos="V">nistohtêwak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nistohtê-</stem>
@@ -21803,7 +21803,7 @@
 			<l pos="V">nistokâtêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nistokâtê-</stem>
@@ -21840,7 +21840,7 @@
 			<l pos="V">nistokâtêwêyâw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>nistokâtêwêyâ-</stem>
@@ -21877,7 +21877,7 @@
 			<l pos="V">nistokêwak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nistokê-</stem>
@@ -21988,7 +21988,7 @@
 			<l pos="V">nistopiponwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nistopiponwê-</stem>
@@ -22062,7 +22062,7 @@
 			<l pos="V">nistosinwak</l>
 			
       
-			<lc>VAI-2</lc>
+			<lc>VAI-n</lc>
 			
       
 			<stem>nistosin-</stem>
@@ -22136,7 +22136,7 @@
 			<l pos="V">nistoyawêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nistoyawê-</stem>
@@ -22210,7 +22210,7 @@
 			<l pos="V">nitawahcikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nitawahcikê-</stem>
@@ -22247,7 +22247,7 @@
 			<l pos="V">nitawastimwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nitawastimwê-</stem>
@@ -22358,7 +22358,7 @@
 			<l pos="V">nitawâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nitawâpi-</stem>
@@ -22432,7 +22432,7 @@
 			<l pos="V">nitawi-mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nitawi-mîciso-</stem>
@@ -22580,7 +22580,7 @@
 			<l pos="V">nitopayiwinihkêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nitopayiwinihkê-</stem>
@@ -22891,7 +22891,7 @@
 			<l pos="V">niyânaniwa</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>niyânani-</stem>
@@ -22943,7 +22943,7 @@
 			<l pos="V">niyânaniwak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>niyânani-</stem>
@@ -22995,7 +22995,7 @@
 			<l pos="V">niyânano-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>niyânano-kîsikâ-</stem>
@@ -23217,7 +23217,7 @@
 			<l pos="V">niyâw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>niyâ-</stem>
@@ -23254,7 +23254,7 @@
 			<l pos="V">nîkân-ayâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nîkân-ayâ-</stem>
@@ -23291,7 +23291,7 @@
 			<l pos="V">nîminâniwan</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nîmi-</stem>
@@ -23328,7 +23328,7 @@
 			<l pos="V">nîmiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nîmi-</stem>
@@ -23439,7 +23439,7 @@
 			<l pos="V">nîpin</l>
 			
       
-			<lc>VII-1n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>nîpin-</stem>
@@ -23602,7 +23602,7 @@
 			<l pos="V">nîpinisiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nîpinisi-</stem>
@@ -23879,7 +23879,7 @@
 			<l pos="V">nîso-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>nîso-kîsikâ-</stem>
@@ -23990,7 +23990,7 @@
 			<l pos="V">nîso-tipiskâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>nîso-tipiskâ-</stem>
@@ -24064,7 +24064,7 @@
 			<l pos="V">nîsopiponwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nîsopiponwê-</stem>
@@ -24279,7 +24279,7 @@
 			<l pos="V">nôhtê-mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nôhtê-mîciso-</stem>
@@ -24331,7 +24331,7 @@
 			<l pos="V">nôhtê-nipâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nôhtê-nipâ-</stem>
@@ -24368,7 +24368,7 @@
 			<l pos="V">nôhtêpayiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nôhtêpayi-</stem>
@@ -24420,7 +24420,7 @@
 			<l pos="V">nôhtêpayiw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>nôhtêpayi-</stem>
@@ -24472,7 +24472,7 @@
 			<l pos="V">nôkohcikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nôkohcikê-</stem>
@@ -24635,7 +24635,7 @@
 			<l pos="V">nôtamiskwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nôtamiskwê-</stem>
@@ -24672,7 +24672,7 @@
 			<l pos="V">ocêhtowi-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>ocêhtowi-kîsikâ-</stem>
@@ -24709,7 +24709,7 @@
 			<l pos="V">ocikisiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ocikisi-</stem>
@@ -24746,7 +24746,7 @@
 			<l pos="V">ocipicikâtêw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>ocipicikâtê-</stem>
@@ -24887,7 +24887,7 @@
 			<l pos="V">ocipitikow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ocipitiko-</stem>
@@ -24939,7 +24939,7 @@
 			<l pos="V">ociwâmiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ociwâmi-</stem>
@@ -25117,7 +25117,7 @@
 			<l pos="V">ohci-wayawîw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohci-wayawî-</stem>
@@ -25169,7 +25169,7 @@
 			<l pos="V">ohciciwan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>ohciciwan-</stem>
@@ -25258,7 +25258,7 @@
 			<l pos="V">ohcikawâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohcikawâpi-</stem>
@@ -25436,7 +25436,7 @@
 			<l pos="V">ohcikawitêyikomêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohcikawitêyikomê-</stem>
@@ -25525,7 +25525,7 @@
 			<l pos="V">ohcinâkosiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohcinâkosi-</stem>
@@ -25562,7 +25562,7 @@
 			<l pos="V">ohcinâkwan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>ohcinâkwan-</stem>
@@ -25599,7 +25599,7 @@
 			<l pos="V">ohcinêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohcinê-</stem>
@@ -25636,7 +25636,7 @@
 			<l pos="V">ohcipahtâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohcipahtâ-</stem>
@@ -25673,7 +25673,7 @@
 			<l pos="V">ohcipayin</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>ohcipayin-</stem>
@@ -25725,7 +25725,7 @@
 			<l pos="V">ohcipayiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohcipayi-</stem>
@@ -25777,7 +25777,7 @@
 			<l pos="V">ohcipayiw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>ohcipayi-</stem>
@@ -25866,7 +25866,7 @@
 			<l pos="V">ohcipiciw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohcipici-</stem>
@@ -25977,7 +25977,7 @@
 			<l pos="V">ohcisin</l>
 			
       
-			<lc>VAI-2</lc>
+			<lc>VAI-n</lc>
 			
       
 			<stem>ohcisin-</stem>
@@ -26014,7 +26014,7 @@
 			<l pos="V">ohciskanawêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohciskanawê-</stem>
@@ -26051,7 +26051,7 @@
 			<l pos="V">ohcistin</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>ohcistin-</stem>
@@ -26177,7 +26177,7 @@
 			<l pos="V">ohciyâkêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohciyâkê-</stem>
@@ -26214,7 +26214,7 @@
 			<l pos="V">ohcîw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohcî-</stem>
@@ -26251,7 +26251,7 @@
 			<l pos="V">ohtawakayêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohtawakayê-</stem>
@@ -26325,7 +26325,7 @@
 			<l pos="V">ohtiskawapiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>ohtiskawapi-</stem>
@@ -26466,7 +26466,7 @@
 			<l pos="V">okitohcikaniw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>okitohcikani-</stem>
@@ -26570,7 +26570,7 @@
 			<l pos="V">omisimiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>omisimi-</stem>
@@ -26607,7 +26607,7 @@
 			<l pos="V">omistikomiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>omistikomi-</stem>
@@ -26644,7 +26644,7 @@
 			<l pos="V">omîciwiniw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>omîciwini-</stem>
@@ -26718,7 +26718,7 @@
 			<l pos="V">opawahikaniw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>opawahikani-</stem>
@@ -26844,7 +26844,7 @@
 			<l pos="V">opêpîmiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>opêpîmi-</stem>
@@ -26918,7 +26918,7 @@
 			<l pos="V">opimîmiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>opimîmi-</stem>
@@ -27140,7 +27140,7 @@
 			<l pos="V">osâwi-sôniyâwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>osâwi-sôniyâwê-</stem>
@@ -27177,7 +27177,7 @@
 			<l pos="V">osâwi-sôniyâwiw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>osâwi-sôniyâwi-</stem>
@@ -27340,7 +27340,7 @@
 			<l pos="V">osôniyâmiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>osôniyâmi-</stem>
@@ -27377,7 +27377,7 @@
 			<l pos="V">otami-mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>otami-mîciso-</stem>
@@ -27488,7 +27488,7 @@
 			<l pos="V">otayisiyinîmiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>otayisiyinîmi-</stem>
@@ -27525,7 +27525,7 @@
 			<l pos="V">otâkwani-mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>otâkwani-mîciso-</stem>
@@ -27636,7 +27636,7 @@
 			<l pos="V">otâkwani-mîcisowinihkêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>otâkwani-mîcisowinihkê</stem>
@@ -27710,7 +27710,7 @@
 			<l pos="V">otânisiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>otânisi-</stem>
@@ -28066,7 +28066,7 @@
 			<l pos="V">pa-pasakwâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pasakwâpi-</stem>
@@ -28103,7 +28103,7 @@
 			<l pos="V">pahkwêsikani-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>pahkwêsikani-kîsikâ-</stem>
@@ -28318,7 +28318,7 @@
 			<l pos="V">paminawasow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>paminawaso-</stem>
@@ -28355,7 +28355,7 @@
 			<l pos="V">paminâwasow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>paminâwaso-</stem>
@@ -28444,7 +28444,7 @@
 			<l pos="V">papâm-âyâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>papâm-âyâ-</stem>
@@ -28481,7 +28481,7 @@
 			<l pos="V">papâmâmow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>papâmâmo-</stem>
@@ -28533,7 +28533,7 @@
 			<l pos="V">papâmitâcimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>papâmitâcimo-</stem>
@@ -28585,7 +28585,7 @@
 			<l pos="V">pasakwâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pasakwâpi-</stem>
@@ -28815,7 +28815,7 @@
 			<l pos="V">pawahikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pawahikê-</stem>
@@ -28867,7 +28867,7 @@
 			<l pos="V">pawahiminêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pawahiminê-</stem>
@@ -28904,7 +28904,7 @@
 			<l pos="V">pawahokêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pawahokê-</stem>
@@ -29067,7 +29067,7 @@
 			<l pos="V">pâh-pasakwâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pasakwâpi-</stem>
@@ -29156,7 +29156,7 @@
 			<l pos="V">pâh-pawahikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pawahikê-</stem>
@@ -29341,7 +29341,7 @@
 			<l pos="V">pâhkwâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pâhkwâpi-</stem>
@@ -29467,7 +29467,7 @@
 			<l pos="V">pê-mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>mîciso-</stem>
@@ -29504,7 +29504,7 @@
 			<l pos="V">pê-nipâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>nipâ-</stem>
@@ -29667,7 +29667,7 @@
 			<l pos="V">pêkwatâmow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêkwatâmo-</stem>
@@ -30274,7 +30274,7 @@
 			<l pos="V">pêyako-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>pêyako-kîsikâ-</stem>
@@ -30311,7 +30311,7 @@
 			<l pos="V">pêyako-nîmâskwêwinêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyako-nîmâskwêwinê-</stem>
@@ -30348,7 +30348,7 @@
 			<l pos="V">pêyako-nîpawiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyako-nîpawi-</stem>
@@ -30422,7 +30422,7 @@
 			<l pos="V">pêyako-tipiskwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyako-tipiskwê-</stem>
@@ -30459,7 +30459,7 @@
 			<l pos="V">pêyakocihcêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakocihcê-</stem>
@@ -30652,7 +30652,7 @@
 			<l pos="V">pêyakohkwâmiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakohkwâmi-</stem>
@@ -30759,7 +30759,7 @@
 			<l pos="V">pêyakokamikosiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakokamikosi-</stem>
@@ -30796,7 +30796,7 @@
 			<l pos="V">pêyakokâpawiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakokâpawi-</stem>
@@ -30870,7 +30870,7 @@
 			<l pos="V">pêyakokâtêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakokâtê-</stem>
@@ -30922,7 +30922,7 @@
 			<l pos="V">pêyakokêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakokê-</stem>
@@ -31011,7 +31011,7 @@
 			<l pos="V">pêyakonêhow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakonêho-</stem>
@@ -31174,7 +31174,7 @@
 			<l pos="V">pêyakopêhikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakopêhikê-</stem>
@@ -31211,7 +31211,7 @@
 			<l pos="V">pêyakopiponwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakopiponwê-</stem>
@@ -31337,7 +31337,7 @@
 			<l pos="V">pêyakosimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakosimo-</stem>
@@ -31414,7 +31414,7 @@
 			<l pos="V">pêyakosisâniwiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakosisâniwi-</stem>
@@ -31488,7 +31488,7 @@
 			<l pos="V">pêyakotêskanêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakotêskanê-</stem>
@@ -31525,7 +31525,7 @@
 			<l pos="V">pêyakow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyako-</stem>
@@ -31577,7 +31577,7 @@
 			<l pos="V">pêyakowiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakowi-</stem>
@@ -31703,7 +31703,7 @@
 			<l pos="V">pêyakôskânêsiwak</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakôskânêsi-</stem>
@@ -31792,7 +31792,7 @@
 			<l pos="V">pêyakwahpicikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakwahpicikê-</stem>
@@ -31940,7 +31940,7 @@
 			<l pos="V">pêyakwan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>pêyakwan-</stem>
@@ -32096,7 +32096,7 @@
 			<l pos="V">pêyakwapiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakwapi-</stem>
@@ -32133,7 +32133,7 @@
 			<l pos="V">pêyakwaskan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>pêyakwaskan-</stem>
@@ -32244,7 +32244,7 @@
 			<l pos="V">pêyakwaskisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakwaskiso-</stem>
@@ -32281,7 +32281,7 @@
 			<l pos="V">pêyakwaskokâpawiw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>pêyakwaskokâpawi-</stem>
@@ -32585,7 +32585,7 @@
 			<l pos="V">pêyakwêkan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>pêyakwêkan-</stem>
@@ -32622,7 +32622,7 @@
 			<l pos="V">pêyakwêyimisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pêyakwêyimiso-</stem>
@@ -32696,7 +32696,7 @@
 			<l pos="V">piminawasosiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>piminawasosi-</stem>
@@ -32733,7 +32733,7 @@
 			<l pos="V">piminawasow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>piminawaso-</stem>
@@ -32859,7 +32859,7 @@
 			<l pos="V">pimitâcimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pimitâcimo-</stem>
@@ -32963,7 +32963,7 @@
 			<l pos="V">pimohtêskanawan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>pimohtêskanawan-</stem>
@@ -33074,7 +33074,7 @@
 			<l pos="V">pipon</l>
 			
       
-			<lc>VII-1n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>pipon-</stem>
@@ -33474,7 +33474,7 @@
 			<l pos="V">piponâspinêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>piponâspinê-</stem>
@@ -33585,7 +33585,7 @@
 			<l pos="V">piponihêwiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>piponihêwi-</stem>
@@ -33622,7 +33622,7 @@
 			<l pos="V">piponisiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>piponisi-</stem>
@@ -33726,7 +33726,7 @@
 			<l pos="V">piponwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>piponwê-</stem>
@@ -33800,7 +33800,7 @@
 			<l pos="V">pîhawawâskwêyâw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>pîhawawâskwêyâ-</stem>
@@ -33874,7 +33874,7 @@
 			<l pos="V">pîhtokêtâcimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pîhtokêtâcimo-</stem>
@@ -33963,7 +33963,7 @@
 			<l pos="V">pîmayiwinisêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pîmayiwinisê-</stem>
@@ -34000,7 +34000,7 @@
 			<l pos="V">pîwapiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pîwapi-</stem>
@@ -34037,7 +34037,7 @@
 			<l pos="V">pohciniskêyiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pohciniskêyi-</stem>
@@ -34074,7 +34074,7 @@
 			<l pos="V">pohcipayihow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pohcipayiho-</stem>
@@ -34126,7 +34126,7 @@
 			<l pos="V">pohcipayin</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>pohcipayin-</stem>
@@ -34393,7 +34393,7 @@
 			<l pos="V">postayiwinisahisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>postayiwinisahiso-</stem>
@@ -34430,7 +34430,7 @@
 			<l pos="V">postayiwinisêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>postayiwinisê-</stem>
@@ -34504,7 +34504,7 @@
 			<l pos="V">pôn-âpihtâ-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>pôn-âpihtâ-kîsikâ-</stem>
@@ -34541,7 +34541,7 @@
 			<l pos="V">pôn-âpihtâ-tipiskâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>pôn-âpihtâ-tipiskâ-</stem>
@@ -34578,7 +34578,7 @@
 			<l pos="V">pôn-âyamihêwi-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>pôn-âyamihêwi-kîsikâ-</stem>
@@ -34615,7 +34615,7 @@
 			<l pos="V">pôni-mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>pôni-mîciso-</stem>
@@ -34652,7 +34652,7 @@
 			<l pos="V">samiskamâsow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>samiskamâso-</stem>
@@ -34689,7 +34689,7 @@
 			<l pos="V">sasîpihtawakêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>sasîpihtawakê-</stem>
@@ -34963,7 +34963,7 @@
 			<l pos="V">sêkwasow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>sêkwaso-</stem>
@@ -35148,7 +35148,7 @@
 			<l pos="V">sîtawahikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>sîtawahikê-</stem>
@@ -35185,7 +35185,7 @@
 			<l pos="V">sôniyâhkâkêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>sôniyâhkâkê-</stem>
@@ -35296,7 +35296,7 @@
 			<l pos="V">sôniyâhkêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>sôniyâhkê-</stem>
@@ -35400,7 +35400,7 @@
 			<l pos="V">sôniyâskâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>sôniyâskâ-</stem>
@@ -35489,7 +35489,7 @@
 			<l pos="V">sôniyâw-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>sôniyâw-kîsikâ-</stem>
@@ -35600,7 +35600,7 @@
 			<l pos="V">sôniyâw-okimâwiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>sôniyâw-okimâwi-</stem>
@@ -35711,7 +35711,7 @@
 			<l pos="V">sôniyâwan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>sôniyâwan-</stem>
@@ -35859,7 +35859,7 @@
 			<l pos="V">sôniyâwâskosiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>sôniyâwâskosi-</stem>
@@ -35896,7 +35896,7 @@
 			<l pos="V">sôniyâwi-pîwayêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>sôniyâwi-pîwayê-</stem>
@@ -35933,7 +35933,7 @@
 			<l pos="V">sôniyâwihkêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>sôniyâwihkê-</stem>
@@ -36059,7 +36059,7 @@
 			<l pos="V">sôniyâwiw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>sôniyâwi-</stem>
@@ -36170,7 +36170,7 @@
 			<l pos="V">tahkohci-pahkisin</l>
 			
       
-			<lc>VAI-2</lc>
+			<lc>VAI-n</lc>
 			
       
 			<stem>tahkohci-pahkisin-</stem>
@@ -36207,7 +36207,7 @@
 			<l pos="V">tahkohcikâpawiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>tahkohcikâpawi-</stem>
@@ -36244,7 +36244,7 @@
 			<l pos="V">tahkohcipayihow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>tahkohcipayiho-</stem>
@@ -36281,7 +36281,7 @@
 			<l pos="V">tahkohcipayiw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>tahkohcipayi-</stem>
@@ -36318,7 +36318,7 @@
 			<l pos="V">tahkohcisin</l>
 			
       
-			<lc>VAI-2</lc>
+			<lc>VAI-n</lc>
 			
       
 			<stem>tahkohcisin-</stem>
@@ -36496,7 +36496,7 @@
 			<l pos="V">tahtopiponwêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>tahtopiponwê-</stem>
@@ -36570,7 +36570,7 @@
 			<l pos="V">takosinômakan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>takosinômakan-</stem>
@@ -36681,7 +36681,7 @@
 			<l pos="V">tastawahikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>tastawahikê-</stem>
@@ -36829,7 +36829,7 @@
 			<l pos="V">tawahcâw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>tawahcâ-</stem>
@@ -36866,7 +36866,7 @@
 			<l pos="V">tawahikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>tawahikê-</stem>
@@ -36903,7 +36903,7 @@
 			<l pos="V">tawahkahikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>tawahkahikê-</stem>
@@ -36977,7 +36977,7 @@
 			<l pos="V">tawaskisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>tawaskiso-</stem>
@@ -37014,7 +37014,7 @@
 			<l pos="V">tawastêw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>tawastê-</stem>
@@ -37125,7 +37125,7 @@
 			<l pos="V">tawayâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>tawayâ-</stem>
@@ -37162,7 +37162,7 @@
 			<l pos="V">tawâstêw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>tawâstê-</stem>
@@ -37528,7 +37528,7 @@
 			<l pos="V">tânitahtopiponêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>tânitahtopiponê-</stem>
@@ -37602,7 +37602,7 @@
 			<l pos="V">têpakohpopiponêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>têpakohpopiponê-</stem>
@@ -37639,7 +37639,7 @@
 			<l pos="V">têpi-mîcisow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>têpi-mîciso-</stem>
@@ -37676,7 +37676,7 @@
 			<l pos="V">têpi-nipâw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>têpi-nipâ-</stem>
@@ -37750,7 +37750,7 @@
 			<l pos="V">têwihtawakêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>têwihtawakê-</stem>
@@ -37787,7 +37787,7 @@
 			<l pos="V">têyihtawakêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>têyihtawakê-</stem>
@@ -38039,7 +38039,7 @@
 			<l pos="V">tipinawahikêw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>tipinawahikê-</stem>
@@ -38143,7 +38143,7 @@
 			<l pos="V">tipiskâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>tipiskâ-</stem>
@@ -38343,7 +38343,7 @@
 			<l pos="V">wahkêmow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>wahkêmo-</stem>
@@ -38395,7 +38395,7 @@
 			<l pos="V">wanimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>wanimo-</stem>
@@ -38432,7 +38432,7 @@
 			<l pos="V">wanitipiskâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>wanitipiskâ-</stem>
@@ -38484,7 +38484,7 @@
 			<l pos="V">wayawîtâcimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>wayawîtâcimo-</stem>
@@ -39010,7 +39010,7 @@
 			<l pos="V">wâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>wâpi-</stem>
@@ -39087,7 +39087,7 @@
 			<l pos="V">wâsêkamatawâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>wâsêkamatawâpi-</stem>
@@ -39124,7 +39124,7 @@
 			<l pos="V">wâwâsêkamatawâpiw</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>wâwâsêkamatawâpi-</stem>
@@ -39657,7 +39657,7 @@
 			<l pos="V">wîpâci-kîsikâw</l>
 			
       
-			<lc>VII-1v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>wîpâci-kîsikâ-</stem>
@@ -39805,7 +39805,7 @@
 			<l pos="V">yahkîmow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>yahkîmo-</stem>
@@ -39931,7 +39931,7 @@
 			<l pos="V">yêkawahcâw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>yêkawahcâ-</stem>
@@ -39968,7 +39968,7 @@
 			<l pos="V">yêkawan</l>
 			
       
-			<lc>VII-2n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>yêkawan-</stem>
@@ -40005,7 +40005,7 @@
 			<l pos="V">yîkatêtâcimow</l>
 			
       
-			<lc>VAI-1</lc>
+			<lc>VAI-v</lc>
 			
       
 			<stem>yîkatêtâcimo-</stem>
@@ -40079,7 +40079,7 @@
 			<l pos="V">yîkwawan</l>
 			
       
-			<lc>VII-1n</lc>
+			<lc>VII-n</lc>
 			
       
 			<stem>yîkwawan-</stem>
@@ -40116,7 +40116,7 @@
 			<l pos="V">yîkwawanipayiw</l>
 			
       
-			<lc>VII-2v</lc>
+			<lc>VII-v</lc>
 			
       
 			<stem>yîkwawanipayi-</stem>

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -102,21 +102,11 @@ def test_search_for_exact_lemma(lemma: Wordform):
     # assert all(len(dfn.source_ids) >= 1 for dfn in exact_match.definitions)
 
 
-@pytest.mark.skip(reason="need a better English stemmer/lemmatizer")
 @pytest.mark.django_db
 def test_search_for_english() -> None:
     """
     Search for a word that is definitely in English.
     """
-
-    # todo: this
-
-    # s = snowballstemmer.EnglishStemmer()
-
-    # >>> s.stemWord('story')
-    # 'stori'
-    # >>> s.stemWord('stories')
-    # 'stori'
 
     # This should match "âcimowin" and related words:
     search_results = Wordform.search("story")

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -246,7 +246,7 @@ def test_search_text_with_ambiguous_word_classes():
 def test_lemma_ranking_most_frequent_word():
     # the English sleep should many cree words. But nipâw should show first because
     # it undoubtedly has the highest frequency
-    results = Wordform.search("sleep")
+    results = Wordform.search("sleeps")
     assert results[0].matched_cree == "nipâw"
 
 

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -102,11 +102,19 @@ def test_search_for_exact_lemma(lemma: Wordform):
     # assert all(len(dfn.source_ids) >= 1 for dfn in exact_match.definitions)
 
 
+@pytest.mark.skip(reason="need a better English stemmer/lemmatizer")
 @pytest.mark.django_db
 def test_search_for_english() -> None:
     """
     Search for a word that is definitely in English.
     """
+
+    # s = snowballstemmer.EnglishStemmer()
+
+    # >>> s.stemWord('story')
+    # 'stori'
+    # >>> s.stemWord('stories')
+    # 'stori'
 
     # This should match "âcimowin" and related words:
     search_results = Wordform.search("story")
@@ -246,7 +254,7 @@ def test_search_text_with_ambiguous_word_classes():
 def test_lemma_ranking_most_frequent_word():
     # the English sleep should many cree words. But nipâw should show first because
     # it undoubtedly has the highest frequency
-    results = Wordform.search("sleeps")
+    results = Wordform.search("sleep")
     assert results[0].matched_cree == "nipâw"
 
 

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -109,6 +109,8 @@ def test_search_for_english() -> None:
     Search for a word that is definitely in English.
     """
 
+    # todo: this
+
     # s = snowballstemmer.EnglishStemmer()
 
     # >>> s.stemWord('story')

--- a/CreeDictionary/tests/DatabaseManager_tests/xml_importer_test.py
+++ b/CreeDictionary/tests/DatabaseManager_tests/xml_importer_test.py
@@ -1,7 +1,7 @@
 import pytest
 from API.models import Wordform
 from DatabaseManager.cree_inflection_generator import expand_inflections
-from DatabaseManager.xml_importer import find_latest_xml_files, load_engcrk_xml
+from DatabaseManager.xml_importer import find_latest_xml_file
 from tests.conftest import migrate_and_import
 from utils import PartOfSpeech, shared_res_dir
 
@@ -81,58 +81,30 @@ def test_import_xml_crkeng_small_common_xml_l_different_ic(shared_datadir):
     assert len(Wordform.objects.filter(text="pisiw", is_lemma=True)) == 2
 
 
-def test_load_engcrk():
-    res = load_engcrk_xml(shared_res_dir / "test_dictionaries" / "engcrk.xml")
-    # nipâw means "sleep"
-    assert "sleep" in res["nipâw", PartOfSpeech.V]
-
-
 @pytest.mark.parametrize(
-    "file_names,expected_crkeng_index,expected_engcrk_index",
+    "file_names,expected_crkeng_index",
     [
         # should use un-timestamped files if necessary
-        (["crkeng.xml", "engcrk.xml"], 0, 1),
+        (["crkeng.xml"], 0),
         # should use un-timestamped files if necessary but timestamped files take higher precedence
-        (["crkeng.xml", "engcrk.xml", "engcrk_cw_md_200113.xml"], 0, 2),
+        (["crkeng_cw_md_200113.xml", "crkeng.xml",], 0),
         # should compare timestamps
-        (
-            [
-                "crkeng_200314.xml",
-                "engcrk_200419.xml",
-                "crkeng_200112.xml",
-                "engcrk_200114.xml",
-            ],
-            0,
-            1,
-        ),
+        (["crkeng_200314.xml", "crkeng_200112.xml",], 0,),
         # irrelevant files should not matter
-        (
-            [
-                "crkeng_200314.xml",
-                "engcrk_200419.xml",
-                "crkeng_200112.xml",
-                "engcrk_200114.xml",
-                "README.md",
-            ],
-            0,
-            1,
-        ),
+        (["crkeng_200314.xml", "README.md", "crkeng_200112.xml",], 0,),
     ],
 )
-def test_find_latest_xml_files(
-    tmp_path_factory, file_names, expected_crkeng_index, expected_engcrk_index
-):
+def test_find_latest_xml_files(tmp_path_factory, file_names, expected_crkeng_index):
     temp_dir = tmp_path_factory.mktemp("foo")
     for file_name in file_names:
         (temp_dir / file_name).write_text("")
-    crkeng_file_path, eng_crk_file_path = find_latest_xml_files(temp_dir)
+    crkeng_file_path = find_latest_xml_file(temp_dir)
     assert file_names.index(crkeng_file_path.name) == expected_crkeng_index
-    assert file_names.index(eng_crk_file_path.name) == expected_engcrk_index
 
 
 def test_find_latest_xml_files_no_file_found(tmp_path):
     with pytest.raises(FileNotFoundError):
-        find_latest_xml_files(tmp_path)
+        find_latest_xml_file(tmp_path)
 
 
 # todo: tests for EnglishKeywords

--- a/CreeDictionary/utils/english_keyword_extraction.py
+++ b/CreeDictionary/utils/english_keyword_extraction.py
@@ -1,5 +1,5 @@
 import re
-from typing import List
+from typing import Set
 
 import snowballstemmer
 
@@ -10,18 +10,16 @@ stop_words = {"a", "an", "the", "s/he", "s.o.", "s.t."}
 stemmer = snowballstemmer.EnglishStemmer()
 
 
-def extract_keywords(translation: str) -> List[str]:
+def stem_keywords(translation: str) -> Set[str]:
     """
     returns lowercased keywords from the translation, by stripping stop words like a/an s/he s.o. s.t.
 
-    returned list has no duplicates
-
-    >>> sorted(extract_keywords("s/he is of a that kind (previously mentioned)"))
+    >>> sorted(stem_keywords("s/he is of a that kind (previously mentioned)"))
     ['is', 'kind', 'mention', 'of', 'previous', 'that']
     """
     words = set(word_pattern.findall(translation.lower()))
 
     # .strip('.') is because of the trailing periods in some translation
-    return stemmer.stemWords(
-        {word.strip(".") for word in words if word not in stop_words}
+    return set(
+        stemmer.stemWords([word.strip(".") for word in words if word not in stop_words])
     )

--- a/Pipfile
+++ b/Pipfile
@@ -31,6 +31,7 @@ attrs = "~=19.1"
 django-js-reverse = "~=0.9"
 sortedcontainers = {file = "https://eddieantonio.keybase.pub/sortedcontainers-2.1.0.tar.gz"}
 marisa-trie = "~=0.7"
+snowballstemmer = "*"
 
 [scripts]
 # look stuff up

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "efaa3fcee3057aee743d6c6575d967ebf5c472ed05f874b03e2ba1d7c02aec97"
+            "sha256": "9318c6af1cb73ab0740c8b7313fe7b70ae5d5e406bd41b738c0ff97f5e73f456"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -84,11 +84,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:edf0ecf6657713b0435b6757e6069466925cae70d634a3283c96b80c01e06191",
-                "sha256:f2250bd35d0f6c23e930c544629934144e5dd39a4c06092e1050c731c1712ba8"
+                "sha256:3e2f5d172215862abf2bac3138d8a04229d34dbd2d0dab42c6bf33876cc22323",
+                "sha256:91f540000227eace0504a24f508de26daa756353aa7376c6972d7920bc339a3a"
             ],
             "index": "pypi",
-            "version": "==2.2.14"
+            "version": "==2.2.15"
         },
         "django-js-reverse": {
             "hashes": [
@@ -121,6 +121,14 @@
             ],
             "index": "pypi",
             "version": "==2019.2"
+        },
+        "snowballstemmer": {
+            "hashes": [
+                "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0",
+                "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
         },
         "sortedcontainers": {
             "file": "https://eddieantonio.keybase.pub/sortedcontainers-2.1.0.tar.gz"
@@ -196,11 +204,11 @@
         },
         "codecov": {
             "hashes": [
-                "sha256:491938ad774ea94a963d5d16354c7299e90422a33a353ba0d38d0943ed1d5091",
-                "sha256:b67bb8029e8340a7bf22c71cbece5bd18c96261fdebc2f105ee4d5a005bc8728"
+                "sha256:0be9cd6358cc6a3c01a1586134b0fb524dfa65ccbec3a40e9f28d5f976676ba2",
+                "sha256:65e8a8008e43eb45a9404bf68f8d4a60d36de3827ef2287971c94940128eba1e"
             ],
             "index": "pypi",
-            "version": "==2.1.7"
+            "version": "==2.1.8"
         },
         "coverage": {
             "hashes": [
@@ -242,11 +250,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:edf0ecf6657713b0435b6757e6069466925cae70d634a3283c96b80c01e06191",
-                "sha256:f2250bd35d0f6c23e930c544629934144e5dd39a4c06092e1050c731c1712ba8"
+                "sha256:3e2f5d172215862abf2bac3138d8a04229d34dbd2d0dab42c6bf33876cc22323",
+                "sha256:91f540000227eace0504a24f508de26daa756353aa7376c6972d7920bc339a3a"
             ],
             "index": "pypi",
-            "version": "==2.2.14"
+            "version": "==2.2.15"
         },
         "django-debug-toolbar": {
             "hashes": [
@@ -294,11 +302,11 @@
                 "pyproject"
             ],
             "hashes": [
-                "sha256:6ae9cf5414e416954e3421f861cbbfc099b3ace63cb270cc76c6670efd960a0a",
-                "sha256:78661ad751751cb3c181d37302e175a0c644b3714877c073df058c596281d7fd"
+                "sha256:60a1b97e33f61243d12647aaaa3e6cc6778f5eb9f42997650f1cc975b6008750",
+                "sha256:d488ba1c5a2db721669cc180180d5acf84ebdc5af7827f7aaeaa75f73cf0e2b8"
             ],
             "index": "pypi",
-            "version": "==5.0.4"
+            "version": "==5.4.2"
         },
         "more-itertools": {
             "hashes": [
@@ -387,11 +395,11 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:1a629dc9f48e53512fcbfda6b07de490c374b0c83c55ff7a1720b3fccff0ac87",
-                "sha256:6e6d18092dce6fad667cd7020deed816f858ad3b49d5b5e2b1cc1c97a4dba65c"
+                "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191",
+                "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"
             ],
             "index": "pypi",
-            "version": "==2.10.0"
+            "version": "==2.10.1"
         },
         "pytest-datadir": {
             "hashes": [
@@ -434,29 +442,29 @@
         },
         "regex": {
             "hashes": [
-                "sha256:08997a37b221a3e27d68ffb601e45abfb0093d39ee770e4257bd2f5115e8cb0a",
-                "sha256:112e34adf95e45158c597feea65d06a8124898bdeac975c9087fe71b572bd938",
-                "sha256:1700419d8a18c26ff396b3b06ace315b5f2a6e780dad387e4c48717a12a22c29",
-                "sha256:2f6f211633ee8d3f7706953e9d3edc7ce63a1d6aad0be5dcee1ece127eea13ae",
-                "sha256:52e1b4bef02f4040b2fd547357a170fc1146e60ab310cdbdd098db86e929b387",
-                "sha256:55b4c25cbb3b29f8d5e63aeed27b49fa0f8476b0d4e1b3171d85db891938cc3a",
-                "sha256:5aaa5928b039ae440d775acea11d01e42ff26e1561c0ffcd3d805750973c6baf",
-                "sha256:654cb773b2792e50151f0e22be0f2b6e1c3a04c5328ff1d9d59c0398d37ef610",
-                "sha256:690f858d9a94d903cf5cada62ce069b5d93b313d7d05456dbcd99420856562d9",
-                "sha256:6ad8663c17db4c5ef438141f99e291c4d4edfeaacc0ce28b5bba2b0bf273d9b5",
-                "sha256:89cda1a5d3e33ec9e231ece7307afc101b5217523d55ef4dc7fb2abd6de71ba3",
-                "sha256:92d8a043a4241a710c1cf7593f5577fbb832cf6c3a00ff3fc1ff2052aff5dd89",
-                "sha256:95fa7726d073c87141f7bbfb04c284901f8328e2d430eeb71b8ffdd5742a5ded",
-                "sha256:97712e0d0af05febd8ab63d2ef0ab2d0cd9deddf4476f7aa153f76feef4b2754",
-                "sha256:b2ba0f78b3ef375114856cbdaa30559914d081c416b431f2437f83ce4f8b7f2f",
-                "sha256:bae83f2a56ab30d5353b47f9b2a33e4aac4de9401fb582b55c42b132a8ac3868",
-                "sha256:c78e66a922de1c95a208e4ec02e2e5cf0bb83a36ceececc10a72841e53fbf2bd",
-                "sha256:cf59bbf282b627130f5ba68b7fa3abdb96372b24b66bdf72a4920e8153fc7910",
-                "sha256:e3cdc9423808f7e1bb9c2e0bdb1c9dc37b0607b30d646ff6faf0d4e41ee8fee3",
-                "sha256:e9b64e609d37438f7d6e68c2546d2cb8062f3adb27e6336bc129b51be20773ac",
-                "sha256:fbff901c54c22425a5b809b914a3bfaf4b9570eee0e5ce8186ac71eb2025191c"
+                "sha256:0dc64ee3f33cd7899f79a8d788abfbec168410be356ed9bd30bbd3f0a23a7204",
+                "sha256:1269fef3167bb52631ad4fa7dd27bf635d5a0790b8e6222065d42e91bede4162",
+                "sha256:14a53646369157baa0499513f96091eb70382eb50b2c82393d17d7ec81b7b85f",
+                "sha256:3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb",
+                "sha256:46bac5ca10fb748d6c55843a931855e2727a7a22584f302dd9bb1506e69f83f6",
+                "sha256:4c037fd14c5f4e308b8370b447b469ca10e69427966527edcab07f52d88388f7",
+                "sha256:51178c738d559a2d1071ce0b0f56e57eb315bcf8f7d4cf127674b533e3101f88",
+                "sha256:5ea81ea3dbd6767873c611687141ec7b06ed8bab43f68fad5b7be184a920dc99",
+                "sha256:6961548bba529cac7c07af2fd4d527c5b91bb8fe18995fed6044ac22b3d14644",
+                "sha256:75aaa27aa521a182824d89e5ab0a1d16ca207318a6b65042b046053cfc8ed07a",
+                "sha256:7a2dd66d2d4df34fa82c9dc85657c5e019b87932019947faece7983f2089a840",
+                "sha256:8a51f2c6d1f884e98846a0a9021ff6861bdb98457879f412fdc2b42d14494067",
+                "sha256:9c568495e35599625f7b999774e29e8d6b01a6fb684d77dee1f56d41b11b40cd",
+                "sha256:9eddaafb3c48e0900690c1727fba226c4804b8e6127ea409689c3bb492d06de4",
+                "sha256:bbb332d45b32df41200380fff14712cb6093b61bd142272a10b16778c418e98e",
+                "sha256:bc3d98f621898b4a9bc7fecc00513eec8f40b5b83913d74ccb445f037d58cd89",
+                "sha256:c11d6033115dc4887c456565303f540c44197f4fc1a2bfb192224a301534888e",
+                "sha256:c50a724d136ec10d920661f1442e4a8b010a4fe5aebd65e0c2241ea41dbe93dc",
+                "sha256:d0a5095d52b90ff38592bbdc2644f17c6d495762edf47d876049cfd2968fbccf",
+                "sha256:d6cff2276e502b86a25fd10c2a96973fdb45c7a977dca2138d661417f3728341",
+                "sha256:e46d13f38cfcbb79bfdb2964b0fe12561fe633caf964a77a5f8d4e45fe5d2ef7"
             ],
-            "version": "==2020.6.8"
+            "version": "==2020.7.14"
         },
         "requests": {
             "hashes": [
@@ -491,11 +499,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:63ef7a6d3eb39f80d6b36e4867566b3d8e5f1fe3d6cb50c5e9ede2b3198ba7b7",
-                "sha256:7810e627bcf9d983a99d9ff8a0c09674400fd2927eddabeadf153c14a2ec8656"
+                "sha256:1a336d2b829be50e46b84668691e0a2719f26c97c62846298dd5ae2937e4d5cf",
+                "sha256:564d632ea2b9cb52979f7956e093e831c28d441c11751682f84c86fc46e4fd21"
             ],
             "index": "pypi",
-            "version": "==4.47.0"
+            "version": "==4.48.2"
         },
         "typed-ast": {
             "hashes": [
@@ -534,10 +542,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
-                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
+                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
-            "version": "==1.25.9"
+            "version": "==1.25.10"
         },
         "wcwidth": {
             "hashes": [

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -41,7 +41,7 @@ context('Regressions', () => {
   // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/158
   it('should display relevant English results', () => {
 
-    cy.visitSearch('eat')
+    cy.visitSearch('eats')
     cy.get('[data-cy=search-results]')
       .should('contain', 'mîcisow')
       .and('contain', 'mîciw')

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -40,11 +40,6 @@ context('Regressions', () => {
 
   // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/158
   it('should display relevant English results', () => {
-    cy.visitSearch('see')
-    cy.get('[data-cy=search-results]')
-      .should('contain', 'wâpiw')
-      .and('contain', 'wâpahtam')
-      .and('contain', 'wâpamêw')
 
     cy.visitSearch('eat')
     cy.get('[data-cy=search-results]')

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -41,7 +41,13 @@ context('Regressions', () => {
   // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/158
   it('should display relevant English results', () => {
 
-    cy.visitSearch('eats')
+    cy.visitSearch('see')
+    cy.get('[data-cy=search-results]')
+      .should('contain', 'wâpiw')
+      .and('contain', 'wâpahtam')
+      .and('contain', 'wâpamêw')
+
+    cy.visitSearch('eat')
     cy.get('[data-cy=search-results]')
       .should('contain', 'mîcisow')
       .and('contain', 'mîciw')
@@ -108,11 +114,11 @@ context('Regressions', () => {
     // Note: It's in dispute whether minôsis should be treated as a diminutive form of minôs
     // todo: enable this test if fst recognized minôsis as diminutive minôs
     it.skip('should show minôs and minôsis for minôsis', () => {
-      cy.visitSearch('minôsis')
-      cy.get('[data-cy=search-results]')
-        .should('contain', 'minôsis')
-        .and('contain', 'minôs')
-    }
+        cy.visitSearch('minôsis')
+        cy.get('[data-cy=search-results]')
+          .should('contain', 'minôsis')
+          .and('contain', 'minôs')
+      }
     )
   })
 

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -1,4 +1,30 @@
 context('Searching', () => {
+
+  // todo: A better English lemmatizer/stemmer
+  describe('it should handles inflected English words', () => {
+
+    it.skip('should treat English "sees" and "see" equally ', () => {
+
+      // both sees/see should give these results
+      cy.visitSearch('see')
+      cy.get('[data-cy=search-results]')
+        .should('contain', 'wâpiw')
+        .and('contain', 'wâpahtam')
+        .and('contain', 'wâpamêw')
+
+      cy.visitSearch('sees')
+      cy.get('[data-cy=search-results]')
+        .should('contain', 'wâpiw')
+        .and('contain', 'wâpahtam')
+        .and('contain', 'wâpamêw')
+
+
+    })
+
+
+  })
+
+
   describe('I want to know what a Cree word means in English', () => {
     // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/120
     it('should search for an exact lemma', () => {
@@ -11,7 +37,7 @@ context('Searching', () => {
     })
 
     it('should perform the search by going directly to the URL', () => {
-      cy.visit('/search?q=minos', { escapeComponents: false })
+      cy.visit('/search?q=minos', {escapeComponents: false})
 
       cy.get('[data-cy=search-results]')
         .should('contain', 'cat')
@@ -141,7 +167,7 @@ context('Searching', () => {
         .contains('[data-cy=definition-title]', 'nipê-âcimon')
 
       cy.get('@searchResult').get('[data-cy=reference-to-lemma]')
-        .contains( 'âcimow')
+        .contains('âcimow')
     })
   })
 
@@ -277,7 +303,7 @@ context('Searching', () => {
       cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
 
       // has to use force: true since div is not clickable
-      cy.get('[data-cy=information-mark]').first().click({force:true})
+      cy.get('[data-cy=information-mark]').first().click({force: true})
 
       cy.get('[data-cy=linguistic-breakdown]').should('be.visible')
         // NOTE: this depends on Antti's relabellings; if they change,
@@ -293,7 +319,7 @@ context('Searching', () => {
 
       // lock onto the searchbar
       cy.get('[data-cy=search]')
-      // get a word (nipaw)
+        // get a word (nipaw)
         .type('nipaw')
 
       // tab through the elements to force the tooltip to pop up
@@ -309,7 +335,7 @@ context('Searching', () => {
       cy.visit('/')
       // lock onto the searchbar
       cy.get('[data-cy=search]')
-      // get a word (use nipaw)
+        // get a word (use nipaw)
         .type('nipaw')
 
       // tab through the page elements until arriving on the '?' icon
@@ -325,11 +351,11 @@ context('Searching', () => {
 
       // lock onto the searchbar
       cy.get('[data-cy=search]')
-      // get a word (Eddie's comment used a very long word in `e-ki-nitawi-kah-kimoci-kotiskaweyahk`, so we will use that!)
+        // get a word (Eddie's comment used a very long word in `e-ki-nitawi-kah-kimoci-kotiskaweyahk`, so we will use that!)
         .type('e-ki-nitawi-kah-kimoci-kotiskaweyahk')
 
       // force the tooltip to appear
-      cy.get('[data-cy=information-mark]').first().click({force:true})
+      cy.get('[data-cy=information-mark]').first().click({force: true})
 
       // check that the z-index of the tooltip is greater than that of all other page elements
       cy.get('[data-cy=information-mark]').first().focus().next().should('have.css', 'z-index', '1') // not a fan of this because of how verbose it is – if there's amore concise way of selecting for a non-focusable element, I'm all ears!
@@ -370,7 +396,7 @@ context('Searching', () => {
   describe('display of the header', function () {
     const lemma = 'nîmiw'
     const wordclassEmoji = '➡️' // the arrow is the most consistent thing, which means verb
-    const inflectionalCategory = 'VAI-1'
+    const inflectionalCategory = 'VAI-v'
     const plainEnglishInflectionalCategory = 'like: nipâw'
     const nonLemmaFormWithDefinition = 'nîminâniwan'
     const nonLemmaFormWithoutDefinition = 'ninîmin'
@@ -607,6 +633,7 @@ context('Searching', () => {
         .should('contain', 'like: pê-')
         .and('not.contain', 'None')
     })
+
     /**
      * @returns {string} the wordform, as if you typed very quickly on your niece's peanut butter-smeared iPad
      */

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -1,30 +1,5 @@
 context('Searching', () => {
 
-  // todo: A better English lemmatizer/stemmer
-  describe('it should handles inflected English words', () => {
-
-    it.skip('should treat English "sees" and "see" equally ', () => {
-
-      // both sees/see should give these results
-      cy.visitSearch('see')
-      cy.get('[data-cy=search-results]')
-        .should('contain', 'wâpiw')
-        .and('contain', 'wâpahtam')
-        .and('contain', 'wâpamêw')
-
-      cy.visitSearch('sees')
-      cy.get('[data-cy=search-results]')
-        .should('contain', 'wâpiw')
-        .and('contain', 'wâpahtam')
-        .and('contain', 'wâpamêw')
-
-
-    })
-
-
-  })
-
-
   describe('I want to know what a Cree word means in English', () => {
     // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/120
     it('should search for an exact lemma', () => {

--- a/libexec/crkeng_stop_word_stat.py
+++ b/libexec/crkeng_stop_word_stat.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+"""
+find out the stop words in crkeng.xml's translations
+"""
+import argparse
+import re
+from collections import Counter
+from pprint import pprint
+from typing import List
+from xml.etree import ElementTree as ET
+
+parser = argparse.ArgumentParser(
+    description="find out the stop words in crkeng.xml's translations"
+)
+parser.add_argument("crkeng_file")
+
+if __name__ == "__main__":
+    word_pattern = re.compile(r"[\w.\-/']+")
+    args = parser.parse_args()
+    root = ET.parse(str(args.crkeng_file)).getroot()
+    elements = root.findall(".//t")
+    translations = {e.text.lower() for e in elements if e.text is not None}
+
+    words: List[str] = [
+        word
+        for translation in translations
+        for word in re.findall(word_pattern, translation)
+    ]
+    print("result is case insensitive:")
+    pprint(Counter(words).most_common(100))
+
+"""
+result on CreeDictionary/res/dictionaries/crkeng_cw_md_200314.xml 
+[('s/he', 17963),
+ ('is', 5010),
+ ('s.o.', 4665),
+ ('a', 4647),
+ ('it', 4255),
+ ('s.t.', 3385),
+ ('he', 2605),
+ ('the', 2566),
+ ('of', 2090),
+ ('to', 2030),
+ ('in', 2022),
+ ('has', 1464),
+ ('for', 1394),
+ ('things', 1233),
+ ('with', 1228),
+ ('by', 1201),
+ ('or', 1136),
+ ('people', 1083),
+ ('on', 1064),
+ ('makes', 999),
+ ('e.g.', 867),
+ ('as', 859),
+ ('his/her', 712),
+ ('one', 685),
+ ('from', 672),
+ ('at', 615),
+ ('my', 569),
+ ('up', 561),
+ ('out', 532),
+ ('an', 523),
+ ('they', 517),
+ ('and', 510),
+ ('it/him', 498),
+ ('him/herself', 475),
+ ('off', 474),
+ ('there', 435),
+ ('own', 422),
+ ('something', 394),
+ ('him', 390),
+ ('takes', 382),
+ ('goes', 374),
+ ('down', 360),
+ ('water', 356),
+ ('about', 355),
+ ('into', 329),
+ ('small', 320),
+ ('being', 317),
+ ('another', 309),
+ ('it.', 306),
+ ('all', 304),
+ ('so', 301),
+ ('him.', 301),
+ ('looks', 289),
+ ('over', 285),
+ ('pulls', 284),
+ ('puts', 280),
+ ('are', 275),
+ ('literally', 262),
+ ('thus', 260),
+ ('cree', 253),
+ ('hand', 252),
+ ('good', 246),
+ ('little', 227),
+ ('thinks', 221),
+ ('together', 219),
+ ('well', 215),
+ ('that', 214),
+ ('gives', 214),
+ ("s.o.'s", 214),
+ ('away', 211),
+ ('way', 209),
+ ('gets', 207),
+ ('back', 201),
+ ('holds', 200),
+ ('cuts', 198),
+ ('be', 194),
+ ('.', 190),
+ ('breaks', 189),
+ ('runs', 185),
+ ('through', 185),
+ ('his', 182),
+ ('places', 181),
+ ('around', 179),
+ ('place', 178),
+ ('time', 174),
+ ('comes', 167),
+ ('animate', 166),
+ ('does', 166),
+ ('bad', 165),
+ ('head', 165),
+ ('not', 163),
+ ('person', 162),
+ ('throws', 158),
+ ('long', 156),
+ ('many', 156),
+ ('such', 155),
+ ('along', 154),
+ ('uses', 150),
+ ('speaks', 147),
+ ('moves', 146)]
+"""


### PR DESCRIPTION
engcrk.xml now is extracted at runtime and no longer needed. Also with documentation cleanup.