### PR TITLE
Add a useful, read-only admin interface

### DIFF
--- a/CreeDictionary/API/admin.py
+++ b/CreeDictionary/API/admin.py
@@ -14,6 +14,7 @@ def admin_url_for(obj):
 
 
 class CustomModelAdmin(admin.ModelAdmin):
+    # Make everything read-only
     # https://stackoverflow.com/a/53070092/14558
     def has_change_permission(self, request, obj=None):
         return False
@@ -25,19 +26,25 @@ class CustomModelAdmin(admin.ModelAdmin):
         return False
 
     def __init__(self, model, admin_site):
+        self.exclude = []
+
         # If the subclass already defined FOO_as_link in list_display, use that
         def maybe_link(field_name):
             if field_name + "_as_link" in self.list_display:
+                self.exclude.append(field_name)
                 return field_name + "_as_link"
             return field_name
 
+        # Show all easily-displayable fields
         self.list_display = tuple(
             maybe_link(field.name)
             for field in model._meta.get_fields()
             if not field.many_to_many and not field.auto_created
         )
-        print(self.list_display)
         self.list_select_related = True
+
+        # This makes the _as_link function get used on the detail page
+        self.readonly_fields = self.list_display
 
         field_names = [f.name for f in model._meta.get_fields()]
         if "id" in field_names:
@@ -88,10 +95,43 @@ class DictionarySourceAdmin(CustomModelAdmin):
     pass
 
 
+class DefinitionInline(admin.TabularInline):
+    model = Definition
+    show_change_link = True
+    view_on_site = False
+
+
+class EnglishKeywordInline(admin.TabularInline):
+    model = EnglishKeyword
+    show_change_link = True
+    view_on_site = False
+
+
+class WordformInline(admin.TabularInline):
+    model = Wordform
+    show_change_link = True
+    verbose_name = "Inflection"
+    verbose_name_plural = "Inflections"
+
+    def get_view_on_site_url(self, obj=None):
+        # get_absolute_url() throws exceptions if obj is not a lemma
+        if obj.is_lemma:
+            return obj.get_absolute_url()
+        return None
+
+
 @admin.register(Wordform)
-class DictionarySourceAdmin(CustomModelAdmin):
+class WordformAdmin(CustomModelAdmin):
     list_display = ("lemma_as_link",)
     search_fields = ("text", "analysis", "stem")
+    list_filter = ("is_lemma", "as_is")
+
+    inlines = [DefinitionInline, EnglishKeywordInline, WordformInline]
+
+    def view_on_site(self, obj):
+        if obj.is_lemma:
+            return obj.get_absolute_url()
+        return None
 
     def lemma_as_link(self, obj: Wordform):
         if obj.lemma == obj:

--- a/CreeDictionary/API/admin.py
+++ b/CreeDictionary/API/admin.py
@@ -56,6 +56,13 @@ class CustomModelAdmin(admin.ModelAdmin):
         super().__init__(model, admin_site)
 
 
+def add_short_description(func, short_description):
+    # There’s currently no reasonable way in mypy to declare attributes on
+    # function objects
+    # https://github.com/python/mypy/issues/2087
+    func.short_description = short_description
+
+
 @admin.register(Definition)
 class DefinitionAdmin(CustomModelAdmin):
     list_display = ("wordform_as_link",)
@@ -71,7 +78,7 @@ class DefinitionAdmin(CustomModelAdmin):
             name=str(obj.wordform),
         )
 
-    wordform_as_link.short_description = "Wordform"
+    add_short_description(wordform_as_link, "Wordform")
 
 
 @admin.register(EnglishKeyword)
@@ -87,7 +94,7 @@ class EnglishKeywordAdmin(CustomModelAdmin):
             name=str(obj.lemma),
         )
 
-    lemma_as_link.short_description = "Lemma"
+    add_short_description(lemma_as_link, "Lemma")
 
 
 @admin.register(DictionarySource)
@@ -144,4 +151,4 @@ class WordformAdmin(CustomModelAdmin):
             name=str(obj.lemma),
         )
 
-    lemma_as_link.short_description = "Lemma"
+    add_short_description(lemma_as_link, "Lemma")

