### PR TITLE
refactor: move bulk of search to fetch_cree_and_english_results()

### DIFF
--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -201,9 +201,9 @@ class Wordform(models.Model):
 
     class Meta:
         indexes = [
-            # analysis is for faster user query (in function fetch_lemma_by_user_query below)
+            # analysis is for faster user query (see search.py)
             models.Index(fields=["analysis"]),
-            # text index benefits fast lemma matching in function fetch_lemma_by_user_query
+            # text index benefits fast wordform matching (see search.py)
             models.Index(fields=["text"]),
         ]
 

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -39,6 +39,7 @@ from .schema import SerializedLinguisticTag, SerializedSearchResult
 Preverb = Union[Wordform, str]
 Lemma = NewType("Lemma", Wordform)
 MatchedEnglish = NewType("MatchedEnglish", str)
+InternalForm = NewType("InternalForm", str)
 
 logger = logging.getLogger(__name__)
 
@@ -393,6 +394,7 @@ def fetch_preverbs(user_query: str) -> Set[Wordform]:
 
     return Wordform.PREVERB_ASCII_LOOKUP[user_query]
 
+
 # TODO: RENAME
 # TODO: REFACTOR!!!
 def fetch_lemma_by_user_query(
@@ -689,7 +691,7 @@ def sort_by_user_query(user_query: str) -> Callable[[Any], Any]:
     )
 
 
-def clean_query(user_query: str) -> str:
+def clean_query(user_query: str) -> InternalForm:
     """
     Takes a raw query and cleans it up.
     """
@@ -701,7 +703,7 @@ def clean_query(user_query: str) -> str:
     user_query = unicodedata.normalize("NFC", user_query)
     user_query = user_query.lower()
     user_query = to_sro_circumflex(user_query)
-    return user_query
+    return InternalForm(user_query)
 
 
 def to_sro_circumflex(text: str) -> str:

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -729,8 +729,17 @@ def clean_query(user_query: str) -> InternalForm:
     # that is, all characters that can be composed are composed.
     user_query = unicodedata.normalize("NFC", user_query)
     user_query = user_query.lower()
-    user_query = to_sro_circumflex(user_query)
-    return InternalForm(user_query)
+
+    return to_internal_form(user_query)
+
+
+def to_internal_form(user_query: str) -> InternalForm:
+    """
+    Convert text to the internal form used by the database entries, tries, FSTs, etc.
+
+    In itwêwina, the Plains Cree dictionary, this means SRO circumflexes.
+    """
+    return InternalForm(to_sro_circumflex(user_query))
 
 
 def to_sro_circumflex(text: str) -> str:

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -394,6 +394,8 @@ def fetch_preverbs(user_query: str) -> Set[Wordform]:
     return Wordform.PREVERB_ASCII_LOOKUP[user_query]
 
 
+# TODO: RENAME
+# TODO: REFACTOR!!!
 def fetch_lemma_by_user_query(
     user_query: str, affix_search: bool = True, **extra_constraints
 ) -> CreeAndEnglish:
