### PR TITLE
change: make the other Cree words links

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
@@ -19,7 +19,7 @@
       or using syllabics (e.g.,
       <a href="{% url_for_query 'ᐊᒋᒧᓯᐢ' %}"><span lang="cr">ᐊᒋᒧᓯᐢ</span></a>).</p>
   {% endwith %}
-  <p><a href="{% url_for_query 'itwêwina %}">{% orth 'itwêwina' %}</a>
+  <p><a href="{% url_for_query 'itwêwina' %}">{% orth 'itwêwina' %}</a>
       was made by the
       <a href="https://altlab.artsrn.ualberta.ca/">Alberta Language Technology Lab (ALTLab)</a>,
       in collaboration with the

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
@@ -19,10 +19,15 @@
       or using syllabics (e.g.,
       <a href="{% url_for_query 'ᐊᒋᒧᓯᐢ' %}"><span lang="cr">ᐊᒋᒧᓯᐢ</span></a>).</p>
   {% endwith %}
-  <p>{% orth 'itwêwina' %} was made by the University of Alberta ALTLab,
-      in collaboration with the First Nations University and Maskwacîs Education
-      Schools Commission (MESC). The dictionary entries are courtesy of Dr.
-      Arok Wolvengrey and MESC.</p>
+  <p><a href="{% url_for_query 'itwêwina %}">{% orth 'itwêwina' %}</a>
+      was made by the
+      <a href="https://altlab.artsrn.ualberta.ca/">Alberta Language Technology Lab (ALTLab)</a>,
+      in collaboration with the
+      <a href="https://www.fnuniv.ca/">First Nations University</a> and
+      <a href="https://www.maskwacised.ca/">Maskwacîs Education Schools Commission (MESC)</a>.
+      The dictionary entries are courtesy of
+      <a href="https://www.fnuniv.ca/academic/faculty/dr-arok-wolvengrey/">Dr.  Arok Wolvengrey</a>
+      and MESC.</p>
 </article>
 {% endblock %}
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/index.html
@@ -10,12 +10,14 @@
   <p>{% orth 'itwêwina' %} is a Plains Cree Dictionary.</p>
   {% with long_word='ê-kî-nitawi-kâh-kîmôci-kotiskâwêyâhk' %}
   <p>Type any Cree word to find its English translation. You can search for
-      short Cree words (e.g., {% orth 'atim' %}) or very long Cree words
-      (e.g., <a data-cy="long-word-example" href="{% url_for_query long_word %}">{% orth long_word %}</a>). Or you can type an
-      English word and find its possible Cree translations. You can write words
-      in Cree using standard Roman orthography (SRO) (like
-      <span lang="cr">acimosis</span>) or using syllabics (e.g.,
-      <span lang="cr">ᐊᒋᒧᓯᐢ</span>).</p>
+      short Cree words
+      (e.g., <a href="{% url_for_query 'atim' %}">{% orth 'atim' %}</a>) or very long Cree words
+      (e.g., <a data-cy="long-word-example" href="{% url_for_query long_word %}">{% orth long_word %}</a>).
+      Or you can type an English word and find its possible Cree translations.
+      You can write words in Cree using standard Roman orthography (SRO) (like
+      <a href="{% url_for_query 'acimosis' %}"><span lang="cr">acimosis</span></a>)
+      or using syllabics (e.g.,
+      <a href="{% url_for_query 'ᐊᒋᒧᓯᐢ' %}"><span lang="cr">ᐊᒋᒧᓯᐢ</span></a>).</p>
   {% endwith %}
   <p>{% orth 'itwêwina' %} was made by the University of Alberta ALTLab,
       in collaboration with the First Nations University and Maskwacîs Education


### PR DESCRIPTION
I was upset that only ê-kî-nitawi-kâh-kîmôci-kotiskâwêyâhk was the only Cree word that was a link, so I made the other ones links too