### PR TITLE
fix/refactor: metatags

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -3,26 +3,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>itwêwina: the online Cree dictionary</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#A20010">
   {% block metatags %}
-  <!-- Primary Meta Tags -->
-  <meta name="description" content="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit">
-
-  <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://itwewina.altlab.app/">
-  <meta property="og:title" content="itwêwina: the Plains Cree dictionary">
-  <meta property="og:description" content="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit">
-  <meta property="og:image" content="{% static 'CreeDictionary/images/itwewina-social.svg' %}">
-
-  <!-- Twitter -->
-  <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://itwewina.altlab.app/">
-  <meta property="twitter:title" content="itwêwina: the Plains Cree dictionary">
-  <meta property="twitter:description" content="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit">
-  <meta property="twitter:image" content="{% static 'CreeDictionary/images/itwewina-social.svg' %}">
+  {% include 'CreeDictionary/components/metatags.html' %}
   {% endblock %}
   <link rel="icon" type="image/png" href="{% static 'CreeDictionary/images/itwewina-32.png' %}">
   <link rel="alternate icon" type="image/svg+xml" href="{% static 'CreeDictionary/images/itwewina.svg' %}">

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/metatags.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/metatags.html
@@ -11,7 +11,7 @@
 
   {% load url_extras %}
 
