### PR TITLE
change: use .js-* classes to select things in the paradigm

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
@@ -17,6 +17,8 @@
     JavaScript hooks:
      - .js-replaceable-paradigm: encapsulates the ENTIRE paradgim so that
        JavaScript can replace the contents with a different paradigm.
+     - .js-paradigm-size-button: the button for advancing the paradigm size
+        (basic, full, linguistic, etc.)
      - .js-plus-minus: the + or - sign in the [± show more/less] button
      - .js-button-text: the text in the [± show more/less] button
 
@@ -82,7 +84,7 @@
       </table>
     </div>
 
-    <button class="paradigm__size-toggle-button" data-cy="paradigm-toggle-button">
+    <button class="paradigm__size-toggle-button js-paradigm-size-button" data-cy="paradigm-toggle-button">
       <span class="paradigm__size-toggle-plus-minus js-plus-minus">
         {% if paradigm_size.value == 'LINGUISTIC' %}- {% else %}+ {% endif %}
       </span>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
@@ -15,10 +15,10 @@
         | [       + show more      ] |
 
     JavaScript hooks:
-     - .js-replaceable-paradigm: encapsulates the ENTIRE paradgim so that
+     - .js-replaceable-paradigm: encapsulates the ENTIRE paradigm so that
        JavaScript can replace the contents with a different paradigm.
      - .js-paradigm-size-button: the button for advancing the paradigm size
-        (basic, full, linguistic, etc.)
+       (basic, full, linguistic, etc.)
      - .js-plus-minus: the + or - sign in the [± show more/less] button
      - .js-button-text: the text in the [± show more/less] button
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
@@ -14,9 +14,11 @@
         | You  | kinipân | ê-nipâyan |
         | [       + show more      ] |
 
-    Notes:
-     - has class `js-replaceable-paradigm` so that JavaScript can replace this
-       contents with a different paradigm.
+    JavaScript hooks:
+     - .js-replaceable-paradigm: encapsulates the ENTIRE paradgim so that
+       JavaScript can replace the contents with a different paradigm.
+     - .js-plus-minus: the + or - sign in the [± show more/less] button
+     - .js-button-text: the text in the [± show more/less] button
 
   {% endcomment %}
 
@@ -81,10 +83,10 @@
     </div>
 
     <button class="paradigm__size-toggle-button" data-cy="paradigm-toggle-button">
-      <span class="paradigm__size-toggle-plus-minus">
+      <span class="paradigm__size-toggle-plus-minus js-plus-minus">
         {% if paradigm_size.value == 'LINGUISTIC' %}- {% else %}+ {% endif %}
       </span>
-      <span class="paradigm__size-toggle-button-text">
+      <span class="paradigm__size-toggle-button-text js-button-text">
         show {% if paradigm_size.value == 'LINGUISTIC' %}less{% else %}more{% endif %}
       </span>
     </button>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
@@ -14,11 +14,15 @@
         | You  | kinipân | ê-nipâyan |
         | [       + show more      ] |
 
+    Notes:
+     - has class `js-replaceable-paradigm` so that JavaScript can replace this
+       contents with a different paradigm.
+
   {% endcomment %}
 
   {% load morphodict_orth %}
 
