### PR TITLE
Optional affix search for click-in-text API

### DIFF
--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -237,10 +237,9 @@ class Wordform(models.Model):
         super(Wordform, self).save(*args, **kwargs)
 
     @classmethod
-    def search(cls, query: str, **constraints) -> SortedSet["SearchResult"]:
+    def search(cls, query: str, affix_search: bool = True, **constraints) -> SortedSet["SearchResult"]:
         from .search import WordformSearch
-
-        search = WordformSearch(query, constraints)
+        search = WordformSearch(query,constraints,affix_search)
         return search.perform()
 
 

--- a/CreeDictionary/API/views.py
+++ b/CreeDictionary/API/views.py
@@ -18,7 +18,7 @@ def click_in_text(request) -> HttpResponse:
         return HttpResponseBadRequest("query param q is an empty string")
 
     results: List[SerializedSearchResult] = []
-    for result in Wordform.search(q):
+    for result in Wordform.search(q, affix_search=False):
         results.append(result.serialize())
 
     response = {"results": results}

--- a/CreeDictionary/tests/API_tests/test_views.py
+++ b/CreeDictionary/tests/API_tests/test_views.py
@@ -36,3 +36,24 @@ def test_click_in_text_no_params():
     response = c.get(reverse("cree-dictionary-word-click-in-text-api"))
 
     assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_click_in_text_no_affix_search():
+    # This test guarantees affix search is turned off in click-in-text API
+
+    # Should affix search be turned on for click-in-tex, we would have a full page of results
+    # for the case of wapamew and a lot of results are from prefix/suffix search
+    #
+    # The user might not be certain what they are looking for on Itwewina, thus the need
+    # for relaxation and affix search. While click-in-text users searches for some exact cree they find on the web.
+    # So prefix/suffix search is unnecessary.
+    c = Client()
+
+    ascii_wapamew = "wapamew"
+    suffix_search_result = "asawâpamêw"
+    normal_search_response = c.get(reverse("cree-dictionary-search") + f"?q={ascii_wapamew}").content.decode("utf-8")
+    click_in_text_response = c.get(reverse("cree-dictionary-word-click-in-text-api") + f"?q={ascii_wapamew}").content.decode(
+        "utf-8")
+
+    assert suffix_search_result in normal_search_response and suffix_search_result not in click_in_text_response

--- a/CreeDictionary/tests/API_tests/test_views.py
+++ b/CreeDictionary/tests/API_tests/test_views.py
@@ -52,8 +52,16 @@ def test_click_in_text_no_affix_search():
 
     ascii_wapamew = "wapamew"
     suffix_search_result = "asawâpamêw"
-    normal_search_response = c.get(reverse("cree-dictionary-search") + f"?q={ascii_wapamew}").content.decode("utf-8")
+
+    # fixme: I meant to do a comparison.
+    #  Normal searching with affix search should yields asawâpamêw
+    #  but not click in text search
+    #  however the next line (normal search) errors out and the traceback output is cryptic
+    #  I spent an hour debugging on this. It seems to error at template rendering. But accessing the same
+    #  url in the browser shows no error.
+    # normal_search_response = c.get(reverse("cree-dictionary-search") + f"?q={ascii_wapamew}").content.decode("utf-8")
     click_in_text_response = c.get(reverse("cree-dictionary-word-click-in-text-api") + f"?q={ascii_wapamew}").content.decode(
         "utf-8")
+    # assert suffix_search_result in normal_search_response and suffix_search_result not in click_in_text_response
 
-    assert suffix_search_result in normal_search_response and suffix_search_result not in click_in_text_response
+    assert suffix_search_result not in click_in_text_response

--- a/CreeDictionary/tests/API_tests/test_views.py
+++ b/CreeDictionary/tests/API_tests/test_views.py
@@ -1,6 +1,8 @@
 import pytest
 from django.test import Client
 from django.urls import reverse
+from django.conf import settings
+import time
 
 
 @pytest.fixture(scope="module")
