### PR TITLE
Fix paradigm audio

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
@@ -59,7 +59,7 @@
       </ol>
     </section>
 
-    <section  id="paradigm">
+    <section id="paradigm">
       {% if paradigm_tables %}
         {% include './components/paradigm.html' %}
       {% endif %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
@@ -17,8 +17,7 @@
   {% load inflection_extras %}
   {% load morphodict_orth %}
 
-  {# TODO: this ID should NOT be "paradigm"!!!! #}
-  <article class="definition" id="paradigm">
+  <article class="definition">
     <header class="definition__header">
       <h1 id="head" class="definition-title">
         <dfn class="definition__matched-head">
@@ -60,8 +59,10 @@
       </ol>
     </section>
 
-    {% if paradigm_tables %}
-      {% include './components/paradigm.html' %}
-    {% endif %}
+    <section  id="paradigm">
+      {% if paradigm_tables %}
+        {% include './components/paradigm.html' %}
+      {% endif %}
+    </section>
   </article>
 {% endspaceless %}

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -115,6 +115,12 @@ _urlpatterns = [
         views.lemma_details_internal,
         "cree-dictionary-lemma-detail",
     ),
+    # internal use to render paradigm and only the paradigm
+    (
+        "_paradigm_details/",
+        views.paradigm_internal,
+        "cree-dictionary-paradigm-detail",
+    ),
     # cree word translation for click-in-text
     (
         "click-in-text/",

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -109,12 +109,6 @@ _urlpatterns = [
         views.search_results,
         "cree-dictionary-search-results",
     ),
-    # internal use to render paradigm and detailed info for a lemma
-    (
-        "_lemma_details/",
-        views.lemma_details_internal,
-        "cree-dictionary-lemma-detail",
-    ),
     # internal use to render paradigm and only the paradigm
     (
         "_paradigm_details/",

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -118,59 +118,6 @@ def search_results(request, query_string: str):  # pragma: no cover
         },
     )
 
-
-@require_GET
-def lemma_details_internal(request):
-    """
-    Render word-detail.html for a lemma. `index` view function renders a whole page that contains word-detail.html too.
-    This function, however, is used by javascript to dynamically replace the paradigm with the ones of different sizes.
-
-    `lemma-id` and `paradigm-size` are the expected query params in the request
-
-    4xx errors will have a single string as error message
-
-    :raise 400 Bad Request: when the query params are not as expected or inappropriate
-    :raise 404 Not Found: when the lemma-id isn't found in the database
-    :raise 405 Method Not Allowed: when method other than GET is used
-    """
-    lemma_id = request.GET.get("lemma-id")
-    paradigm_size = request.GET.get("paradigm-size")
-    # guards
-    if lemma_id is None or paradigm_size is None:
-        return HttpResponseBadRequest("query params missing")
-    try:
-        lemma_id = int(lemma_id)
-    except ValueError:
-        return HttpResponseBadRequest("lemma-id should be a non-negative integer")
-    else:
-        if lemma_id < 0:
-            return HttpResponseBadRequest(
-                "lemma-id is negative and should be non-negative"
-            )
-    try:
-        paradigm_size = ParadigmSize(paradigm_size.upper())
-    except ValueError:
-        return HttpResponseBadRequest(
-            f"paradigm-size is not one {[x.value for x in ParadigmSize]}"
-        )
-
-    try:
-        lemma = Wordform.objects.get(id=lemma_id)
-    except Wordform.DoesNotExist:
-        return HttpResponseNotFound("specified lemma-id is not found in the database")
-    # end guards
-
-    return render(
-        request,
-        "CreeDictionary/word-detail.html",
-        {
-            "lemma": lemma,
-            "paradigm_size": paradigm_size.value,
-            "paradigm_tables": lemma.get_paradigm_layouts(size=paradigm_size),
-        },
-    )
-
-
 @require_GET
 def paradigm_internal(request):
     """

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -171,6 +171,58 @@ def lemma_details_internal(request):
     )
 
 
+@require_GET
+def paradigm_internal(request):
+    """
+    Render word-detail.html for a lemma. `index` view function renders a whole page that contains word-detail.html too.
+    This function, however, is used by javascript to dynamically replace the paradigm with the ones of different sizes.
+
+    `lemma-id` and `paradigm-size` are the expected query params in the request
+
+    4xx errors will have a single string as error message
+
+    :raise 400 Bad Request: when the query params are not as expected or inappropriate
+    :raise 404 Not Found: when the lemma-id isn't found in the database
+    :raise 405 Method Not Allowed: when method other than GET is used
+    """
+    lemma_id = request.GET.get("lemma-id")
+    paradigm_size = request.GET.get("paradigm-size")
+    # guards
+    if lemma_id is None or paradigm_size is None:
+        return HttpResponseBadRequest("query params missing")
+    try:
+        lemma_id = int(lemma_id)
+    except ValueError:
+        return HttpResponseBadRequest("lemma-id should be a non-negative integer")
+    else:
+        if lemma_id < 0:
+            return HttpResponseBadRequest(
+                "lemma-id is negative and should be non-negative"
+            )
+    try:
+        paradigm_size = ParadigmSize(paradigm_size.upper())
+    except ValueError:
+        return HttpResponseBadRequest(
+            f"paradigm-size is not one {[x.value for x in ParadigmSize]}"
+        )
+
+    try:
+        lemma = Wordform.objects.get(id=lemma_id)
+    except Wordform.DoesNotExist:
+        return HttpResponseNotFound("specified lemma-id is not found in the database")
+    # end guards
+
+    return render(
+        request,
+        "CreeDictionary/components/paradigm.html",
+        {
+            "lemma": lemma,
+            "paradigm_size": paradigm_size.value,
+            "paradigm_tables": lemma.get_paradigm_layouts(size=paradigm_size),
+        },
+    )
+
+
 def about(request):  # pragma: no cover
     """
     About page.

--- a/CreeDictionary/tests/CreeDictionary_tests/test_views.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_views.py
@@ -43,7 +43,7 @@ class TestLemmaDetailsInternal4xx:
             ],  # we'll never have as many as 99999999 entries in the database so it's a non-existent id
         ],
     )
