### PR TITLE
Change/linguistic popup

### DIFF
--- a/CreeDictionary/API/schema.py
+++ b/CreeDictionary/API/schema.py
@@ -33,6 +33,14 @@ class SerializedWordform(TypedDict):
     definition: List[SerializedDefinition]
 
 
+class SerializedLinguisticTag(TypedDict):
+    # The tag in its original form, e.g., from the FST
+    value: str
+
+    # The value of the feature, written in plain English
+    in_plain_english: str
+
+
 class SerializedSearchResult(TypedDict):
     # the text of the match
     matched_cree: str
@@ -53,6 +61,9 @@ class SerializedSearchResult(TypedDict):
     # Sequence of all preverb tags, in order
     # Optional: we might not have some preverbs in our database
     preverbs: Tuple[Union[str, SerializedWordform], ...]
+
+    # This omits preverbs and other features displayed elsewhere
+    relevant_tags: Tuple[SerializedLinguisticTag, ...]
 
     # TODO: there are things to be figured out for this :/
     # Sequence of all reduplication tags present, in order

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -21,10 +21,11 @@ from typing import (
 import attr
 from attr import attrs
 from cree_sro_syllabics import syllabics2sro
-from CreeDictionary import hfstol as temp_hfstol
 from django.conf import settings
 from django.db.models import Q
 from sortedcontainers import SortedSet
+
+from CreeDictionary import hfstol as temp_hfstol
 from utils import Language, PartOfSpeech, fst_analysis_parser, get_modified_distance
 from utils.cree_lev_dist import remove_cree_diacritics
 from utils.english_keyword_extraction import stem_keywords
@@ -32,7 +33,7 @@ from utils.fst_analysis_parser import LABELS, partition_analysis
 from utils.types import ConcatAnalysis, FSTTag, Label
 
 from .models import Definition, EnglishKeyword, Wordform
-from .schema import SerializedSearchResult
+from .schema import SerializedLinguisticTag, SerializedSearchResult
 
 # it's a str when the preverb does not exist in the database
 Preverb = Union[Wordform, str]
@@ -41,6 +42,26 @@ MatchedEnglish = NewType("MatchedEnglish", str)
 
 
 logger = logging.getLogger(__name__)
+
+
+@attrs(auto_attribs=True, frozen=True)
+class LinguisticTag:
+    """
+    A linguistic feature/tag pair.
+    """
+
+    # The value in its original form (e.g., +V)
+    value: FSTTag
+    # TODO: feature
+
+    @property
+    def in_plain_english(self) -> str:
+        return LABELS.english.get(self.value) or "???"
+
+    def serialize(self) -> SerializedLinguisticTag:
+        return SerializedLinguisticTag(
+            value=self.value, in_plain_english=self.in_plain_english,
+        )
 
 
 @attrs(auto_attribs=True, frozen=True)  # frozen makes it hashable
@@ -68,6 +89,9 @@ class SearchResult:
     # user friendly linguistic breakdowns
     linguistic_breakdown_head: Tuple[str, ...]
     linguistic_breakdown_tail: Tuple[str, ...]
+
+    # The suffix tags, straight from the FST
+    raw_suffix_tags: Tuple[FSTTag, ...]
 
     # Sequence of all preverb tags, in order
     # Optional: we might not have some preverbs in our database
@@ -102,7 +126,21 @@ class SearchResult:
         result["definitions"] = [
             definition.serialize() for definition in self.definitions
         ]
+        result["relevant_tags"] = tuple(t.serialize() for t in self.relevant_tags)
+
         return cast(SerializedSearchResult, result)
+
+    @property
+    def relevant_tags(self) -> Tuple[LinguisticTag, ...]:
+        """
+        Tags and features to display in the linguistic breakdown pop-up.
+        This omits preverbs and other features displayed elsewhere
+
+        In itwêwina, these tags are derived from the suffix features exclusively.
+        """
+        return tuple(
+            LinguisticTag(value=cast(FSTTag, tag)) for tag in self.raw_suffix_tags
+        )
 
 
 class CreeResult(NamedTuple):
@@ -206,6 +244,7 @@ class WordformSearch:
                 linguistic_breakdown_tail=tuple(
                     replace_user_friendly_tags(linguistic_breakdown_tail)
                 ),
+                raw_suffix_tags=tuple(linguistic_breakdown_tail),
                 lemma_wordform=cree_result.lemma,
                 preverbs=get_preverbs_from_head_breakdown(linguistic_breakdown_head),
                 reduplication_tags=(),
@@ -236,6 +275,7 @@ class WordformSearch:
                 linguistic_breakdown_tail=tuple(
                     replace_user_friendly_tags(linguistic_breakdown_tail)
                 ),
+                raw_suffix_tags=tuple(linguistic_breakdown_tail),
                 definitions=tuple(result.matched_cree.definitions.all()),
                 # todo: current EnglishKeyword is bound to
                 #       lemmas, whose definitions are guaranteed in the database.
@@ -279,8 +319,7 @@ def get_preverbs_from_head_breakdown(
                     preverb_result = min(
                         preverb_results,
                         key=lambda pr: get_modified_distance(
-                            normative_preverb_text,
-                            pr.text.strip("-"),
+                            normative_preverb_text, pr.text.strip("-"),
                         ),
                     )
 
@@ -476,9 +515,7 @@ def fetch_lemma_by_user_query(user_query: str, **extra_constraints) -> CreeAndEn
     for preverb_wf in fetch_preverbs(user_query):
         cree_results.add(
             CreeResult(
-                ConcatAnalysis(preverb_wf.analysis),
-                preverb_wf,
-                Lemma(preverb_wf),
+                ConcatAnalysis(preverb_wf.analysis), preverb_wf, Lemma(preverb_wf),
             )
         )
 
@@ -523,11 +560,9 @@ def replace_user_friendly_tags(fst_tags: List[FSTTag]) -> List[Label]:
 
 def safe_partition_analysis(analysis: ConcatAnalysis):
     try:
-        (
-            linguistic_breakdown_head,
-            _,
-            linguistic_breakdown_tail,
-        ) = partition_analysis(analysis)
+        (linguistic_breakdown_head, _, linguistic_breakdown_tail,) = partition_analysis(
+            analysis
+        )
     except ValueError:
         linguistic_breakdown_head = []
         linguistic_breakdown_tail = []

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -14,6 +14,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    TypeVar,
     Union,
     cast,
 )
@@ -24,6 +25,7 @@ from cree_sro_syllabics import syllabics2sro
 from django.conf import settings
 from django.db.models import Q
 from sortedcontainers import SortedSet
+from typing_extensions import Protocol
 
 from CreeDictionary import hfstol as temp_hfstol
 from utils import Language, PartOfSpeech, fst_analysis_parser, get_modified_distance
@@ -44,24 +46,66 @@ MatchedEnglish = NewType("MatchedEnglish", str)
 logger = logging.getLogger(__name__)
 
 
-@attrs(auto_attribs=True, frozen=True)
-class LinguisticTag:
+class LinguisticTag(Protocol):
     """
     A linguistic feature/tag pair.
     """
 
-    # The value in its original form (e.g., +V)
-    value: FSTTag
-    # TODO: feature
+    @property
+    def value(self) -> FSTTag:
+        ...
+
+    # TODO: linguistic feature
 
     @property
     def in_plain_english(self) -> str:
-        return LABELS.english.get(self.value) or "???"
+        ...
 
     def serialize(self) -> SerializedLinguisticTag:
         return SerializedLinguisticTag(
             value=self.value, in_plain_english=self.in_plain_english,
         )
+
+
+class SimpleLinguisticTag(LinguisticTag):
+    """
+    A linguistic feature/tag pair.
+    """
+
+    def __init__(self, value: FSTTag):
+        self._value = value
+
+    @property
+    def value(self) -> FSTTag:
+        return self._value
+
+    @property
+    def in_plain_english(self) -> str:
+        return LABELS.english.get(self.value) or "???"
+
+
+class CompoundLinguisticTag(LinguisticTag):
+    def __init__(self, tags: Iterable[FSTTag]) -> None:
+        self._fst_tags = tuple(tags)
+
+    @property
+    def value(self):
+        return "".join(self._fst_tags)
+
+    @property
+    def in_plain_english(self):
+        return LABELS.english.get_longest(self._fst_tags)
+
+
+def linguistic_tag_from_fst_tags(tags: Tuple[FSTTag, ...]) -> LinguisticTag:
+    """
+    Returns the appropriate LinguisticTag, no matter how many tags you chuck at it!
+    """
+    assert len(tags) > 0
+    if len(tags) == 1:
+        return SimpleLinguisticTag(tags[0])
+    else:
+        return CompoundLinguisticTag(tags)
 
 
 @attrs(auto_attribs=True, frozen=True)  # frozen makes it hashable
@@ -137,9 +181,11 @@ class SearchResult:
         This omits preverbs and other features displayed elsewhere
 
         In itwêwina, these tags are derived from the suffix features exclusively.
+        We chunk based on the English relabelleings!
         """
         return tuple(
-            LinguisticTag(value=cast(FSTTag, tag)) for tag in self.raw_suffix_tags
+            linguistic_tag_from_fst_tags(fst_tags)
+            for fst_tags in LABELS.english.chunk(self.raw_suffix_tags)
         )
 
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition-title.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/_definition-title.html
@@ -34,35 +34,8 @@
     &#32; {# separate title proper from icons #}
 
     <div class="definition__icons" data-wordform="{{ result.matched_cree }}">
-      {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
-        <div tabindex="0" class="definition__icon definition-title__tooltip-icon" data-has-tooltip data-cy="information-mark">
-          <img
-            src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
-            alt="linguistic breakdown">
-        </div>
-
-        <div class="tooltip" role="tooltip">
-          <div data-cy="linguistic-breakdown">
-            <ol class="linguistic-breakdown">
-              {% if result.lemma_wordform.stem %}
-                <li class="linguistic-breakdown__breakdown-stem" data-cy="linguistic-breakdown__breakdown-stem">
-                  Stem: {{ result.lemma_wordform.stem }}
-                </li>
-              {% endif %}
-              {% with tags=result.linguistic_breakdown_head|add:result.linguistic_breakdown_tail %}
-                {% for linguistic_tag in tags %}
-                  <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
-                    {{ linguistic_tag }}
-                  </li>
-                {% endfor %}
-              {% endwith %}
-            </ol>
-          </div>
-
-          <div class="tooltip__arrow" data-popper-arrow></div>
-        </div>
-        {# NB: the "Play recording" icon will be appened here #}
-      {% endif %}
+      {% include "CreeDictionary/components/linguistic-breakdown.html" %}
+      {# NB: 🔊 Recording button is added here dynamically by JavaScript #}
     </div>
   </div>
 {% endspaceless %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/linguistic-breakdown.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/linguistic-breakdown.html
@@ -31,14 +31,13 @@
           {% if result.lemma_wordform.stem %}
             <h3 class="linguistic-breakdown__stem"> {{ result.lemma_wordform.stem }} </h3>
           {% endif %}
-          <ol class="linguistic-breakdown">
-            {% with tags=result.linguistic_breakdown_head|add:result.linguistic_breakdown_tail %}
-              {% for linguistic_tag in tags %}
-                <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
-                  {{ linguistic_tag }}
-                </li>
-              {% endfor %}
-            {% endwith %}
+
+          <ol class="linguistic-breakdown__list">
+            {% for tag in result.relevant_tags %}
+              <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
+                <data value="{{ tag.value }}">{{ tag.in_plain_english }}</data>
+              </li>
+            {% endfor %}
           </ol>
         </div>
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/linguistic-breakdown.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/linguistic-breakdown.html
@@ -28,12 +28,10 @@
 
       <div class="tooltip" role="tooltip">
         <div data-cy="linguistic-breakdown">
+          {% if result.lemma_wordform.stem %}
+            <h3 class="linguistic-breakdown__stem"> {{ result.lemma_wordform.stem }} </h3>
+          {% endif %}
           <ol class="linguistic-breakdown">
-            {% if result.lemma_wordform.stem %}
-              <li class="linguistic-breakdown__breakdown-stem" data-cy="linguistic-breakdown__breakdown-stem">
-                Stem: {{ result.lemma_wordform.stem }}
-              </li>
-            {% endif %}
             {% with tags=result.linguistic_breakdown_head|add:result.linguistic_breakdown_tail %}
               {% for linguistic_tag in tags %}
                 <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/linguistic-breakdown.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/linguistic-breakdown.html
@@ -1,0 +1,51 @@
+{% spaceless %}
+
+  {% comment %}
+    ## .linguistic-breakdown ##
+
+    Example:
+
+                ℹ️
+      ,---------^-------.
+      | nîmi-           |
+      |   action word   |
+      |   ni-/ki- word  |
+      |   now           |
+      |   somebody      |
+      `-----------------'
+
+  {% endcomment %}
+
+  {% load morphodict_orth %}
+  {% load static %}
+
+    {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
+      <div tabindex="0" class="definition__icon definition-title__tooltip-icon" data-has-tooltip data-cy="information-mark">
+        <img
+          src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
+          alt="linguistic breakdown">
+      </div>
+
+      <div class="tooltip" role="tooltip">
+        <div data-cy="linguistic-breakdown">
+          <ol class="linguistic-breakdown">
+            {% if result.lemma_wordform.stem %}
+              <li class="linguistic-breakdown__breakdown-stem" data-cy="linguistic-breakdown__breakdown-stem">
+                Stem: {{ result.lemma_wordform.stem }}
+              </li>
+            {% endif %}
+            {% with tags=result.linguistic_breakdown_head|add:result.linguistic_breakdown_tail %}
+              {% for linguistic_tag in tags %}
+                <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
+                  {{ linguistic_tag }}
+                </li>
+              {% endfor %}
+            {% endwith %}
+          </ol>
+        </div>
+
+        <div class="tooltip__arrow" data-popper-arrow></div>
+      </div>
+      {# NB: the "Play recording" icon will be appened here #}
+    {% endif %}
+{% endspaceless %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/linguistic-breakdown.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/linguistic-breakdown.html
@@ -34,9 +34,7 @@
 
           <ol class="linguistic-breakdown__list">
             {% for tag in result.relevant_tags %}
-              <li class="linguistic-breakdown__breakdown-tail" data-cy="linguistic-breakdown__breakdown-tail">
-                <data value="{{ tag.value }}">{{ tag.in_plain_english }}</data>
-              </li>
+              <li><data value="{{ tag.value }}">{{ tag.in_plain_english }}</data></li>
             {% endfor %}
           </ol>
         </div>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/preverb-breakdown.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/preverb-breakdown.html
@@ -1,0 +1,51 @@
+{% spaceless %}
+
+  {% comment %}
+    ## .preverb-breakdown ##
+
+    Example:
+
+      Preverb: ê- [i]
+      Preverb: kî- [i]
+      Preverb: nitawi- [i]
+      Preverb: kâh- [i]
+      Preverb: kimoci- [i]
+
+  {% endcomment %}
+
+  {% load creedictionary_extras %}
+  {% load morphodict_orth %}
+  {% load static %}
+
+  {# show preverb breakdown #}
+  <ol class="preverb-breakdown">
+    {% for preverb in result.preverbs %}
+      <li>
+        <span>Preverb: {% if preverb.id %}
+          <a href="{% url_for_query preverb.text %}">{% orth preverb.text %}</a>{% else %}
+          {% orth preverb.text %}{% endif %}
+        </span>
+
+        {% if preverb.id %} {# we know the preverb in the database #}
+          <div tabindex="0" class="preverb-breakdown__tooltip-icon" data-has-tooltip data-cy="information-mark">
+            <img
+              src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
+              alt="preverb breakdown">
+          </div>
+
+          <div class="tooltip" role="tooltip">
+            {% for definition in preverb.definitions %}
+            <p class="preverb-breakdown__preverb-definition">{{ definition.text }}
+            {% for source in definition.source_ids %}
+            <cite class="cite-dict cite-dict--popup">{{ source }}</cite>
+            {% endfor %}
+            </p>
+            {% endfor %}
+            <div class="tooltip__arrow" data-popper-arrow></div>
+          </div>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ol>
+{% endspaceless %}
+{# vim: set ft=htmldjango: et sw=t ts=2 sts=2 #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-entries.html
@@ -24,37 +24,7 @@
       {% endfor %}
     </ol>
 
-    {# show preverb breakdown #}
-    <ol class="preverb-breakdown">
-      {% for preverb in result.preverbs %}
-        <li>
-          <span>Preverb: {% if preverb.id %}
-            <a href="{% url_for_query preverb.text %}">{% orth preverb.text %}</a>{% else %}
-            {% orth preverb.text %}{% endif %}
-          </span>
-
-          {% if preverb.id %} {# we know the preverb in the database #}
-            <div tabindex="0" class="preverb-breakdown__tooltip-icon" data-has-tooltip data-cy="information-mark">
-              <img
-                src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"
-                alt="preverb breakdown">
-            </div>
-
-            <div class="tooltip" role="tooltip">
-              {% for definition in preverb.definitions %}
-              <p class="preverb-breakdown__preverb-definition">{{ definition.text }}
-              {% for source in definition.source_ids %}
-              <cite class="cite-dict cite-dict--popup">{{ source }}</cite>
-              {% endfor %}
-              </p>
-              {% endfor %}
-              <div class="tooltip__arrow" data-popper-arrow></div>
-            </div>
-          {% endif %}
-        </li>
-      {% endfor %}
-    </ol>
-    {# end preverb breakdown #}
+    {% include "CreeDictionary/components/preverb-breakdown.html" %}
 
     {# Show the matched lemma (when this is NOT a lemma). #}
     {% if not result.is_lemma %}

--- a/CreeDictionary/tests/utils_tests/relabelling_test.py
+++ b/CreeDictionary/tests/utils_tests/relabelling_test.py
@@ -4,6 +4,7 @@
 from io import StringIO
 
 import pytest
+
 from utils.fst_analysis_parser import Relabelling
 
 labels = Relabelling.from_tsv(
@@ -68,4 +69,15 @@ def test_get_full_relabelling():
         "something is happening now",
         "ni-/ki- word",
         "s/he → him/her/them",
+    ]
+
+
+def test_chunks_make_full_labels():
+    tag_set = ("V", "TA", "Prs", "Ind", "3Sg", "4Sg/PlO")
+    chunks = list(labels.english.chunk(tag_set))
+    assert chunks == [
+        ("V", "TA"),
+        ("Prs",),
+        ("Ind",),
+        ("3Sg", "4Sg/PlO"),
     ]

--- a/CreeDictionary/utils/fst_analysis_parser.py
+++ b/CreeDictionary/utils/fst_analysis_parser.py
@@ -96,9 +96,7 @@ class _RelabelFetcher:
     """
 
     def __init__(
-        self,
-        data: Relabelling._DataStructure,
-        label: LabelFriendliness,
+        self, data: Relabelling._DataStructure, label: LabelFriendliness,
     ):
         self._data = data
         self._friendliness = label
@@ -118,6 +116,21 @@ class _RelabelFetcher:
         """
         _unmatched, label = self._get_longest(tags)
         return label
+
+    def chunk(self, tags: Iterable[FSTTag]) -> Iterable[Tuple[FSTTag, ...]]:
+        """
+        Chunk FST Labels that match relabellings and yield the tags.
+        """
+        tag_set = tuple(tags)
+        while tag_set:
+            unmatched, _ = self._get_longest(tag_set)
+            prefix_length = len(tag_set) - len(unmatched)
+            if prefix_length == 0:
+                # There was no relabelling found, but we can just return the first tag.
+                prefix_length = 1
+
+            yield tag_set[:prefix_length]
+            tag_set = tag_set[prefix_length:]
 
     def get_full_relabelling(self, tags: Iterable[FSTTag]) -> List[Label]:
         """

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -283,10 +283,8 @@ context('Searching', () => {
         .and('contain', 'wâpam-') // stem
         // NOTE: this depends on Antti's relabellings; if they change,
         // this assertion has to change :/
-        .and('contain', 'Action word') // verb
-      // TODO: these two should be on one line...
-        .and('contain', 'you (one)')  // 3Sg
-        .and('contain', '→ him/her/it')  // -> 4Sg/PlO
+        .and('contain', 'Action word - like') // VTA
+        .and('contain', 'you (one) → him/her')  // 3Sg -> 4Sg/PlO
     })
 
     it('should show linguistic breakdowns as an ordered list when the user clicks on the i icon beside a word', () => {

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -1,5 +1,4 @@
 context('Searching', () => {
-  
   describe('I want to see search results showing dynamically while I type', () => {
     // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/120
     it('should search for first minos, then minosis', () => {
@@ -22,15 +21,15 @@ context('Searching', () => {
 
     })
   })
-  
-  
+
+
   describe('I want to see search results by the url', () => {
     it('perform the search by going directly to the URL', () => {
       cy.visitSearch('minos')
         .searchResultsContain('cat')
     })
   })
-  
+
 
   describe('I want to know what a Cree word means in English', () => {
     // https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/120
@@ -119,7 +118,7 @@ context('Searching', () => {
 
     it('should forgive omitted long vowel marking', () => {
       cy.visit('/')
-      
+
       cy.visitSearch('acimew')
         .searchResultsContain('âcimêw')
 
@@ -323,6 +322,29 @@ context('Searching', () => {
 
       // check that the z-index of the tooltip is greater than that of all other page elements
       cy.get('[data-cy=information-mark]').first().focus().next().should('have.css', 'z-index', '1') // not a fan of this because of how verbose it is – if there's amore concise way of selecting for a non-focusable element, I'm all ears!
+    })
+
+    /**
+     * https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/549
+     */
+    it('displays the stem prominently', function () {
+      cy.visitSearch('pê-nîmiw')
+
+      // Open the linguistic breakdown popup
+      cy.get('[data-cy=search-result]')
+        .find('[data-cy=information-mark]')
+        .first()
+        .click()
+
+      cy.get('[data-cy=linguistic-breakdown]')
+        .as('linguistic-breakdown')
+        .should('be.visible')
+
+      cy.get('@linguistic-breakdown')
+        .contains('nîmi-')
+        .should(($el) => {
+          expect(+$el.css('font-weight')).to.be.greaterThan(400)
+        })
     })
   })
 

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -327,7 +327,7 @@ context('Searching', () => {
     /**
      * https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/549
      */
-    it('displays the stem prominently', function () {
+    it('displays the stem prominently in the linguistic breakdown', function () {
       cy.visitSearch('pê-nîmiw')
 
       // Open the linguistic breakdown popup
@@ -345,6 +345,26 @@ context('Searching', () => {
         .should(($el) => {
           expect(+$el.css('font-weight')).to.be.greaterThan(400)
         })
+    })
+
+    it('displays the suffix features in the linguistic breakdown', function () {
+      cy.visitSearch('pê-nîmiw')
+
+      // Open the linguistic breakdown popup
+      cy.get('[data-cy=search-result]')
+        .find('[data-cy=information-mark]')
+        .first()
+        .click()
+
+      cy.get('[data-cy=linguistic-breakdown]')
+        .as('linguistic-breakdown')
+        .should('be.visible')
+      cy.get('@linguistic-breakdown')
+        .contains('li', 'Action word')
+      cy.get('@linguistic-breakdown')
+        .contains('li', 'ni-/ki- word')
+      cy.get('@linguistic-breakdown')
+        .contains('li', 's/he')
     })
   })
 

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -263,7 +263,6 @@ context('Searching', () => {
 
       // not visible at the start
       cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
-        .and('contain', 'complementizer') // preververb
         .and('contain', 'Action word') // verb
 
       cy.get('[data-cy=information-mark]').first().focus()
@@ -278,14 +277,16 @@ context('Searching', () => {
       cy.get('[data-cy=linguistic-breakdown]').should('not.be.visible')
 
       // has to use force: true since div is not clickable
-      cy.get('[data-cy=information-mark]').first().click({force: true})
+      cy.get('[data-cy=information-mark]').first().click()
 
       cy.get('[data-cy=linguistic-breakdown]').should('be.visible')
+        .and('contain', 'wâpam-') // stem
         // NOTE: this depends on Antti's relabellings; if they change,
         // this assertion has to change :/
         .and('contain', 'Action word') // verb
-        .and('contain', 'you (one) → him/her') // 3Sg -> 4Sg/PlO
-        .and('contain', 'wâpam-') // stem
+      // TODO: these two should be on one line...
+        .and('contain', 'you (one)')  // 3Sg
+        .and('contain', '→ him/her/it')  // -> 4Sg/PlO
     })
 
     it('should show linguistic breakdowns as an ordered list when the user clicks on the i icon beside a word', () => {

--- a/src/css/_tooltip.css
+++ b/src/css/_tooltip.css
@@ -85,27 +85,3 @@
   border-bottom: 0;
   border-left: 0;
 }
-
-/**
- * TOOLTIP specific styling
- *
- * Should remove the numbering from the lists that come with the linguistic breakdowns
- */
-.linguistic-breakdown__breakdown-tail {
-  /* Fallback (for Safari) */
-  list-style: disc;
-  /* What we actually want: (Safari ignores this line) */
-  list-style: " – ";
-}
-
-/**
- * TOOLTIP specific styling
- *
- * Should remove the numbering for ol
- */
-.linguistic-breakdown__breakdown-stem {
-  /* Fallback (for Safari) */
-  list-style: disc;
-  /* What we actually want: (Safari ignores this line) */
-  list-style: " – ";
-}

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -600,27 +600,17 @@ a.multiple-recordings__action-button {
 }
 
 /**
- * TOOLTIP specific styling
+ * ELEMENT list
  *
- * Should remove the numbering from the lists that come with the linguistic breakdowns
+ * The list that describes each morphosyntactic feature (tag).
  */
-.linguistic-breakdown__breakdown-tail {
-  /* Fallback (for Safari) */
-  list-style: disc;
-  /* What we actually want: (Safari ignores this line) */
-  list-style: " – ";
-}
+.linguistic-breakdown__list {
+  padding-left: 3em;
 
-/**
- * TOOLTIP specific styling
- *
- * Should remove the numbering for ol
- */
-.linguistic-breakdown__breakdown-stem {
-  /* Fallback (for Safari) */
-  list-style: disc;
-  /* What we actually want: (Safari ignores this line) */
-  list-style: " – ";
+  /* Create a hanging indent: */
+  text-indent: -1em;
+
+  list-style: none;
 }
 
 /**

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -582,6 +582,23 @@ a.multiple-recordings__action-button {
   cursor: help;
 }
 
+/*************************** LINGUISTIC BREAKDOWN ***************************/
+
+/**
+ * BLOCK linguistic-breakdown
+ *
+ * Contains linguistic information about a wordform.
+ */
+
+/**
+ * ELEMENT linguistic-breakdown__stem
+ *
+ * The stem of the word that is then inflected.
+ */
+.linguistic-breakdown__stem {
+  margin: 0;
+}
+
 /**
  * BLOCK cleave-inflection-from-lemma
  *

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -600,6 +600,30 @@ a.multiple-recordings__action-button {
 }
 
 /**
+ * TOOLTIP specific styling
+ *
+ * Should remove the numbering from the lists that come with the linguistic breakdowns
+ */
+.linguistic-breakdown__breakdown-tail {
+  /* Fallback (for Safari) */
+  list-style: disc;
+  /* What we actually want: (Safari ignores this line) */
+  list-style: " – ";
+}
+
+/**
+ * TOOLTIP specific styling
+ *
+ * Should remove the numbering for ol
+ */
+.linguistic-breakdown__breakdown-stem {
+  /* Fallback (for Safari) */
+  list-style: disc;
+  /* What we actually want: (Safari ignores this line) */
+  list-style: " – ";
+}
+
+/**
  * BLOCK cleave-inflection-from-lemma
  *
  * Separates the info for the matched wordform/inflection


### PR DESCRIPTION
This is what the linguistic breakdown pop-up looks like now:

![the new search for pê-nîmiw](https://user-images.githubusercontent.com/2294397/96619954-044d5900-12c4-11eb-971e-1462fc37503d.png)

Resolves #549 