### PR TITLE
Fix Debouncing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -224,7 +224,7 @@ function debounce(func, wait, immediate) {
 const debouncedLoadSearchResults = debounce(() => {
   const searchBar = document.getElementById('search')
   loadSearchResults(searchBar)
-}, 700)
+}, 450)
 
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -221,16 +221,18 @@ function debounce(func, wait, immediate) {
   }
 }
 
+const debouncedLoadSearchResults = debounce(() => {
+  const searchBar = document.getElementById('search')
+  loadSearchResults(searchBar)
+}, 700)
+
+
 
 function setupSearchBar() {
-  let searchBar = document.getElementById('search')
+  const searchBar = document.getElementById('search')
   searchBar.addEventListener('input', () => {
-
     indicateLoading()
-    debounce(() => {
-      loadSearchResults(searchBar)
-    }, 450)()
-
+    debouncedLoadSearchResults()
   })
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,16 @@ import {
 
 const NO_BREAK_SPACE = '\u00A0'
 
+/**
+ * Milliseconds, we only send search requests after this long of time of inactivity has passed.
+ * Prevents too many invalid requests from being sent during typing
+ *
+ * Check the brief blog post to read a study about people's typing speed:
+ * https://madoshakalaka.github.io/2020/08/31/how-hard-should-you-debounce-on-a-responsive-search-bar.html
+ * @type {number}
+ */
+const SERACH_BAR_DEBOUNCE_TIME = 450
+
 
 //////////////////////////////// On page load ////////////////////////////////
 
@@ -224,7 +234,7 @@ function debounce(func, wait, immediate) {
 const debouncedLoadSearchResults = debounce(() => {
   const searchBar = document.getElementById('search')
   loadSearchResults(searchBar)
-}, 450)
+}, SERACH_BAR_DEBOUNCE_TIME)
 
 
 


### PR DESCRIPTION
previously everytime on input, `debounce(loadsearch)` is called to instantiate a new function. This is simply not how debounce is meant to be used. A debounced-function should be instantiated and reused. The wrong usage results in delayed but not debounced requests as mentioned in #529 

Now it's fixed.