### PR TITLE
refactor: more affix search refactoring

### DIFF
--- a/CreeDictionary/API/affix_search.py
+++ b/CreeDictionary/API/affix_search.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from itertools import chain
-from typing import Dict, Iterable, List, Tuple, NewType
+from typing import Dict, Iterable, List, NewType, Tuple
 
 import dawg
 from utils.cree_lev_dist import remove_cree_diacritics
@@ -40,19 +40,17 @@ class AffixSearcher:
         :return: an iterable of Wordform IDs that match the prefix
         """
         term = self.to_simplified_form(prefix)
-        return chain(*[self.text_to_ids[t] for t in self._prefixes.keys(term)])
+        matched_words = self._prefixes.keys(term)
+        return chain.from_iterable(self.text_to_ids[t] for t in matched_words)
 
     def search_by_suffix(self, suffix: str) -> Iterable[int]:
         """
         :return: an iterable of Wordform IDs that match the suffix
         """
         term = self.to_simplified_form(suffix)
-
-        return chain(
-            *[
-                self.text_to_ids[_reverse(key)]
-                for key in self._suffixes.keys(_reverse(term))
-            ]
+        matched_reversed_words = self._suffixes.keys(_reverse(term))
+        return chain.from_iterable(
+            self.text_to_ids[_reverse(t)] for t in matched_reversed_words
         )
 
     @staticmethod

--- a/CreeDictionary/API/apps.py
+++ b/CreeDictionary/API/apps.py
@@ -70,12 +70,7 @@ def initialize_affix_search() -> None:
     Build tries and attach to Wordform class to facilitate prefix/suffix search
     """
     logger.info("Building tries for affix search...")
-    from .models import (
-        EnglishKeyword,
-        Wordform,
-        set_affix_searcher_for_cree,
-        set_affix_searcher_for_english,
-    )
+    from .models import EnglishKeyword, Wordform
 
     try:
         Wordform.objects.count()
@@ -107,3 +102,13 @@ def fetch_cree_lemmas_with_ids():
     from .models import Wordform
 
     return Wordform.objects.filter(is_lemma=True).values_list("text", "id")
+
+
+def set_affix_searcher_for_cree(searcher: AffixSearcher):
+    from .models import Wordform
+    Wordform._cree_affix_searcher = searcher
+
+
+def set_affix_searcher_for_english(searcher: AffixSearcher):
+    from .models import Wordform
+    Wordform._english_affix_searcher = searcher

--- a/CreeDictionary/API/apps.py
+++ b/CreeDictionary/API/apps.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 class APIConfig(AppConfig):
     name = "API"
 
+    cree_affix_searcher: AffixSearcher
+
     def ready(self) -> None:
         """
         This function is called when you restart dev server or touch wsgi.py
@@ -37,7 +39,7 @@ class APIConfig(AppConfig):
             logger.exception("Cannot build tries: Wordform table does not exist (yet)!")
             return
 
-        set_affix_searcher_for_cree(AffixSearcher(fetch_cree_lemmas_with_ids()))
+        self.cree_affix_searcher = AffixSearcher(fetch_cree_lemmas_with_ids())
         set_affix_searcher_for_english(AffixSearcher(fetch_english_keywords_with_ids()))
 
         logger.info("Finished building tries")
@@ -49,7 +51,7 @@ class APIConfig(AppConfig):
 
         This way you can get access to the affix searchers in other modules!
         """
-        return apps.get_app_config(cls.app_label)
+        return apps.get_app_config(cls.name)
 
 
 def initialize_preverb_search():

--- a/CreeDictionary/API/apps.py
+++ b/CreeDictionary/API/apps.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 
-from django.apps import AppConfig
+from django.apps import AppConfig, apps
 from django.db import OperationalError
 from utils import shared_res_dir
 from utils.cree_lev_dist import remove_cree_diacritics
@@ -41,6 +41,15 @@ class APIConfig(AppConfig):
         set_affix_searcher_for_english(AffixSearcher(fetch_english_keywords_with_ids()))
 
         logger.info("Finished building tries")
+
+    @classmethod
+    def active_instance(cls) -> "APIConfig":
+        """
+        Fetch the instance of this Config from the Django app registry.
+
+        This way you can get access to the affix searchers in other modules!
+        """
+        return apps.get_app_config(cls.app_label)
 
 
 def initialize_preverb_search():
