### PR TITLE
Refactor affix search test

### DIFF
--- a/CreeDictionary/tests/API_tests/test_views.py
+++ b/CreeDictionary/tests/API_tests/test_views.py
@@ -1,8 +1,9 @@
+import time
+
 import pytest
+from django.conf import settings
 from django.test import Client
 from django.urls import reverse
-from django.conf import settings
-import time
 
 
 @pytest.fixture(scope="module")

--- a/CreeDictionary/tests/API_tests/test_views.py
+++ b/CreeDictionary/tests/API_tests/test_views.py
@@ -1,8 +1,5 @@
-import time
-
 import pytest
 from django.conf import settings
-from django.test import Client
 from django.urls import reverse
 
 

--- a/CreeDictionary/tests/API_tests/test_views.py
+++ b/CreeDictionary/tests/API_tests/test_views.py
@@ -22,20 +22,18 @@ def django_db_setup():
 
 
 @pytest.mark.django_db
-def test_click_in_text_correct_usage():
-    c = Client()
-
+def test_click_in_text_correct_usage(client):
     # niskak means goose in plains Cree
-    response = c.get(reverse("cree-dictionary-word-click-in-text-api") + "?q=niskak")
+    response = client.get(
+        reverse("cree-dictionary-word-click-in-text-api") + "?q=niskak"
+    )
 
     assert b"goose" in response.content
 
 
 @pytest.mark.django_db
-def test_click_in_text_no_params():
-    c = Client()
-
-    response = c.get(reverse("cree-dictionary-word-click-in-text-api"))
+def test_click_in_text_no_params(client):
+    response = client.get(reverse("cree-dictionary-word-click-in-text-api"))
 
     assert response.status_code == 400
 
@@ -51,17 +49,15 @@ class TestClickInTextDisablesAffixSearch:
     EXPECTED_SUFFIX_SEARCH_RESULT = "asawâpamêw"
 
     @pytest.mark.django_db
-    def test_normal_search_uses_affix_search(self):
-        c = Client()
-        normal_search_response = c.get(
+    def test_normal_search_uses_affix_search(self, client):
+        normal_search_response = client.get(
             reverse("cree-dictionary-search") + f"?q={self.ASCII_WAPAMEW}"
         ).content.decode("utf-8")
         assert self.EXPECTED_SUFFIX_SEARCH_RESULT in normal_search_response
 
     @pytest.mark.django_db
-    def test_click_in_text_disables_affix_search(self):
-        c = Client()
-        click_in_text_response = c.get(
+    def test_click_in_text_disables_affix_search(self, client):
+        click_in_text_response = client.get(
             reverse("cree-dictionary-word-click-in-text-api")
             + f"?q={self.ASCII_WAPAMEW}"
         ).content.decode("utf-8")

--- a/CreeDictionary/tests/API_tests/test_views.py
+++ b/CreeDictionary/tests/API_tests/test_views.py
@@ -2,6 +2,9 @@ import pytest
 from django.conf import settings
 from django.urls import reverse
 
+ASCII_WAPAMEW = "wapamew"
+EXPECTED_SUFFIX_SEARCH_RESULT = "asawâpamêw"
+
 
 @pytest.fixture(scope="module")
 def django_db_setup():
@@ -33,10 +36,6 @@ def test_click_in_text_no_params(client):
     response = client.get(reverse("cree-dictionary-word-click-in-text-api"))
 
     assert response.status_code == 400
-
-
-ASCII_WAPAMEW = "wapamew"
-EXPECTED_SUFFIX_SEARCH_RESULT = "asawâpamêw"
 
 
 @pytest.mark.django_db

--- a/CreeDictionary/tests/API_tests/test_views.py
+++ b/CreeDictionary/tests/API_tests/test_views.py
@@ -38,51 +38,37 @@ def test_click_in_text_no_params(client):
     assert response.status_code == 400
 
 
-class TestClickInTextDisablesAffixSearch:
+ASCII_WAPAMEW = "wapamew"
+EXPECTED_SUFFIX_SEARCH_RESULT = "asawâpamêw"
+
+
+@pytest.mark.django_db
+def test_normal_search_uses_affix_search(client):
     """
-    This test is a comparison
-    #  1. Normal searching with wapamew and affix search on should yield asawâpamêw
-    #  2. click in text search won't yield asawâpamêw
+    Regular dictionary search should return affix results.
+
+    e.g.,
+
+    > search?q=wapamew
+    should return both "wâpamêw" and "asawâpamêw"
     """
+    normal_search_response = client.get(
+        reverse("cree-dictionary-search") + f"?q={ASCII_WAPAMEW}"
+    ).content.decode("utf-8")
+    assert EXPECTED_SUFFIX_SEARCH_RESULT in normal_search_response
 
-    ASCII_WAPAMEW = "wapamew"
-    EXPECTED_SUFFIX_SEARCH_RESULT = "asawâpamêw"
 
-    @pytest.mark.django_db
-    def test_normal_search_uses_affix_search(self, client):
-        normal_search_response = client.get(
-            reverse("cree-dictionary-search") + f"?q={self.ASCII_WAPAMEW}"
-        ).content.decode("utf-8")
-        assert self.EXPECTED_SUFFIX_SEARCH_RESULT in normal_search_response
+@pytest.mark.django_db
+def test_click_in_text_disables_affix_search(client):
+    """
+    The Click-in-Text API should NOT return affix results — too many results!
 
-    @pytest.mark.django_db
-    def test_click_in_text_disables_affix_search(self, client):
-        click_in_text_response = client.get(
-            reverse("cree-dictionary-word-click-in-text-api")
-            + f"?q={self.ASCII_WAPAMEW}"
-        ).content.decode("utf-8")
-        assert self.EXPECTED_SUFFIX_SEARCH_RESULT not in click_in_text_response
+    e.g.,
 
-    # Note the class pattern with *two methods* is deliberate here.
-    # You might be tempted to use a single function instead as below:
-    # This however won't work. I (Matt Yan <syan4.ualberta.ca>) spent great time on this.
-    # You'll see "sqliteError: Cannot operate on a closed database" during the second client.get()
-    # It seems like something closes the database connection after the first client.get()
-    # And I can't find related bug/issue reports on the web
-    # The moral is, whenever you need multiple client.get()'s, split into multiple function
-
-    # Think positively too! The above class pattern is so much more readible and clearer!
-
-    # @pytest.mark.django_db
-    # def test_click_in_text_no_affix_search():
-    #
-    #     c = Client() # tried: seperate client instances c1, c2 won't help
-    #
-    #     ascii_wapamew = "wapamew"
-    #     suffix_search_result = "asawâpamêw"
-    #
-    #     normal_search_response = c.get(reverse("cree-dictionary-search") + f"?q={ascii_wapamew}").content.decode("utf-8")
-    #     click_in_text_response = c.get(
-    #         reverse("cree-dictionary-word-click-in-text-api") + f"?q={ascii_wapamew}").content.decode(
-    #         "utf-8")
-    #     assert suffix_search_result in normal_search_response and suffix_search_result not in click_in_text_response
+    > search?q=wapamew
+    should return "wâpamêw" but NOT "asawâpamêw"
+    """
+    click_in_text_response = client.get(
+        reverse("cree-dictionary-word-click-in-text-api") + f"?q={ASCII_WAPAMEW}"
+    ).content.decode("utf-8")
+    assert EXPECTED_SUFFIX_SEARCH_RESULT not in click_in_text_response


### PR DESCRIPTION
I was curious to see what would happen if I used the `client` fixture from `pytest-django`. It works! Though maybe that's because the two requests were placed into two separate functions :/
