### PR TITLE
Let logging from non-Django code reach console

### DIFF
--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -300,20 +300,28 @@ else:
         "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
     )
 
+log_level = env.log_level("LOG_LEVEL", default="INFO")
+
+# To debug what the *actual* config ends up being, use the logging_tree package
+# See https://stackoverflow.com/a/53058203/14558
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "handlers": {
         "console": {
-            "level": env.log_level("LOG_LEVEL", default="INFO"),
+            "level": log_level,
             "class": "logging.StreamHandler",
         },
     },
-    # learn how different loggers are used in Django: https://docs.djangoproject.com/en/3.0/topics/logging/#id3
+    'root': {
+        'handlers': ['console'],
+        'level': log_level,
+    },
     "loggers": {
+        # learn how different loggers are used in Django: https://docs.djangoproject.com/en/3.0/topics/logging/#id3
         "django": {
-            "handlers": ["console"],
-            "level": "DEBUG",
+            "handlers": [],
+            "level": log_level,
             "propagate": True,
         },
     },


### PR DESCRIPTION
  - With a root handler, loggers from other code, e.g., in `utils`, will
    produce output on the console

  - Django installs its own handler by default, but if we let it propagate
    to the root handler, the `django` logger doesn’t need its own handler

This does eliminate some default features of Django that we’re not using,
such as mailing admins a copy of any error messages. But if we want to use
that, we can explicitly set it up later.