### PR TITLE
Use `ENABLE_DJANGO_DEBUG_FLAG` instead of relying on CI

### DIFF
--- a/CreeDictionary/CreeDictionary/coerce.py
+++ b/CreeDictionary/CreeDictionary/coerce.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from typing import Union
+
+
+def to_boolean(envvar: Union[str, bool]) -> bool:
+    """
+    Coerce the input to a boolean.
+
+    >>> to_boolean("True")
+    True
+    >>> to_boolean("FALSE")
+    False
+
+    NOTE: An empty string is interpreted as False:
+
+    >>> to_boolean("")
+    False
+
+    Booleans are returned as-is:
+
+    >>> to_boolean(True)
+    True
+    >>> to_boolean(False)
+    False
+
+    Anything else is an error:
+
+    >>> to_boolean("1")
+    Traceback (most recent call last):
+        ...
+    ValueError: Could not coerce value to True or False: '1'
+    """
+    if isinstance(envvar, bool):
+        return envvar
+
+    str_value = envvar.lower()
+    if str_value == "true":
+        return True
+    elif str_value in ("false", ""):
+        return False
+    else:
+        raise ValueError(f"Could not coerce value to True or False: {envvar!r}")

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -35,9 +35,6 @@ RUNNING_ON_SAPIR = (
 # Debug is default to False
 # Turn it to True in development
 DEBUG = os.environ.get("DEBUG", "False").lower() == "true"
-ENABLE_DJANGO_DEBUG_TOOLBAR = (
-    os.environ.get("ENABLE_DJANGO_DEBUG_TOOLBAR", str(DEBUG)).lower() == "true"
-)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 if RUNNING_ON_SAPIR:  # pragma: no cover
@@ -45,6 +42,29 @@ if RUNNING_ON_SAPIR:  # pragma: no cover
 
 # travis has CI equals True
 CI = os.environ.get("CI", "False").lower() == "true"
+
+# The Django debug toolbar is a great help when... you know... debugging Django,
+# but it has a few issues:
+#  - the middleware SIGNIFICANTLY increases request times
+#  - the debug toolbar adds junk on the DOM, which may interfere with end-to-end tests
+#
+# The reasonable default is to enable it on development machines and let the developer
+# opt out of it, if needed.
+if "ENABLE_DJANGO_DEBUG_TOOLBAR" in os.environ:
+    ENABLE_DJANGO_DEBUG_TOOLBAR = (
+        os.environ["ENABLE_DJANGO_DEBUG_TOOLBAR"].lower() == "true"
+    )
+else:
+    ENABLE_DJANGO_DEBUG_TOOLBAR = DEBUG
+
+# The debug toolbar should ALWAYS be turned off:
+#  - when DEBUG is disabled
+#  - in CI environments
+if not DEBUG or CI:
+    ENABLE_DJANGO_DEBUG_TOOLBAR = False
+
+
+# Host settings:
 
 if DEBUG:
     ALLOWED_HOSTS = ["*"]

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -35,6 +35,9 @@ RUNNING_ON_SAPIR = (
 # Debug is default to False
 # Turn it to True in development
 DEBUG = os.environ.get("DEBUG", "False").lower() == "true"
+ENABLE_DJANGO_DEBUG_TOOLBAR = (
+    os.environ.get("ENABLE_DJANGO_DEBUG_TOOLBAR", str(DEBUG)).lower() == "true"
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 if RUNNING_ON_SAPIR:  # pragma: no cover
@@ -78,20 +81,20 @@ MIDDLEWARE = [
 ]
 
 # configure tools for development, CI, and production
-if DEBUG:
-    if not CI:  # enable django-debug-toolbar for development
-        INSTALLED_APPS.append("debug_toolbar")
-        MIDDLEWARE.insert(
-            0, "debug_toolbar.middleware.DebugToolbarMiddleware"
-        )  # middleware order is important
+if DEBUG and ENABLE_DJANGO_DEBUG_TOOLBAR:
+    # enable django-debug-toolbar for development
+    INSTALLED_APPS.append("debug_toolbar")
+    MIDDLEWARE.insert(
+        0, "debug_toolbar.middleware.DebugToolbarMiddleware"
+    )  # middleware order is important
 
-        # works with django-debug-toolbar app
-        DEBUG_TOOLBAR_CONFIG = {
-            # Toolbar options
-            "SHOW_COLLAPSED": True,  # collapse the toolbar by default
-        }
+    # works with django-debug-toolbar app
+    DEBUG_TOOLBAR_CONFIG = {
+        # Toolbar options
+        "SHOW_COLLAPSED": True,  # collapse the toolbar by default
+    }
 
-        INTERNAL_IPS = ["127.0.0.1"]
+    INTERNAL_IPS = ["127.0.0.1"]
 
 if RUNNING_ON_SAPIR:  # pragma: no cover
     # Sapir uses `wsgi_express` that requires mod_wsgi

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -145,20 +145,21 @@ WSGI_APPLICATION = "CreeDictionary.wsgi.application"
 USE_TEST_DB = to_boolean(os.environ.get("USE_TEST_DB", False))
 
 
-if not USE_TEST_DB:
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
-        }
-    }
-else:
+if USE_TEST_DB:
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
             "NAME": os.path.join(BASE_DIR, "test_db.sqlite3"),
         }
     }
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+        }
+    }
+
 # Password validation
 # https://docs.djangoproject.com/en/1.9/ref/settings/#auth-password-validators
 

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -15,6 +15,7 @@ import posixpath
 from pathlib import Path
 from sys import stderr
 