-  <section class="definition__paradigm paradigm" data-cy="paradigm">
+  <section class="definition__paradigm paradigm js-replaceable-paradigm" data-cy="paradigm">
     {# XXX: we should find a better way to contain all the data in the table :/ #}
     <div class="HACK-overflow-x-scroll">
       <table class="paradigm__table">

--- a/cypress/integration/regressions.spec.js
+++ b/cypress/integration/regressions.spec.js
@@ -351,6 +351,5 @@ context('Regressions', () => {
 
     cy.get('[data-cy=play-recording]')
       .should('be.visible')
-
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -190,12 +190,9 @@ function setupParadigmSizeToggleButton() {
         const paradigmFrag = document.createRange().createContextualFragment(text)
 
         if (mostDetailedParadigmSizeIsSelected()) {
-          paradigmFrag.querySelector('.js-button-text').textContent = 'show less'
-          paradigmFrag.querySelector('.js-plus-minus').textContent = '- '
-
+          setParadigmSizeToggleButtonText('-', 'show less')
         } else {
-          paradigmFrag.querySelector('.js-button-text').textContent = 'show more'
-          paradigmFrag.querySelector('.js-plus-minus').textContent = '+ '
+          setParadigmSizeToggleButtonText('+', 'show more')
         }
 
         window.history.replaceState({}, document.title, updateQueryParam('paradigm-size', nextParadigmSize))
@@ -203,6 +200,11 @@ function setupParadigmSizeToggleButton() {
         oldParadigmNode.querySelector('.js-replaceable-paradigm').replaceWith(paradigmFrag)
         paradigmSize = nextParadigmSize
         setupParadigmSizeToggleButton() // prepare the new button
+
+        function setParadigmSizeToggleButtonText(symbol, text) {
+          paradigmFrag.querySelector('.js-button-text').textContent = text
+          paradigmFrag.querySelector('.js-plus-minus').textContent = symbol
+        }
       }
     ).catch(
       err => console.error(err)
@@ -212,6 +214,7 @@ function setupParadigmSizeToggleButton() {
   function mostDetailedParadigmSizeIsSelected() {
     return allParadigmSizes.indexOf(nextParadigmSize) === allParadigmSizes.length - 1
   }
+
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -206,9 +206,10 @@ function setupParadigmSizeToggleButton() {
           paradigmFrag.querySelector('.js-plus-minus').textContent = symbol
         }
       }
-    ).catch(
-      err => console.error(err)
-    )
+    ).catch((err) => {
+      displayButtonAsError(toggleButton)
+      console.error(err)
+    })
   })
 
   function mostDetailedParadigmSizeIsSelected() {
@@ -221,6 +222,14 @@ function setupParadigmSizeToggleButton() {
  */
 function displayButtonAsLoading(toggleButton) {
   toggleButton.classList.add('paradigm__size-toggle-button--loading')
+}
+
+/**
+ * Make the button look like something went wrong.
+ */
+function displayButtonAsError(toggleButton) {
+  toggleButton.classList.remove('paradigm__size-toggle-button--loading')
+  // TODO: should have an error state for the toggle button!
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ function updateQueryParam(key, value) {
  *  - prepare the new "show more/less" button to do these 3
  */
 function setupParadigmSizeToggleButton() {
-  const toggleButton = document.getElementsByClassName('paradigm__size-toggle-button')[0]
+  const toggleButton = document.querySelector('.js-paradigm-size-button')
 
   if (!toggleButton) {
     // There's nothing to toggle, hence nothing to setup. Done!

--- a/src/index.js
+++ b/src/index.js
@@ -188,7 +188,7 @@ function setupParadigmSizeToggleButton() {
     }).then(
       text => {
         const paradigmFrag = document.createRange().createContextualFragment(text)
-        if (allParadigmSizes.indexOf(nextParadigmSize) === allParadigmSizes.length - 1) {
+        if (mostDetailedParadigmSizeIsSelected()) {
           paradigmFrag.querySelector('.paradigm__size-toggle-button-text').textContent = 'show less'
           paradigmFrag.querySelector('.paradigm__size-toggle-plus-minus').textContent = '- '
 
@@ -206,6 +206,10 @@ function setupParadigmSizeToggleButton() {
       err => console.error(err)
     )
   })
+
+  function mostDetailedParadigmSizeIsSelected() {
+    return allParadigmSizes.indexOf(nextParadigmSize) === allParadigmSizes.length - 1
+  }
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -175,9 +175,9 @@ function setupParadigmSizeToggleButton() {
   }
 
   const nextParadigmSize = getNextParadigmSize(paradigmSize)
+
   toggleButton.addEventListener('click', () => {
-    // Make it look like it's loading:
-    toggleButton.classList.add('paradigm__size-toggle-button--loading')
+    displayButtonAsLoading(toggleButton)
 
     fetch(Urls['cree-dictionary-paradigm-detail']() + `?lemma-id=${lemmaId}&paradigm-size=${nextParadigmSize}`).then(r => {
       if (r.ok) {
@@ -214,7 +214,13 @@ function setupParadigmSizeToggleButton() {
   function mostDetailedParadigmSizeIsSelected() {
     return allParadigmSizes.indexOf(nextParadigmSize) === allParadigmSizes.length - 1
   }
+}
 
+/**
+ * Make the button look like it's loading.
+ */
+function displayButtonAsLoading(toggleButton) {
+  toggleButton.classList.add('paradigm__size-toggle-button--loading')
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -188,14 +188,16 @@ function setupParadigmSizeToggleButton() {
     }).then(
       text => {
         const paradigmFrag = document.createRange().createContextualFragment(text)
+
         if (mostDetailedParadigmSizeIsSelected()) {
-          paradigmFrag.querySelector('.paradigm__size-toggle-button-text').textContent = 'show less'
-          paradigmFrag.querySelector('.paradigm__size-toggle-plus-minus').textContent = '- '
+          paradigmFrag.querySelector('.js-button-text').textContent = 'show less'
+          paradigmFrag.querySelector('.js-plus-minus').textContent = '- '
 
         } else {
-          paradigmFrag.querySelector('.paradigm__size-toggle-button-text').textContent = 'show more'
-          paradigmFrag.querySelector('.paradigm__size-toggle-plus-minus').textContent = '+ '
+          paradigmFrag.querySelector('.js-button-text').textContent = 'show more'
+          paradigmFrag.querySelector('.js-plus-minus').textContent = '+ '
         }
+
         window.history.replaceState({}, document.title, updateQueryParam('paradigm-size', nextParadigmSize))
         const oldParadigmNode = document.getElementById('paradigm')
         oldParadigmNode.querySelector('.js-replaceable-paradigm').replaceWith(paradigmFrag)

--- a/src/index.js
+++ b/src/index.js
@@ -82,9 +82,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Word detail/paradigm page. This one has the 🔊 button.
     setSubtitle(getEntryHead())
     setupAudioOnPageLoad()
-    if (document.getElementById('paradigm')) { // if the lemma has a paradigm thus having a "show more/less" button
-      setupParadigmSizeToggleButton()
-    }
+    setupParadigmSizeToggleButton()
   } else {
     throw new Error(`Could not match route: ${route}`)
   }
@@ -187,8 +185,10 @@ function setupParadigmSizeToggleButton() {
       }
     }).then(
       text => {
-        const paradigmFrag = document.createRange().createContextualFragment(text)
+        const newParadigm = document.createRange().createContextualFragment(text)
 
+        // TODO: is this necessary? Shouldn't the component itself know what
+        // text to use?
         if (mostDetailedParadigmSizeIsSelected()) {
           setParadigmSizeToggleButtonText('-', 'show less')
         } else {
@@ -196,14 +196,16 @@ function setupParadigmSizeToggleButton() {
         }
 
         window.history.replaceState({}, document.title, updateQueryParam('paradigm-size', nextParadigmSize))
-        const oldParadigmNode = document.getElementById('paradigm')
-        oldParadigmNode.querySelector('.js-replaceable-paradigm').replaceWith(paradigmFrag)
+
+        const paradigmContainer = document.getElementById('paradigm')
+        paradigmContainer.querySelector('.js-replaceable-paradigm').replaceWith(newParadigm)
+
         paradigmSize = nextParadigmSize
-        setupParadigmSizeToggleButton() // prepare the new button
+        setupParadigmSizeToggleButton()
 
         function setParadigmSizeToggleButtonText(symbol, text) {
-          paradigmFrag.querySelector('.js-button-text').textContent = text
-          paradigmFrag.querySelector('.js-plus-minus').textContent = symbol
+          newParadigm.querySelector('.js-button-text').textContent = text
+          newParadigm.querySelector('.js-plus-minus').textContent = symbol
         }
       }
     ).catch((err) => {

--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ function setupParadigmSizeToggleButton() {
         }
         window.history.replaceState({}, document.title, updateQueryParam('paradigm-size', nextParadigmSize))
         const oldParadigmNode = document.getElementById('paradigm')
-        oldParadigmNode.firstElementChild.replaceWith(paradigmFrag)
+        oldParadigmNode.querySelector('.js-replaceable-paradigm').replaceWith(paradigmFrag)
         paradigmSize = nextParadigmSize
         setupParadigmSizeToggleButton() // prepare the new button
       }


### PR DESCRIPTION
An improvement to #641. I felt uneasy using the existing (unweildly!) [BEM](http://getbem.com/) class names, and chose instead to use the `js-*` prefix for the class names to use in JavaScript.

I also refactored and cleaned up variable names because I can't help myself ¯\\\_(ツ)\_/¯  