### PR TITLE
Debouncing User Queries

### DIFF
--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -179,8 +179,8 @@ context('Regressions', () => {
    */
   it('should search from the about page', function () {
     cy.visit('/about')
-    cy.get('[data-cy="search"]')
-      .type('acâhkos')
+
+    cy.search('acâhkos')
 
     cy.url()
       .should('contain', '/search')

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -1,30 +1,49 @@
 context('Searching', () => {
+  
+  describe('I want to see search results showing dynamically while I type', () => {
+    // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/120
+    it('should search for first minos, then minosis', () => {
+      cy.visit('/')
+      cy.search('minos')
+        .searchResultsContain('cat')
+
+      // makes it minos+is = minosis
+      cy.search('is')
+        .searchResultsContain('kitten')
+    })
+  })
+
+  describe('I want to see search results showing immediately after pressing enter', () => {
+    // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/120
+    it('shows results for minosis immediately after enter is pressed', () => {
+      cy.visit('/')
+      cy.search('minosis', {pressEnter:true})
+        .searchResultsContain('kitten')
+
+    })
+  })
+  
+  
+  describe('I want to see search results by the url', () => {
+    it('perform the search by going directly to the URL', () => {
+      cy.visitSearch('minos')
+        .searchResultsContain('cat')
+    })
+  })
+  
 
   describe('I want to know what a Cree word means in English', () => {
     // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/120
     it('should search for an exact lemma', () => {
-      cy.visit('/')
-      cy.get('[data-cy=search]')
-        .type('minos')
-
-      cy.get('[data-cy=search-results]')
-        .should('contain', 'cat')
-    })
-
-    it('should perform the search by going directly to the URL', () => {
-      cy.visit('/search?q=minos', {escapeComponents: false})
-
-      cy.get('[data-cy=search-results]')
-        .should('contain', 'cat')
+      cy.visitSearch('minos')
+        .searchResultsContain('cat')
     })
   })
 
-  describe('When I type at the search bar, I should see results instantly', function () {
-    it('should display results in the page', function () {
+  describe('I want to have url changed dynamically according to the page', function () {
+    it('should display corresponding url', function () {
       cy.visit('/')
-
-      cy.get('[data-cy=search]')
-        .type('niya')
+      cy.search('niya')
 
       cy.location('pathname')
         .should('contain', '/search')
@@ -36,8 +55,7 @@ context('Searching', () => {
       let originalPathname, originalSearch
       cy.visit('/')
 
-      cy.get('[data-cy=search]')
-        .type('niya')
+      cy.search('niya')
 
       cy.location().should((loc) => {
         originalPathname = loc.pathname
@@ -94,34 +112,27 @@ context('Searching', () => {
   describe('I want the search for a Cree word to tolerate a query which may be spelled in a non-standard or slightly incorrect way.', () => {
     it('should treat apostrophes as short-Is ', () => {
       cy.visit('/')
-      cy.get('[data-cy=search]')
-        .type('tan\'si')
 
-      cy.get('[data-cy=search-results]')
-        .contains('tânisi')
+      cy.visitSearch('tan\'si')
+        .searchResultsContain('tânisi')
     })
 
     it('should forgive omitted long vowel marking', () => {
       cy.visit('/')
-      cy.get('[data-cy=search]')
-        .type('acimew')
+      
+      cy.visitSearch('acimew')
+        .searchResultsContain('âcimêw')
 
-      cy.get('[data-cy=search-results]')
-        .contains('âcimêw')
+      cy.clearSearchBar()
 
-      cy.get('[data-cy=search]')
-        .clear()
-        .type('ayiman')
+            cy.visitSearch('ayiman')
+        .searchResultsContain('âyiman')
 
-      cy.get('[data-cy=search-results]')
-        .contains('âyiman')
     })
 
     it('should handle English-influenced spelling', () => {
       cy.visitSearch('atchakosuk')
-
-      cy.get('[data-cy=search-results]')
-        .contains('atâhk')
+      .searchResultsContain('atâhk')
     })
   })
 
@@ -130,8 +141,8 @@ context('Searching', () => {
       // *nipe-acimon == nipê-âcimon == PV/pe+âcimow+V+AI+Ind+1Sg
       const searchTerm = 'nipe-acimon'
       cy.visit('/')
-      cy.get('[data-cy=search]')
-        .type(searchTerm)
+
+      cy.visitSearch(searchTerm)
 
       cy.get('[data-cy=search-results]')
         .contains('[data-cy=search-result]', /Form of/i)
@@ -149,18 +160,15 @@ context('Searching', () => {
   it('should leave out not normatized content', () => {
     // nipa means "Kill Him" in MD
     cy.visitSearch('nipa')
-
-    cy.get('[data-cy=search-results]')
-      .should('contain', 'sleeps')
+      .searchResultsContain('sleeps')
       .and('not.contain', 'Kill')
   })
 
   it('should do prefix search and suffix search', () => {
     cy.visitSearch('nipaw')
+      .searchResultsContain('nipawâkan')
+      .searchResultsContain('mâci-nipâw')
 
-    cy.get('[data-cy=search-results]')
-      .should('contain', 'nipawâkan')
-      .and('contain', 'mâci-nipâw')
   })
 
   describe('Loading indicator', () => {
@@ -245,8 +253,7 @@ context('Searching', () => {
       // borrowed the following four lines from above and used 'nipaw' for testing purposes.
       const searchTerm = 'niya'
       cy.visit('/')
-      cy.get('[data-cy=search]')
-        .type(searchTerm)
+      cy.search(searchTerm)
 
       cy.get('[data-cy=search-result]').find('[data-cy=information-mark]')
     })
@@ -255,8 +262,7 @@ context('Searching', () => {
   describe('A tooltip should show up when the user click/focus on the i icon beside the matched wordform', () => {
     it('should show tooltip when the user focuses on the i icon beside ê-wâpamat', () => {
       cy.visit('/')
-      cy.get('[data-cy=search]')
-        .type('ewapamat')
+      cy.search('ewapamat')
 
       // not visible at the start
       cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
@@ -271,8 +277,7 @@ context('Searching', () => {
 
     it('should show tooltip when the user clicks on the i icon beside ê-wâpamat', () => {
       cy.visit('/')
-      cy.get('[data-cy=search]')
-        .type('ewapamat')
+      cy.search('ewapamat')
 
       // not visible at the start
       cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
@@ -292,10 +297,7 @@ context('Searching', () => {
       // begin from the homepage
       cy.visit('/')
 
-      // lock onto the searchbar
-      cy.get('[data-cy=search]')
-        // get a word (nipaw)
-        .type('nipaw')
+      cy.search('nipaw')
 
       // tab through the elements to force the tooltip to pop up
       cy.get('[data-cy=information-mark]').first().click()
@@ -308,10 +310,7 @@ context('Searching', () => {
       // goodness, that's a mouthful and should _probably_ be worded better.
       // begin from the homepage
       cy.visit('/')
-      // lock onto the searchbar
-      cy.get('[data-cy=search]')
-        // get a word (use nipaw)
-        .type('nipaw')
+      cy.search('nipaw')
 
       // tab through the page elements until arriving on the '?' icon
       cy.get('[data-cy=information-mark]').first().click()
@@ -324,10 +323,9 @@ context('Searching', () => {
       // begin from the homepage
       cy.visit('/')
 
-      // lock onto the searchbar
-      cy.get('[data-cy=search]')
-        // get a word (Eddie's comment used a very long word in `e-ki-nitawi-kah-kimoci-kotiskaweyahk`, so we will use that!)
-        .type('e-ki-nitawi-kah-kimoci-kotiskaweyahk')
+      // Eddie's comment used a very long word in `e-ki-nitawi-kah-kimoci-kotiskaweyahk`, so we will use that!
+      cy.search('e-ki-nitawi-kah-kimoci-kotiskaweyahk')
+
 
       // force the tooltip to appear
       cy.get('[data-cy=information-mark]').first().click({force: true})
@@ -344,8 +342,7 @@ context('Searching', () => {
     it('should report no results found for ordinary search', function () {
       cy.visit('/')
 
-      cy.get('[data-cy=search]')
-        .type(NON_WORD)
+      cy.search(NON_WORD)
 
       cy.location().should((loc) => {
         expect(loc.pathname).to.eq('/search')

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -252,8 +252,7 @@ context('Searching', () => {
     it("should show the 'info' icon to allow users to access additional information", () => {
       // borrowed the following four lines from above and used 'nipaw' for testing purposes.
       const searchTerm = 'niya'
-      cy.visit('/')
-      cy.search(searchTerm)
+      cy.visitSearch(searchTerm)
 
       cy.get('[data-cy=search-result]').find('[data-cy=information-mark]')
     })
@@ -261,8 +260,7 @@ context('Searching', () => {
 
   describe('A tooltip should show up when the user click/focus on the i icon beside the matched wordform', () => {
     it('should show tooltip when the user focuses on the i icon beside ê-wâpamat', () => {
-      cy.visit('/')
-      cy.search('ewapamat')
+      cy.visitSearch('ewapamat')
 
       // not visible at the start
       cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
@@ -276,8 +274,7 @@ context('Searching', () => {
     })
 
     it('should show tooltip when the user clicks on the i icon beside ê-wâpamat', () => {
-      cy.visit('/')
-      cy.search('ewapamat')
+      cy.visitSearch('ewapamat')
 
       // not visible at the start
       cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
@@ -294,10 +291,8 @@ context('Searching', () => {
     })
 
     it('should show linguistic breakdowns as an ordered list when the user clicks on the ? icon beside a word', () => {
-      // begin from the homepage
-      cy.visit('/')
 
-      cy.search('nipaw')
+      cy.visitSearch('nipaw')
 
       // tab through the elements to force the tooltip to pop up
       cy.get('[data-cy=information-mark]').first().click()
@@ -320,11 +315,8 @@ context('Searching', () => {
     })
 
     it('should not overlap other page elements when being displayed in the page', () => {
-      // begin from the homepage
-      cy.visit('/')
-
       // Eddie's comment used a very long word in `e-ki-nitawi-kah-kimoci-kotiskaweyahk`, so we will use that!
-      cy.search('e-ki-nitawi-kah-kimoci-kotiskaweyahk')
+      cy.visitSearch('e-ki-nitawi-kah-kimoci-kotiskaweyahk')
 
 
       // force the tooltip to appear
@@ -340,9 +332,7 @@ context('Searching', () => {
     const NON_WORD = 'pîpîpôpô'
 
     it('should report no results found for ordinary search', function () {
-      cy.visit('/')
-
-      cy.search(NON_WORD)
+      cy.visitSearch(NON_WORD)
 
       cy.location().should((loc) => {
         expect(loc.pathname).to.eq('/search')

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -125,14 +125,14 @@ context('Searching', () => {
 
       cy.clearSearchBar()
 
-            cy.visitSearch('ayiman')
+      cy.visitSearch('ayiman')
         .searchResultsContain('âyiman')
 
     })
 
     it('should handle English-influenced spelling', () => {
       cy.visitSearch('atchakosuk')
-      .searchResultsContain('atâhk')
+        .searchResultsContain('atâhk')
     })
   })
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -245,3 +245,44 @@ Cypress.Commands.add('getParadigmCell', {prevSubject: false}, (rowLabel, {colLab
   )
 
 })
+
+
+
+/**
+ * this command will type on the search bar with the given query
+ * Note the search bar is not cleared, use cy.clearSearchBar to clear it
+ *
+ * `options` can have bool pressEnter, and integer waitTime
+ *
+ * pressEnter has default false, waitTime has default 500 for results to be shown.
+ *
+ * when pressEnter is true, an {enter} key will follow so that the search goes off immediately.
+ * The site should be refreshed so no wait is needed, waitTime will default to 0
+ *
+ */
+Cypress.Commands.add('search', {prevSubject: false}, (query, options) => {
+
+  options = options || {pressEnter: false, waitTime: 500}
+
+  if (options.pressEnter === true){
+    options.waitTime = 0
+  }
+
+  cy.get('[data-cy=search]')
+    .type(query + (options.pressEnter ? '{enter}' : '')).wait(options.waitTime)
+})
+
+/**
+ * this command clears the search bar
+ */
+Cypress.Commands.add('clearSearchBar', {prevSubject: false}, () => {
+  cy.get('[data-cy=search]').clear()
+})
+
+/**
+ * this command clears the search bar
+ */
+Cypress.Commands.add('searchResultsContain', {prevSubject: false}, (expectedString) => {
+  return cy.get('[data-cy=search-results]')
+    .should('contain', expectedString)
+})


### PR DESCRIPTION
As #529 mentions, typing on the search bar overwhelms our server by sending too many requests.

Now search requests will only go off after 450 miliseconds of inactivity. 

Notably, you can still press Enter / use the magnifying glass button to speed up and save the 450 miliseconds. I actually contributed nothing towards this. As a surprising satisfaction, thanks to our good HTML practices. The search bar is coded in HTML as a form with action=submit, so entering/pressing button will just refresh the page with the already changed url on the page.

Why 450 miliseconds? I did some research and wrote a [blog post](https://madoshakalaka.github.io/2020/08/31/how-hard-should-you-debounce-on-a-responsive-search-bar.html) about it :sunglasses:

# refactoring to integration test

After the debouncing, one integration test involving typing on the search bar times out cuz of the extra 450 miliseconds. It could be prevented by pressing `{enter}` or waiting after the typing. Either ways, we want searching with enter key / wait to be consistent in the tests. 

Included is a refactoring to cypress tests, we have an extra command `cy.search` that types on the search bar:

`cy.search('minos', {pressEnter:false, waitTime: 500})`

 Old test cases were inconsistent about how search were performed, some test cases for example uses `cy.visitSearch()` to visit the url, some test case uses `cy.get([data-cy=search-bar]).type()`. Now all of them uses `cy.visitSearch()` except the ones that explicitly tests for url/typing one by one, which now uses the new command `cy.search`

There is also a QoL command `cy.searchResultsContain`, so this is possible:

`cy.search('minos').searchResultsContain('cat')`





 

