### PR TITLE
Turn off mypy ignore_missing_imports

### DIFF
--- a/CreeDictionary/DatabaseManager/xml_importer.py
+++ b/CreeDictionary/DatabaseManager/xml_importer.py
@@ -1,7 +1,7 @@
 import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import DefaultDict, Dict, List, NamedTuple, Set, Tuple
+from typing import DefaultDict, Dict, List, NamedTuple, Set, Tuple, Optional
 
 from colorama import init
 from django.conf import settings
@@ -125,7 +125,7 @@ def import_sources():
 
 
 class ProcessedEntry(NamedTuple):
-    stem: str
+    stem: Optional[str]
     ic: str
     lemma_analysis: str
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 
 [mypy-API.migrations.*]
-# Auto-generated code
+# Skip checking Django-auto-generated migration code
 ignore_errors = True
 
 # External packages that we haven’t set up types for
@@ -22,7 +22,14 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-django.*]
-# TODO: try https://pypi.org/project/django-stubs/
+# https://github.com/typeddjango/django-stubs exists, but attempts to use
+# it were fiddly enough that it didn’t seem worth the hassle
+#
+# https://groups.google.com/g/django-developers/c/C_Phs05kL1Q/discussion
+# “Technical Board statement on type hints for Django”, 2020-04-14:
+# “It is the view of the Django Technical Board that inline type
+# annotations should not be added to Django at the current time … the
+# barrier for further inline changes will be high.”
 ignore_missing_imports = True
 
 [mypy-django_js_reverse.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,44 @@
 [mypy]
-ignore_missing_imports = True
 
 [mypy-API.migrations.*]
+# Auto-generated code
 ignore_errors = True
+
+# External packages that we haven’t set up types for
+
+[mypy-Levenshtein.*]
+ignore_missing_imports = True
+
+[mypy-colorama.*]
+ignore_missing_imports = True
+
+[mypy-cree_sro_syllabics.*]
+ignore_missing_imports = True
+
+[mypy-dawg.*]
+ignore_missing_imports = True
+
+[mypy-debug_toolbar.*]
+ignore_missing_imports = True
+
+[mypy-django.*]
+# TODO: try https://pypi.org/project/django-stubs/
+ignore_missing_imports = True
+
+[mypy-django_js_reverse.*]
+ignore_missing_imports = True
+
+[mypy-snowballstemmer.*]
+ignore_missing_imports = True
+
+[mypy-pytest_django.*]
+ignore_missing_imports = True
+
+[mypy-secure.*]
+ignore_missing_imports = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True
+
+[mypy-tqdm.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Python doesn’t always require the file `__init__.py`, but without it, mypy
doesn’t know how to trace imports even between files in the same directory,
so all imports of types turn into `Any`, and `ignore_missing_imports` hides
that anything is amiss.