-  {% with title_="itwêwina: the online Cree dictionary" desc_="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit" %}
+  {% with title_="itwêwina: the online Cree dictionary" desc_="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyiniwâk" %}
   {% abstatic 'CreeDictionary/images/itwewina-social.svg' as image_url %}
 
   {# Primary Meta Tags #}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/metatags.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/metatags.html
@@ -8,10 +8,12 @@
        MOST important part!
      - description — a short summary of the current page
   {% endcomment %}
-  
+
   {% load url_extras %}
 
   {% with title_="itwêwina: the online Cree dictionary" desc_="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit" %}
+  {% abstatic 'CreeDictionary/images/itwewina-social.svg' as image_url %}
+
   {# Primary Meta Tags #}
   <title>{{ title|default:title_ }}</title>
   <meta name="description" content="{{ description|default:desc_ }}">
@@ -21,13 +23,13 @@
   <meta property="og:url" content="https://itwewina.altlab.app/">
   <meta property="og:title" content="{{ title|default:title_ }}">
   <meta property="og:description" content="{{ description|default:desc_ }}">
-  <meta property="og:image" content="{% abstatic 'CreeDictionary/images/itwewina-social.svg' %}">
+  <meta property="og:image" content="{{ image_url }}">
 
   {# Twitter #}
   <meta property="twitter:card" content="summary_large_image">
   <meta property="twitter:url" content="https://itwewina.altlab.app/">
   <meta property="twitter:title" content="{{ title|default:title_ }}">
   <meta property="twitter:description" content="{{ description|default:desc_ }}">
-  <meta property="twitter:image" content="{% abstatic 'CreeDictionary/images/itwewina-social.svg' %}">
+  <meta property="twitter:image" content="{{ image_url }}">
   {% endwith %}
 {% endspaceless %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/metatags.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/metatags.html
@@ -9,7 +9,7 @@
      - description — a short summary of the current page
   {% endcomment %}
   
-  {% load static %}
+  {% load url_extras %}
 
   {% with title_="itwêwina: the online Cree dictionary" desc_="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit" %}
   {# Primary Meta Tags #}
@@ -21,13 +21,13 @@
   <meta property="og:url" content="https://itwewina.altlab.app/">
   <meta property="og:title" content="{{ title|default:title_ }}">
   <meta property="og:description" content="{{ description|default:desc_ }}">
-  <meta property="og:image" content="{% static 'CreeDictionary/images/itwewina-social.svg' %}">
+  <meta property="og:image" content="{% abstatic 'CreeDictionary/images/itwewina-social.svg' %}">
 
   {# Twitter #}
   <meta property="twitter:card" content="summary_large_image">
   <meta property="twitter:url" content="https://itwewina.altlab.app/">
   <meta property="twitter:title" content="{{ title|default:title_ }}">
   <meta property="twitter:description" content="{{ description|default:desc_ }}">
-  <meta property="twitter:image" content="{% static 'CreeDictionary/images/itwewina-social.svg' %}">
+  <meta property="twitter:image" content="{% abstatic 'CreeDictionary/images/itwewina-social.svg' %}">
   {% endwith %}
 {% endspaceless %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/metatags.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/metatags.html
@@ -1,0 +1,25 @@
+{% spaceless %}
+  {% comment %}
+    Inserted into the <head>, this adds tags for social media preview.
+  {% endcomment %}
+  
+  {% load static %}
+
+  {# Primary Meta Tags #}
+  <title>itwêwina: the online Cree dictionary</title>
+  <meta name="description" content="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit">
+
+  {# Open Graph / Facebook #}
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://itwewina.altlab.app/">
+  <meta property="og:title" content="itwêwina: the Plains Cree dictionary">
+  <meta property="og:description" content="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit">
+  <meta property="og:image" content="{% static 'CreeDictionary/images/itwewina-social.svg' %}">
+
+  {# Twitter #}
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:url" content="https://itwewina.altlab.app/">
+  <meta property="twitter:title" content="itwêwina: the Plains Cree dictionary">
+  <meta property="twitter:description" content="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit">
+  <meta property="twitter:image" content="{% static 'CreeDictionary/images/itwewina-social.svg' %}">
+{% endspaceless %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/metatags.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/metatags.html
@@ -1,25 +1,33 @@
 {% spaceless %}
   {% comment %}
     Inserted into the <head>, this adds tags for social media preview.
+
+    Parameters:
+     - title — the title of the webpage -- as this goes in the tab bar, it's
+       the link in search results, and is visible in social media links is the
+       MOST important part!
+     - description — a short summary of the current page
   {% endcomment %}
   
   {% load static %}
 
+  {% with title_="itwêwina: the online Cree dictionary" desc_="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit" %}
   {# Primary Meta Tags #}
-  <title>itwêwina: the online Cree dictionary</title>
-  <meta name="description" content="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit">
+  <title>{{ title|default:title_ }}</title>
+  <meta name="description" content="{{ description|default:desc_ }}">
 
   {# Open Graph / Facebook #}
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://itwewina.altlab.app/">
-  <meta property="og:title" content="itwêwina: the Plains Cree dictionary">
-  <meta property="og:description" content="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit">
+  <meta property="og:title" content="{{ title|default:title_ }}">
+  <meta property="og:description" content="{{ description|default:desc_ }}">
   <meta property="og:image" content="{% static 'CreeDictionary/images/itwewina-social.svg' %}">
 
   {# Twitter #}
   <meta property="twitter:card" content="summary_large_image">
   <meta property="twitter:url" content="https://itwewina.altlab.app/">
-  <meta property="twitter:title" content="itwêwina: the Plains Cree dictionary">
-  <meta property="twitter:description" content="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyinîsit">
+  <meta property="twitter:title" content="{{ title|default:title_ }}">
+  <meta property="twitter:description" content="{{ description|default:desc_ }}">
   <meta property="twitter:image" content="{% static 'CreeDictionary/images/itwewina-social.svg' %}">
+  {% endwith %}
 {% endspaceless %}

--- a/CreeDictionary/CreeDictionary/templatetags/url_extras.py
+++ b/CreeDictionary/CreeDictionary/templatetags/url_extras.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+"""
+Get absolute URLs for static assets.
+"""
+from django import template
+from django.urls import reverse
+from django.templatetags.static import StaticNode
+
+register = template.Library()
+
+
+class AbsoluteStaticNode(StaticNode):
+    def url(self, context) -> str:
+        path = super().url(context)
+        if not path.startswith("/"):
+            # Assume it's already an absolute URI:
+            return path
+
+        return context["request"].build_absolute_uri(path)
+
+
+@register.tag
+def abstatic(parser, token):
+    """
+    Given a relative path to a static asset, return the absolute path to the
+    asset.
+
+    Derived from: https://github.com/django/django/blob/635d53a86a36cde7866b9caefeb64d809e6bfcd9/django/templatetags/static.py#L143-L159
+    """
+    return AbsoluteStaticNode.handle_token(parser, token)

--- a/CreeDictionary/CreeDictionary/templatetags/url_extras.py
+++ b/CreeDictionary/CreeDictionary/templatetags/url_extras.py
@@ -33,15 +33,31 @@ class AbstaticNode(StaticNode):
 
 def is_absolute_uri(url: ParseResult) -> bool:
     """
-    What is an absolute URL?
+    Returns True if the parsed result is an "absolute URI".
 
-    From: https://stackoverflow.com/a/17407021/6626414
+    We define an "absolute URI" as containing at mimimum a **scheme** and an
+    **host** (a.k.a., an authority).
 
-    > Absolute URLs contain a great deal of information which may already be known from
-    > the context of the base document's retrieval, including the scheme, network
-    > location, and parts of the URL path.
+    It must contain SH according to the nomenclature defined in this proposal:
+    https://gist.github.com/andrewdotn/eebeaa60d48c3c0f6f9fc75f0ede8d03#proposal
 
-    See also: https://tools.ietf.org/html/rfc1808
+    Examples of absolute URIs:
+        [SH  ]  https://example.com
+        [SHP ]  https://example.com/
+        [SHPF]  https://example.com/foo/cat.gif
+
+    What are NOT absolute URIs:
+        [   F]  cat.gif
+        [  P ]  /
+        [  PF]  /foo/cat.gif
+        [ HPF]  //example.com/foo/cat.gif†
+        [S  F]  https:cat.gif (uncommon)
+        [S PF]  https:/foo/cat.gif (uncommon)
+
+    †: This is called a "network-path reference, and relies on inferring the scheme
+       based on an existing base URI. For our purposes, this is not "absolute" enough!
+       Source: https://tools.ietf.org/html/rfc3986#section-4.2
+
     """
     # netloc == authority, i.e., [username[:password]@]example.com[:443]
     if url.scheme and url.netloc:

--- a/CreeDictionary/CreeDictionary/templatetags/url_extras.py
+++ b/CreeDictionary/CreeDictionary/templatetags/url_extras.py
@@ -1,7 +1,8 @@
 """
 Get absolute URLs for static assets.
 """
-from typing import Optional
+
+from urllib.parse import ParseResult, urlparse, urlunparse
 
 from django import template
 from django.templatetags.static import StaticNode
@@ -10,35 +11,40 @@ from django.urls import reverse
 register = template.Library()
 
 
-class AbsoluteURLStaticNode(StaticNode):
+class AbstaticNode(StaticNode):
     """
-    Like Django's {% static %} tag, but always returns an absolute URL.
+    {% abstatic %} is like Django's {% static %} tag,
+    but always returns an absolute URI.
     """
 
     def url(self, context) -> str:
-        component = super().url(context)
-        if is_absolute_url(component):
-            return component
+        url_to_asset = super().url(context)
 
-        # Django say "absolute_uri" but they really mean "absolute_url" ;)
-        return context["request"].build_absolute_uri(component)
+        parsed_url = urlparse(url_to_asset)
+        assert parsed_url.path
+
+        if is_absolute_uri(parsed_url):
+            return url_to_asset
+
+        # Delegate to Django to provide its own schema and authority:
+        path_and_file = urlunparse(parsed_url._replace(scheme="", netloc=""))
+        return context["request"].build_absolute_uri(path_and_file)
 
 
-def is_absolute_url(component: str) -> bool:
+def is_absolute_uri(url: ParseResult) -> bool:
     """
     What is an absolute URL?
 
     From: https://stackoverflow.com/a/17407021/6626414
 
     > Absolute URLs contain a great deal of information which may already be known from
-    > the context of the base document's retrieval, including the scheme, network 
+    > the context of the base document's retrieval, including the scheme, network
     > location, and parts of the URL path.
 
     See also: https://tools.ietf.org/html/rfc1808
     """
-    if not component.startswith("/"):
-        assert component.startswith("http"), f"Not an absolute URL: {component!r}"
-        assert ":" in component, f"Not an absolute URL: {component!r}"
+    # netloc == authority, i.e., [username[:password]@]example.com[:443]
+    if url.scheme and url.netloc:
         return True
     return False
 
@@ -51,4 +57,4 @@ def abstatic(parser, token):
 
     Derived from: https://github.com/django/django/blob/635d53a86a36cde7866b9caefeb64d809e6bfcd9/django/templatetags/static.py#L143-L159
     """
-    return AbsoluteURLStaticNode.handle_token(parser, token)
+    return AbstaticNode.handle_token(parser, token)

--- a/CreeDictionary/CreeDictionary/templatetags/url_extras.py
+++ b/CreeDictionary/CreeDictionary/templatetags/url_extras.py
@@ -27,7 +27,7 @@ class AbstaticNode(StaticNode):
             return url_to_asset
 
         # Delegate to Django to provide its own schema and authority:
-        path_and_file = urlunparse(parsed_url._replace(scheme="", netloc=""))
+        path_and_file = to_pf_url(parsed_url)
         return context["request"].build_absolute_uri(path_and_file)
 
 
@@ -63,6 +63,14 @@ def is_absolute_uri(url: ParseResult) -> bool:
     if url.scheme and url.netloc:
         return True
     return False
+
+
+def to_pf_url(url: ParseResult):
+    """
+    Returns *P*ath and *F*ile as defined here:
+    https://gist.github.com/andrewdotn/eebeaa60d48c3c0f6f9fc75f0ede8d03#proposal
+    """
+    return urlunparse(url._replace(scheme="", netloc=""))
 
 
 @register.tag

--- a/CreeDictionary/CreeDictionary/templatetags/url_extras.py
+++ b/CreeDictionary/CreeDictionary/templatetags/url_extras.py
@@ -1,23 +1,46 @@
-#!/usr/bin/env python3
-
 """
 Get absolute URLs for static assets.
 """
+from typing import Optional
+
 from django import template
-from django.urls import reverse
 from django.templatetags.static import StaticNode
+from django.urls import reverse
 
 register = template.Library()
 
 
-class AbsoluteStaticNode(StaticNode):
-    def url(self, context) -> str:
-        path = super().url(context)
-        if not path.startswith("/"):
-            # Assume it's already an absolute URI:
-            return path
+class AbsoluteURLStaticNode(StaticNode):
+    """
+    Like Django's {% static %} tag, but always returns an absolute URL.
+    """
 
-        return context["request"].build_absolute_uri(path)
+    def url(self, context) -> str:
+        component = super().url(context)
+        if is_absolute_url(component):
+            return component
+
+        # Django say "absolute_uri" but they really mean "absolute_url" ;)
+        return context["request"].build_absolute_uri(component)
+
+
+def is_absolute_url(component: str) -> bool:
+    """
+    What is an absolute URL?
+
+    From: https://stackoverflow.com/a/17407021/6626414
+
+    > Absolute URLs contain a great deal of information which may already be known from
+    > the context of the base document's retrieval, including the scheme, network 
+    > location, and parts of the URL path.
+
+    See also: https://tools.ietf.org/html/rfc1808
+    """
+    if not component.startswith("/"):
+        assert component.startswith("http"), f"Not an absolute URL: {component!r}"
+        assert ":" in component, f"Not an absolute URL: {component!r}"
+        return True
+    return False
 
 
 @register.tag
@@ -28,4 +51,4 @@ def abstatic(parser, token):
 
     Derived from: https://github.com/django/django/blob/635d53a86a36cde7866b9caefeb64d809e6bfcd9/django/templatetags/static.py#L143-L159
     """
-    return AbsoluteStaticNode.handle_token(parser, token)
+    return AbsoluteURLStaticNode.handle_token(parser, token)

--- a/CreeDictionary/tests/CreeDictionary_tests/test_url_extras.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_url_extras.py
@@ -11,17 +11,24 @@ def test_orth_template_tag():
     """
     asset = "CreeDictionary/favicon.ico"
 
+    django_builtin_static = render_builtin_django_static(asset)
+    assert not django_builtin_static.startswith("http")
+
+    abstatic_url = render_with_abstatic(asset)
+    assert abstatic_url.startswith("http")
+    assert abstatic_url.endswith(django_builtin_static)
+
+
+def render_with_abstatic(asset: str) -> str:
     request = HttpRequest()
     request.META.setdefault("HTTP_HOST", "example.com")
 
-    django_builtin_static = Template(
-        "{% load static %}" "{% static '" + asset + "' %}"
-    ).render(Context({}))
-    assert not django_builtin_static.startswith("http")
-
     context = RequestContext(request, {})
     template = Template("{% load url_extras %}" "{% abstatic '" + asset + "' %}")
-    rendered = template.render(context)
+    return template.render(context)
 
-    assert rendered.startswith("http")
-    assert rendered.endswith(django_builtin_static)
+
+def render_builtin_django_static(asset: str) -> str:
+    return Template("{% load static %}" "{% static '" + asset + "' %}").render(
+        Context({})
+    )

--- a/CreeDictionary/tests/CreeDictionary_tests/test_url_extras.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_url_extras.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+from django.http import HttpRequest
+from django.template import RequestContext, Context, Template
+
+
+def test_orth_template_tag():
+    """
+    Test that the {% abstatic %} tag returns a static path.
+    """
+    asset = "CreeDictionary/favicon.ico"
+
+    request = HttpRequest()
+    request.META.setdefault("HTTP_HOST", "example.com")
+
+    django_builtin_static = Template(
+        "{% load static %}" "{% static '" + asset + "' %}"
+    ).render(Context({}))
+    assert not django_builtin_static.startswith("http")
+
+    context = RequestContext(request, {})
+    template = Template("{% load url_extras %}" "{% abstatic '" + asset + "' %}")
+    rendered = template.render(context)
+
+    assert rendered.startswith("http")
+    assert rendered.endswith(django_builtin_static)

--- a/CreeDictionary/tests/CreeDictionary_tests/test_url_extras.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_url_extras.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest
 from django.template import RequestContext, Context, Template
 
 
-def test_orth_template_tag():
+def test_abstatic():
     """
     Test that the {% abstatic %} tag returns a static path.
     """
@@ -17,6 +17,21 @@ def test_orth_template_tag():
     abstatic_url = render_with_abstatic(asset)
     assert abstatic_url.startswith("http")
     assert abstatic_url.endswith(django_builtin_static)
+    assert abstatic_url != django_builtin_static
+
+
+def test_abstatic_static_url_set(settings):
+    """
+    When STATIC_URL is set to an absolute URI, {% abstatic %} should be identical to
+    Django's builtin {% static %}.
+    """
+    settings.STATIC_URL = "https://cdn.example.com"
+
+    asset = "CreeDictionary/favicon.ico"
+
+    django_builtin_static = render_builtin_django_static(asset)
+    abstatic_url = render_with_abstatic(asset)
+    assert abstatic_url == django_builtin_static
 
 
 def render_with_abstatic(asset: str) -> str:
@@ -29,6 +44,5 @@ def render_with_abstatic(asset: str) -> str:
 
 
 def render_builtin_django_static(asset: str) -> str:
-    return Template("{% load static %}" "{% static '" + asset + "' %}").render(
-        Context({})
-    )
+    template = Template("{% load static %}" "{% static '" + asset + "' %}")
+    return template.render(Context())

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -884,9 +884,15 @@ a.multiple-recordings__action-button {
    "copyright";
 }
 
-.footer a:link {
+.footer a:link,
+.footer a:visited {
   color: var(--footer-text-color);
 }
+
+.footer a:hover {
+  color: var(--footer-link-hover-color);
+}
+
 
 .footer__copyright {
   margin-top: 1rem;

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -32,6 +32,7 @@
   --embossed-highlight:     #e0e0e0;
   --footer-bg-color:        #832020;
   --footer-text-color:      #FFFFFF;
+  --footer-link-hover-color: #FFC0C0;
   --header-stripe-color:    var(--app-title-color); /* Color of the "stripe" to the left of the title. */
   --link-action-color:      #A568DB; /* A link that implies an immediate action. */
   --link-active-color:      #0E6790; /* Currently active link. */


### PR DESCRIPTION
> _Part 87 in the ongoing saga:_ Eddie is Disappointed in Django's Templating System

So, a few things:
 - I extracted the metatag in its own `{% include %}` component
 - the image URLs need to be **absolute** URIs, so, with _great effort_ I made them as such
 - and a sneaky update to the footer font colours; let me know if I should cherry-pick that into a different PR