@@ -85,7 +94,6 @@ def read_morpheme_rankings():
             Wordform.MORPHEME_RANKINGS[morpheme] = float(freq)
 
 
-
 def fetch_english_keywords_with_ids():
     """
     Return pairs of indexed English keywords with their coorepsonding Wordform IDs.
@@ -106,9 +114,11 @@ def fetch_cree_lemmas_with_ids():
 
 def set_affix_searcher_for_cree(searcher: AffixSearcher):
     from .models import Wordform
+
     Wordform._cree_affix_searcher = searcher
 
 
 def set_affix_searcher_for_english(searcher: AffixSearcher):
     from .models import Wordform
+
     Wordform._english_affix_searcher = searcher

--- a/CreeDictionary/API/apps.py
+++ b/CreeDictionary/API/apps.py
@@ -15,6 +15,7 @@ class APIConfig(AppConfig):
     name = "API"
 
     cree_affix_searcher: AffixSearcher
+    english_affix_searcher: AffixSearcher
 
     def ready(self) -> None:
         """
@@ -40,7 +41,7 @@ class APIConfig(AppConfig):
             return
 
         self.cree_affix_searcher = AffixSearcher(fetch_cree_lemmas_with_ids())
-        set_affix_searcher_for_english(AffixSearcher(fetch_english_keywords_with_ids()))
+        self.english_affix_searcher = AffixSearcher(fetch_english_keywords_with_ids())
 
         logger.info("Finished building tries")
 

--- a/CreeDictionary/API/apps.py
+++ b/CreeDictionary/API/apps.py
@@ -113,15 +113,3 @@ def fetch_cree_lemmas_with_ids():
     from .models import Wordform
 
     return Wordform.objects.filter(is_lemma=True).values_list("text", "id")
-
-
-def set_affix_searcher_for_cree(searcher: AffixSearcher):
-    from .models import Wordform
-
-    Wordform._cree_affix_searcher = searcher
-
-
-def set_affix_searcher_for_english(searcher: AffixSearcher):
-    from .models import Wordform
-
-    Wordform._english_affix_searcher = searcher

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -397,13 +397,3 @@ def get_all_source_ids_for_definition(definition_id: int) -> Tuple[str, ...]:
     """
     dfn = Definition.objects.get(pk=definition_id)
     return tuple(sorted(source.abbrv for source in dfn.citations.all()))
-
-
-# TODO: move this to search, without causing an import cycle!
-def affix_searcher_for_cree() -> AffixSearcher:
-    return Wordform._cree_affix_searcher
-
-
-# TODO: move this to search, without causing an import cycle!
-def affix_searcher_for_english() -> AffixSearcher:
-    return Wordform._english_affix_searcher

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -41,11 +41,6 @@ class Wordform(models.Model):
     # pure MD content won't be included
     PREVERB_ASCII_LOOKUP: Dict[str, Set["Wordform"]] = defaultdict(set)
 
-    # Affix search is initialized in apps.py
-    # TODO: I don't know where else to put these global variables :/
-    _cree_affix_searcher: AffixSearcher
-    _english_affix_searcher: AffixSearcher
-
     # this is initialized upon app ready.
     MORPHEME_RANKINGS: Dict[str, float] = {}
 

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -407,13 +407,3 @@ def affix_searcher_for_cree() -> AffixSearcher:
 # TODO: move this to search, without causing an import cycle!
 def affix_searcher_for_english() -> AffixSearcher:
     return Wordform._english_affix_searcher
-
-
-# TODO: move this to search, without causing an import cycle!
-def set_affix_searcher_for_cree(searcher: AffixSearcher):
-    Wordform._cree_affix_searcher = searcher
-
-
-# TODO: move this to search, without causing an import cycle!
-def set_affix_searcher_for_english(searcher: AffixSearcher):
-    Wordform._english_affix_searcher = searcher

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -34,13 +34,7 @@ from utils.types import ConcatAnalysis, FSTTag, Label
 
 from CreeDictionary import hfstol as temp_hfstol
 
-from .models import (
-    Definition,
-    EnglishKeyword,
-    Wordform,
-    affix_searcher_for_cree,
-    affix_searcher_for_english,
-)
+from .models import Definition, EnglishKeyword, Wordform
 from .schema import SerializedLinguisticTag, SerializedSearchResult
 
 # it's a str when the preverb does not exist in the database
@@ -800,3 +794,18 @@ def to_sro_circumflex(text: str) -> str:
     """
     text = text.replace("ā", "â").replace("ē", "ê").replace("ī", "î").replace("ō", "ô")
     return syllabics2sro(text)