+from .coerce import to_boolean
 from .hostutils import HOST_IS_SAPIR, HOSTNAME
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -28,20 +29,18 @@ SECRET_KEY = "72bcb9a0-d71c-4d51-8694-6bbec435ab34"
 
 # sapir.artsrn.ualberta.ca has some... special requirements,
 # so let's hear about it!
-RUNNING_ON_SAPIR = (
-    os.environ.get("RUNNING_ON_SAPIR", str(HOST_IS_SAPIR)).lower() == "true"
-)
+RUNNING_ON_SAPIR = to_boolean(os.environ.get("RUNNING_ON_SAPIR", HOST_IS_SAPIR))
 
 # Debug is default to False
 # Turn it to True in development
-DEBUG = os.environ.get("DEBUG", "False").lower() == "true"
+DEBUG = to_boolean(os.environ.get("DEBUG", False))
 
 # SECURITY WARNING: don't run with debug turned on in production!
 if RUNNING_ON_SAPIR:  # pragma: no cover
     assert not DEBUG
 
 # travis has CI equals True
-CI = os.environ.get("CI", "False").lower() == "true"
+CI = to_boolean(os.environ.get("CI", False))
 
 # The Django debug toolbar is a great help when... you know... debugging Django,
 # but it has a few issues:
@@ -51,9 +50,7 @@ CI = os.environ.get("CI", "False").lower() == "true"
 # The reasonable default is to enable it on development machines and let the developer
 # opt out of it, if needed.
 if "ENABLE_DJANGO_DEBUG_TOOLBAR" in os.environ:
-    ENABLE_DJANGO_DEBUG_TOOLBAR = (
-        os.environ["ENABLE_DJANGO_DEBUG_TOOLBAR"].lower() == "true"
-    )
+    ENABLE_DJANGO_DEBUG_TOOLBAR = to_boolean(os.environ["ENABLE_DJANGO_DEBUG_TOOLBAR"])
 else:
     ENABLE_DJANGO_DEBUG_TOOLBAR = DEBUG
 
@@ -144,8 +141,8 @@ WSGI_APPLICATION = "CreeDictionary.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases
 
-USE_TEST_DB = os.environ.get("USE_TEST_DB", "False").lower() == "true"
-# if this is set, then use existing test database
+# if this is set, use existing test database
+USE_TEST_DB = to_boolean(os.environ.get("USE_TEST_DB", False))
 
 
 if not USE_TEST_DB:

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -1,6 +1,8 @@
 """
 Definition of urls for CreeDictionary.
 """
+import API.views as api_views
+from CreeDictionary import views
 from django.conf import settings
 from django.conf.urls import url
 from django.conf.urls.static import static
@@ -8,9 +10,6 @@ from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
 from django_js_reverse.views import urls_js
-
-import API.views as api_views
-from CreeDictionary import views
 
 # 2019/May/21 Matt Yan:
 
@@ -56,11 +55,7 @@ _urlpatterns = [
         "cree-dictionary-search-results",
     ),
     # internal use to render paradigm and detailed info for a lemma
-    (
-        "_lemma_details/",
-        views.lemma_details_internal,
-        "cree-dictionary-lemma-detail",
-    ),
+    ("_lemma_details/", views.lemma_details_internal, "cree-dictionary-lemma-detail",),
     # cree word translation for click-in-text #todo (for matt): this
     (
         "_translate-cree/<str:query_string>/",
@@ -68,11 +63,7 @@ _urlpatterns = [
         "cree-dictionary-word-translation-api",
     ),
     ("admin/", admin.site.urls, "admin"),
-    (
-        "",
-        include("morphodict.urls"),
-        "cree-dictionary-change-orthography",
-    ),
+    ("", include("morphodict.urls"), "cree-dictionary-change-orthography",),
 ]
 
 # Add style debugger, but only in DEBUG mode!
@@ -95,7 +86,7 @@ if settings.DEBUG:
     # saves the need to `manage.py collectstatic` in development
     urlpatterns += staticfiles_urlpatterns()
 
-    if not settings.CI:
+    if settings.ENABLE_DJANGO_DEBUG_TOOLBAR:
         import debug_toolbar
 
         # necessary for debug_toolbar to work

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -17,6 +17,8 @@ environment!
 
 The debug toolbar is **always disabled** on production and in CI.
 
+[Django debug toolbar]: https://github.com/jazzband/django-debug-toolbar
+
 # USE_TEST_DB
 
 It specifies whether to use `test_db.sqlite3` instead of `db.sqlite3`. It defaults to production setting "False". you should add `USE_TEST_DB=True` in .env file.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -4,6 +4,19 @@ Django magical variable. This defaults to the production setting `False`.
 You should add `DEBUG=False` to .env file in development.
 Note: `DEBUG` CANNOT be enabled on Sapir!
 
+# ENABLE_DJANGO_DEBUG_TOOLBAR
+
+Whether to enable the [Django debug toolbar]. If unset, the default
+depends on whether `DEBUB` is on, and whether the code is running on
+`CI`. Since you probably want to use debugging tools when `DEBUG` is on,
+it's enabled if `DEBUG` is enabled; however, this toolbar is _slow_ and
+may interfere with end-to-end tests.
+
+Set `ENABLE_DJANGO_DEBUG_TOOLBAR=False` to disable it in your dev
+environment!
+
+The debug toolbar is **always disabled** on production and in CI.
+
 # USE_TEST_DB
 
 It specifies whether to use `test_db.sqlite3` instead of `db.sqlite3`. It defaults to production setting "False". you should add `USE_TEST_DB=True` in .env file.


### PR DESCRIPTION
I'm making this option explicit, as there is reason to run in `DEBUG` mode and not want the toolbar on a local dev machine. Also, it should _always_ be turned off in CI!