--- a/CreeDictionary/API/admin.py
+++ b/CreeDictionary/API/admin.py
@@ -1,0 +1,107 @@
+from django.contrib import admin
+from django.urls import reverse
+from django.utils.html import format_html
+
+from .models import Definition, DictionarySource, EnglishKeyword, Wordform
+
+
+# https://stackoverflow.com/a/1720961/14558
+def admin_url_for(obj):
+    return reverse(
+        "admin:%s_%s_change" % (obj._meta.app_label, obj._meta.model_name),
+        args=[obj.id],
+    )
+
+
+class CustomModelAdmin(admin.ModelAdmin):
+    # https://stackoverflow.com/a/53070092/14558
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_add_permission(self, request):
+        return False
+
+    def __init__(self, model, admin_site):
+        # If the subclass already defined FOO_as_link in list_display, use that
+        def maybe_link(field_name):
+            if field_name + "_as_link" in self.list_display:
+                return field_name + "_as_link"
+            return field_name
+
+        self.list_display = tuple(
+            maybe_link(field.name)
+            for field in model._meta.get_fields()
+            if not field.many_to_many and not field.auto_created
+        )
+        print(self.list_display)
+        self.list_select_related = True
+
+        field_names = [f.name for f in model._meta.get_fields()]
+        if "id" in field_names:
+            self.ordering = ["id"]
+
+        if "text" in field_names:
+            self.list_display_links += ("text",)
+
+        super().__init__(model, admin_site)
+
+
+@admin.register(Definition)
+class DefinitionAdmin(CustomModelAdmin):
+    list_display = ("wordform_as_link",)
+    search_fields = ("text",)
+
+    # “How to add clickable links to a field in Django admin?”:
+    # https://stackoverflow.com/a/31745953/14558
+    def wordform_as_link(self, obj: Definition):
+        return format_html(
+            "<a href='{url}'>{id} {name}</a>",
+            url=admin_url_for(obj.wordform),
+            id=obj.wordform_id,
+            name=str(obj.wordform),
+        )
+
+    wordform_as_link.short_description = "Wordform"
+
+
+@admin.register(EnglishKeyword)
+class EnglishKeywordAdmin(CustomModelAdmin):
+    list_display = ("lemma_as_link",)
+    search_fields = ("text",)
+
+    def lemma_as_link(self, obj: Wordform):
+        return format_html(
+            "<a href='{url}'>{id} {name}</a>",
+            url=admin_url_for(obj.lemma),
+            id=obj.lemma_id,
+            name=str(obj.lemma),
+        )
+
+    lemma_as_link.short_description = "Lemma"
+
+
+@admin.register(DictionarySource)
+class DictionarySourceAdmin(CustomModelAdmin):
+    pass
+
+
+@admin.register(Wordform)
+class DictionarySourceAdmin(CustomModelAdmin):
+    list_display = ("lemma_as_link",)
+    search_fields = ("text", "analysis", "stem")
+
+    def lemma_as_link(self, obj: Wordform):
+        if obj.lemma == obj:
+            return "self"
+
+        return format_html(
+            "<a href='{url}'>{id} {name}</a>",
+            url=admin_url_for(obj.lemma),
+            id=obj.lemma_id,
+            name=str(obj.lemma),
+        )
+
+    lemma_as_link.short_description = "Lemma"

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -5,6 +5,8 @@ Definition of urls for CreeDictionary.
 import logging
 import os
 
+from django.contrib import admin
+
 import API.views as api_views
 from django.conf import settings
 from django.conf.urls import url
@@ -118,6 +120,7 @@ _urlpatterns = [
         api_views.click_in_text,
         "cree-dictionary-word-click-in-text-api",
     ),
+    ("admin/", admin.site.urls, "admin"),
     (
         "",
         include("morphodict.urls"),

--- a/CreeDictionary/tests/CreeDictionary_tests/test_admin.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_admin.py
@@ -1,0 +1,31 @@
+import pytest
+from django.conf import settings
+from django.urls import reverse
+
+from API.models import Wordform
+
+
+@pytest.fixture(scope="module")
+def django_db_setup():
+    """
+    This works with pytest-django plugin.
+    This fixture tells all functions marked with pytest.mark.django_db in this file
+    to use the database specified in settings.py
+    which is the existing test_db.sqlite3 if USE_TEST_DB=True is passed.
+
+    Instead of by default, an empty database in memory.
+    """
+
+    # all functions in this file should use the existing test_db.sqlite3
+    assert settings.USE_TEST_DB
+
+
+@pytest.mark.django_db
+def test_admin_doesnt_crash(admin_client):
+    "This is a minimal test that we can view a wordform in the admin interface"
+    one_wordform = Wordform.objects.filter(is_lemma=True).first()
+    response = admin_client.get(
+        reverse("admin:API_wordform_change", args=[one_wordform.id])
+    )
+    assert response.status_code == 200
+    assert b"Inflections" in response.content


### PR DESCRIPTION
For figuring out where definitions/wordforms come from and how they are linked, I’ve found it very useful to have an internal read-only admin-only view where you can point-and-click to see how things are connected.

<img width="977" alt="new-admin" src="https://user-images.githubusercontent.com/178162/105736573-2fae9800-5ef2-11eb-9b08-a4c1535593b2.png">