-    def test_lemma_details_internal_400_404(
+    def test_paradigm_details_internal_400_404(
         self, lemma_id: Optional[str], paradigm_size: Optional[str], expected_code: int
     ):
         c = Client()
@@ -53,14 +53,14 @@ class TestLemmaDetailsInternal4xx:
             get_data["lemma-id"] = lemma_id
         if paradigm_size is not None:
             get_data["paradigm-size"] = paradigm_size
-        response = c.get("/_lemma_details/", get_data)
+        response = c.get(reverse("cree-dictionary-paradigm-detail"), get_data)
         assert response.status_code == expected_code
 
     @pytest.mark.parametrize(("method",), (("post",), ("put",), ("delete",)))
-    def test_lemma_details_internal_wrong_method(self, method: str):
+    def test_paradigm_details_internal_wrong_method(self, method: str):
         c = Client()
         response = getattr(c, method)(
-            "/_lemma_details/", {"lemma-id": 1, "paradigm-size": "BASIC"}
+            reverse("cree-dictionary-paradigm-detail"), {"lemma-id": 1, "paradigm-size": "BASIC"}
         )
         assert response.status_code == HttpResponseNotAllowed.status_code
 

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -334,7 +334,7 @@ context('Regressions', () => {
    * See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/636 
    */
 
-  it.only("should show audio button after showing more", () => {
+  it("should show audio button after showing more", () => {
     cy.visitSearch("minôs")
 
     cy.contains('[data-cy=lemma-link]', "minôs")

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -346,7 +346,7 @@ context('Regressions', () => {
     cy.get('[data-cy=paradigm-toggle-button')
       .click()
 
-    cy.url()
+    cy.location('search')
       .should("include", "paradigm-size=FULL")
 
     cy.get('[data-cy=play-recording]')

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -327,4 +327,30 @@ context('Regressions', () => {
       })
     }
   })
+
+  /**
+   * Ensure audio is playable after clicking "show more"
+   * 
+   * See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/636 
+   */
+
+  it.only("should show audio button after showing more", () => {
+    cy.visitSearch("minôs")
+
+    cy.contains('[data-cy=lemma-link]', "minôs")
+      .click()
+
+    cy.get('[data-cy=play-recording]')
+      .should("be.visible")
+
+    cy.get('[data-cy=paradigm-toggle-button')
+      .click()
+
+    cy.url()
+      .should("include", "paradigm-size=FULL")
+
+    cy.get('[data-cy=play-recording]')
+      .should("be.visible")
+
+  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -179,7 +179,7 @@ function setupParadigmSizeToggleButton() {
     // Make it look like it's loading:
     toggleButton.classList.add('paradigm__size-toggle-button--loading')
 
-    fetch(Urls['cree-dictionary-lemma-detail']() + `?lemma-id=${lemmaId}&paradigm-size=${nextParadigmSize}`).then(r => {
+    fetch(Urls['cree-dictionary-paradigm-detail']() + `?lemma-id=${lemmaId}&paradigm-size=${nextParadigmSize}`).then(r => {
       if (r.ok) {
         return r.text()
       } else {

--- a/src/index.js
+++ b/src/index.js
@@ -198,12 +198,12 @@ function setupParadigmSizeToggleButton() {
         }
         window.history.replaceState({}, document.title, updateQueryParam('paradigm-size', nextParadigmSize))
         const oldParadigmNode = document.getElementById('paradigm')
-        oldParadigmNode.parentElement.replaceChild(paradigmFrag, oldParadigmNode)
+        oldParadigmNode.firstElementChild.replaceWith(paradigmFrag)
         paradigmSize = nextParadigmSize
         setupParadigmSizeToggleButton() // prepare the new button
       }
     ).catch(
-      r => console.error(r)
+      err => console.error(err)
     )
   })
 }


### PR DESCRIPTION
Fix #636 . Instead of replacing entire word details page when pressing "load more", just replace the paradigm section.