@@ -15,8 +17,7 @@ def django_db_setup():
     """
 
     # all functions in this file should use the existing test_db.sqlite3
-    # assert settings.USE_TEST_DB
-    pass
+    assert settings.USE_TEST_DB
 
 
 @pytest.mark.django_db
@@ -38,30 +39,53 @@ def test_click_in_text_no_params():
     assert response.status_code == 400
 
 
-@pytest.mark.django_db
-def test_click_in_text_no_affix_search():
-    # This test guarantees affix search is turned off in click-in-text API
 
-    # Should affix search be turned on for click-in-tex, we would have a full page of results
-    # for the case of wapamew and a lot of results are from prefix/suffix search
+
+class TestClickInTextDisablesAffixSearch:
+    """
+    This test is a comparison
+    #  1. Normal searching with wapamew and affix search on should yield asawâpamêw
+    #  2. click in text search won't yield asawâpamêw
+    """
+
+    ASCII_WAPAMEW = "wapamew"
+    EXPECTED_SUFFIX_SEARCH_RESULT = "asawâpamêw"
+
+    @pytest.mark.django_db
+    def test_normal_search_uses_affix_search(self):
+        c = Client()
+        normal_search_response = c.get(reverse("cree-dictionary-search") + f"?q={self.ASCII_WAPAMEW}").content.decode(
+            "utf-8")
+        assert self.EXPECTED_SUFFIX_SEARCH_RESULT in normal_search_response
+
+    @pytest.mark.django_db
+    def test_click_in_text_disables_affix_search(self):
+        c = Client()
+        click_in_text_response = c.get(
+            reverse("cree-dictionary-word-click-in-text-api") + f"?q={self.ASCII_WAPAMEW}").content.decode(
+            "utf-8")
+        assert self.EXPECTED_SUFFIX_SEARCH_RESULT not in click_in_text_response
+
+    # Note the class pattern with *two methods* is deliberate here.
+    # You might be tempted to use a single function instead as below:
+    # This however won't work. I (Matt Yan <syan4.ualberta.ca>) spent great time on this.
+    # You'll see "sqliteError: Cannot operate on a closed database" during the second client.get()
+    # It seems like something closes the database connection after the first client.get()
+    # And I can't find related bug/issue reports on the web
+    # The moral is, whenever you need multiple client.get()'s, split into multiple function
+
+    # Think positively too! The above class pattern is so much more readible and clearer!
+
+    # @pytest.mark.django_db
+    # def test_click_in_text_no_affix_search():
     #
-    # The user might not be certain what they are looking for on Itwewina, thus the need
-    # for relaxation and affix search. While click-in-text users searches for some exact cree they find on the web.
-    # So prefix/suffix search is unnecessary.
-    c = Client()
-
-    ascii_wapamew = "wapamew"
-    suffix_search_result = "asawâpamêw"
-
-    # fixme: I meant to do a comparison.
-    #  Normal searching with affix search should yields asawâpamêw
-    #  but not click in text search
-    #  however the next line (normal search) errors out and the traceback output is cryptic
-    #  I spent an hour debugging on this. It seems to error at template rendering. But accessing the same
-    #  url in the browser shows no error.
-    # normal_search_response = c.get(reverse("cree-dictionary-search") + f"?q={ascii_wapamew}").content.decode("utf-8")
-    click_in_text_response = c.get(reverse("cree-dictionary-word-click-in-text-api") + f"?q={ascii_wapamew}").content.decode(
-        "utf-8")
-    # assert suffix_search_result in normal_search_response and suffix_search_result not in click_in_text_response
-
-    assert suffix_search_result not in click_in_text_response
+    #     c = Client() # tried: seperate client instances c1, c2 won't help
+    #
+    #     ascii_wapamew = "wapamew"
+    #     suffix_search_result = "asawâpamêw"
+    #
+    #     normal_search_response = c.get(reverse("cree-dictionary-search") + f"?q={ascii_wapamew}").content.decode("utf-8")
+    #     click_in_text_response = c.get(
+    #         reverse("cree-dictionary-word-click-in-text-api") + f"?q={ascii_wapamew}").content.decode(
+    #         "utf-8")
+    #     assert suffix_search_result in normal_search_response and suffix_search_result not in click_in_text_response


### PR DESCRIPTION
I also added a todo (which I will do), and a fixme (which gives me autistic screeching)...


Also some large diffs are from formatting of my IDE, I tried to use black instead. Looks like something is messed up:

```
C:\Users\Matt\PycharmProjects\cree-intelligent-dictionary>pipenv run python -m black CreeDictionary
Traceback (most recent call last):
  File "C:\Users\Matt\AppData\Local\Programs\Python\Python36-32\Lib\runpy.py", line 183, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "C:\Users\Matt\AppData\Local\Programs\Python\Python36-32\Lib\runpy.py", line 142, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "C:\Users\Matt\AppData\Local\Programs\Python\Python36-32\Lib\runpy.py", line 109, in _get_module_details
    __import__(pkg_name)
  File "C:\Users\Matt\.virtualenvs\cree-intelligent-dictionary-aKpDmaTl\lib\site-packages\black\__init__.py", line 49, in <module>
    from dataclasses import dataclass, field, replace
ModuleNotFoundError: No module named 'dataclasses'

``` 

I'll figure it out later...