@@ -414,19 +416,7 @@ def fetch_lemma_by_user_query(
     :param extra_constraints: additional fields to disambiguate
     """
 
-    # Whitespace won't affect results, but the FST can't deal with it:
-    user_query = user_query.strip()
-    # Normalize to UTF8 NFC
-    user_query = unicodedata.normalize("NFC", user_query)
-    user_query = (
-        user_query.replace("ā", "â")
-        .replace("ē", "ê")
-        .replace("ī", "î")
-        .replace("ō", "ô")
-    )
-    user_query = syllabics2sro(user_query)
-
-    user_query = user_query.lower()
+    user_query = clean_query(user_query)
 
     # build up result_lemmas in 2 ways
     # 1. affix search (return all results that ends/starts with the query string)
@@ -698,3 +688,23 @@ def sort_by_user_query(user_query: str) -> Callable[[Any], Any]:
             partial(sort_search_result, user_query=user_query),
         )
     )
+
+
+def clean_query(user_query: str) -> str:
+    """
+    Takes a raw query and cleans it up.
+    """
+
+    # Whitespace won't affect results, but the FST can't deal with it:
+    user_query = user_query.strip()
+    # Normalize to UTF8 NFC
+    user_query = unicodedata.normalize("NFC", user_query)
+    user_query = (
+        user_query.replace("ā", "â")
+        .replace("ē", "ê")
+        .replace("ī", "î")
+        .replace("ō", "ô")
+    )
+    user_query = syllabics2sro(user_query)
+
+    return user_query.lower()

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -257,10 +257,13 @@ class WordformSearch:
         :return: sorted search results
         """
 
-        res = fetch_lemma_by_user_query(
-            self.query, self._affix_search, **self.constraints
+        cleaned_query = clean_query_text(self.query)
+
+        res = fetch_cree_and_english_results(
+            to_internal_form(cleaned_query), self._affix_search, **self.constraints
         )
-        results = SortedSet(key=sort_by_user_query(self.query))
+
+        results = SortedSet(key=sort_by_user_query(cleaned_query))
         results |= self.prepare_cree_results(res.cree_results)
         results |= self.prepare_english_results(res.english_results)
         return results

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -256,6 +256,7 @@ class WordformSearch:
         Do the search
         :return: sorted search results
         """
+
         res = fetch_lemma_by_user_query(
             self.query, self._affix_search, **self.constraints
         )
@@ -434,7 +435,7 @@ def fetch_lemma_by_user_query(
     """
 
     return fetch_cree_and_english_results(
-        clean_query(user_query), affix_search, **extra_constraints
+        prepare_query_text(user_query), affix_search, **extra_constraints
     )
 
 
@@ -718,7 +719,7 @@ def sort_by_user_query(user_query: str) -> Callable[[Any], Any]:
     )
 
 
-def clean_query(user_query: str) -> InternalForm:
+def prepare_query_text(user_query: str) -> InternalForm:
     """
     Takes a raw query and cleans it up.
     """

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -723,15 +723,19 @@ def prepare_query_text(user_query: str) -> InternalForm:
     """
     Takes a raw query and cleans it up.
     """
+    return to_internal_form(clean_query_text(user_query))
 
+
+def clean_query_text(user_query: str) -> str:
+    """
+    Cleans up the query text before it is passed to further steps.
+    """
     # Whitespace won't affect results, but the FST can't deal with it:
     user_query = user_query.strip()
     # All internal text should be in NFC form --
     # that is, all characters that can be composed are composed.
     user_query = unicodedata.normalize("NFC", user_query)
-    user_query = user_query.lower()
-
-    return to_internal_form(user_query)
+    return user_query.lower()
 
 
 def to_internal_form(user_query: str) -> InternalForm:

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -393,7 +393,6 @@ def fetch_preverbs(user_query: str) -> Set[Wordform]:
 
     return Wordform.PREVERB_ASCII_LOOKUP[user_query]
 
-
 # TODO: RENAME
 # TODO: REFACTOR!!!
 def fetch_lemma_by_user_query(
@@ -700,8 +699,9 @@ def clean_query(user_query: str) -> str:
     # All internal text should be in NFC form --
     # that is, all characters that can be composed are composed.
     user_query = unicodedata.normalize("NFC", user_query)
+    user_query = user_query.lower()
     user_query = to_sro_circumflex(user_query)
-    return user_query.lower()
+    return user_query
 
 
 def to_sro_circumflex(text: str) -> str:

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -697,7 +697,8 @@ def clean_query(user_query: str) -> str:
 
     # Whitespace won't affect results, but the FST can't deal with it:
     user_query = user_query.strip()
-    # Normalize to UTF8 NFC
+    # All internal text should be in NFC form --
+    # that is, all characters that can be composed are composed.
     user_query = unicodedata.normalize("NFC", user_query)
     user_query = to_sro_circumflex(user_query)
     return user_query.lower()
@@ -710,7 +711,7 @@ def to_sro_circumflex(text: str) -> str:
     >>> to_sro_circumflex("tān'si")
     "tân'si"
     >>> to_sro_circumflex("ᑖᓂᓯ")
-    "tânisi"
+    'tânisi'
     """
     text = (
         text.replace("ā", "â")

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -400,11 +400,8 @@ def fetch_preverbs(user_query: str) -> Set[Wordform]:
     return Wordform.PREVERB_ASCII_LOOKUP[user_query]
 
 
-# TODO: RENAME
-# TODO: REFACTOR!!!
-# TODO: DISCONTINUE
-def fetch_lemma_by_user_query(
-    user_query: str, affix_search: bool = True, **extra_constraints
+def fetch_cree_and_english_results(
+    user_query: InternalForm, affix_search: bool = True, **extra_constraints
 ) -> CreeAndEnglish:
     """
     HERE BE DRAGONS!
@@ -412,12 +409,9 @@ def fetch_lemma_by_user_query(
     Historically, this function has been the bulk of our search backend, performing both
     Cree and English search. However, I honestly don't understand how it works. As of
     this writing (2021-01-11), I am refactoring the function to bring some order to it
-    and hopefully understanding how it works. I extracted most of the logic to
-    fetch_cree_and_english_results() which is a very Long Method (code smell).
+    and hopefully understanding how it works.
 
-    And, oh yeah: this function fetches more than just lemmas 🙃
-
-    Original documentation as follows (I don't really understand it):
+    Original documentation for fetch_lemma_by_user_query() as follows (I don't really understand it):
 
     ---
 
@@ -435,19 +429,6 @@ def fetch_lemma_by_user_query(
     :param affix_search: whether to perform affix search or not (both English and Cree)
     :param user_query: can be English or Cree (syllabics or not)
     :param extra_constraints: additional fields to disambiguate
-    """
-
-    return fetch_cree_and_english_results(
-        prepare_query_text(user_query), affix_search, **extra_constraints
-    )
-
-
-def fetch_cree_and_english_results(
-    user_query: InternalForm, affix_search: bool = True, **extra_constraints
-) -> CreeAndEnglish:
-    """
-    The bulk of the logic fetch_lemma_by_user_query(), minus the cleaning up the user's
-    query.
     """
 
     # build up result_lemmas in 2 ways
@@ -720,13 +701,6 @@ def sort_by_user_query(user_query: str) -> Callable[[Any], Any]:
             partial(sort_search_result, user_query=user_query),
         )
     )
-
-
-def prepare_query_text(user_query: str) -> InternalForm:
-    """
-    Takes a raw query and cleans it up.
-    """
-    return to_internal_form(clean_query_text(user_query))
 
 
 def clean_query_text(user_query: str) -> str:

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -443,7 +443,7 @@ def fetch_lemma_by_user_query(
 
 
 def fetch_cree_and_english_results(
-    user_query: InternalForm, affix_search: bool, **extra_constraints
+    user_query: InternalForm, affix_search: bool = True, **extra_constraints
 ) -> CreeAndEnglish:
     """
     The bulk of the logic fetch_lemma_by_user_query(), minus the cleaning up the user's

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -699,12 +699,23 @@ def clean_query(user_query: str) -> str:
     user_query = user_query.strip()
     # Normalize to UTF8 NFC
     user_query = unicodedata.normalize("NFC", user_query)
-    user_query = (
-        user_query.replace("ā", "â")
+    user_query = to_sro_circumflex(user_query)
+    return user_query.lower()
+
+
+def to_sro_circumflex(text: str) -> str:
+    """
+    Convert text to Plains Cree SRO with circumflexes (êîôâ).
+
+    >>> to_sro_circumflex("tān'si")
+    "tân'si"
+    >>> to_sro_circumflex("ᑖᓂᓯ")
+    "tânisi"
+    """
+    text = (
+        text.replace("ā", "â")
         .replace("ē", "ê")
         .replace("ī", "î")
         .replace("ō", "ô")
     )
-    user_query = syllabics2sro(user_query)
-
-    return user_query.lower()
+    return syllabics2sro(text)

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -1,13 +1,15 @@
 import json
+from typing import List
+
 import pytest
 from API.models import Wordform
-from API.search import fetch_lemma_by_user_query
-from CreeDictionary import settings
+from API.search import fetch_cree_and_english_results, to_internal_form
 from hypothesis import assume, given
 from paradigm import EmptyRowType, InflectionCell, Layout, TitleRow
 from tests.conftest import lemmas
-from typing import List
 from utils.enums import Language
+
+from CreeDictionary import settings
 
 
 @pytest.fixture(scope="module")
@@ -23,9 +25,6 @@ def django_db_setup():
 
     # all functions in this file should use the existing test_db.sqlite3
     assert settings.USE_TEST_DB
-
-
-#### Tests for Inflection.fetch_lemmas_by_user_query()
 
 
 @pytest.mark.django_db
@@ -53,7 +52,7 @@ def test_query_exact_wordform_in_database(lemma: Wordform):
     """
 
     query = lemma.text
-    cree_results, _ = fetch_lemma_by_user_query(query)
+    cree_results, _ = fetch_cree_and_english_results(to_internal_form(query))
 
     exact_match = False
     matched_lemma_count = 0
@@ -172,7 +171,7 @@ def test_search_space_characters_in_matched_term(term):
     assert word is not None
 
     # Now try searching for it:
-    cree_results, _ = fetch_lemma_by_user_query(term)
+    cree_results, _ = fetch_cree_and_english_results(to_internal_form(term))
     assert len(cree_results) > 0
 
 


### PR DESCRIPTION
Trying to refactor the search. I mostly separated the query cleaning from the rest of the search logic. This makes it easier to just modify and move the orthography and query normalization.