+
+
+def affix_searcher_for_cree() -> AffixSearcher:
+    """
+    Returns the affix searcher that matches Cree lemmas
+    """
+    return Wordform._cree_affix_searcher
+
+
+def affix_searcher_for_english() -> AffixSearcher:
+    """
+    Returns the affix searcher that matches English keywords (mined from the dictionary
+    definitions
+    """
+    return Wordform._english_affix_searcher

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -809,4 +809,4 @@ def affix_searcher_for_english() -> AffixSearcher:
     Returns the affix searcher that matches English keywords (mined from the dictionary
     definitions
     """
-    return Wordform._english_affix_searcher
+    return APIConfig.active_instance().english_affix_searcher

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -34,6 +34,7 @@ from utils.types import ConcatAnalysis, FSTTag, Label
 
 from CreeDictionary import hfstol as temp_hfstol
 
+from .apps import APIConfig
 from .models import Definition, EnglishKeyword, Wordform
 from .schema import SerializedLinguisticTag, SerializedSearchResult
 
@@ -800,7 +801,7 @@ def affix_searcher_for_cree() -> AffixSearcher:
     """
     Returns the affix searcher that matches Cree lemmas
     """
-    return Wordform._cree_affix_searcher
+    return APIConfig.active_instance().cree_affix_searcher
 
 
 def affix_searcher_for_english() -> AffixSearcher:

--- a/CreeDictionary/API/search.py
+++ b/CreeDictionary/API/search.py
@@ -266,13 +266,13 @@ class _BaseWordformSearch:
         :return: sorted search results
         """
 
-        res = self.fetch_cree_and_english_results()
+        res = self.fetch_bilingual_results()
         results = SortedSet(key=sort_by_user_query(self.cleaned_query))
         results |= self.prepare_cree_results(res.cree_results)
         results |= self.prepare_english_results(res.english_results)
         return results
 
-    def fetch_cree_and_english_results(self):
+    def fetch_bilingual_results(self) -> CreeAndEnglish:
         """
         Subclasses must implement this!
         """
@@ -352,7 +352,7 @@ class WordformSearchWithExactMatch(_BaseWordformSearch):
     Searches for exact matches in both the wordforms and EnglishKeyword tables.
     """
 
-    def fetch_cree_and_english_results(self):
+    def fetch_bilingual_results(self) -> CreeAndEnglish:
         return fetch_cree_and_english_results(self.cleaned_query, affix_search=False)
 
 
@@ -361,7 +361,7 @@ class WordformSearchWithAffixes(_BaseWordformSearch):
     Same as WordformSearchWithExactMatch, but augments results with searches on affixes.
     """
 
-    def fetch_cree_and_english_results(self):
+    def fetch_bilingual_results(self) -> CreeAndEnglish:
         return fetch_cree_and_english_results(self.cleaned_query, affix_search=True)
 
 

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -331,6 +331,8 @@ def test_search_results_order(query: str, top_result: str, later_result: str):
     ), f"{top_result} did not come before {later_result}"
 
 
+####################################### Helpers ########################################
+
 def position_in_results(wordform: str, search_results) -> int:
     """
     Find the EXACT wordform in the results.
@@ -344,6 +346,9 @@ def position_in_results(wordform: str, search_results) -> int:
 
 
 def results_contains_wordform(wordform: str, search_results) -> bool:
+    """
+    Returns True if the wordform is found in the search results.
+    """
     try:
         position_in_results(wordform, search_results)
         return True


### PR DESCRIPTION
Addresses some things that have been bothering me:

 - [x] global affix search instances should not be part of `Wordform`; instead, they're created on a specific `AppConfig` instance (these are globally available, because Django)
 - [x] change ONE of the  `fetch_cree_and_english_results()` to `fetch_bilingual_results()`