### PR TITLE
change: use recommended Google Fonts inclusion line

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -28,7 +28,8 @@
   <link rel="alternate icon" type="image/svg+xml" href="{% static 'CreeDictionary/images/itwewina.svg' %}">
   <link rel="mask-icon" href="{% static 'CreeDictionary/images/itwewina-safari-pinned-tab.svg' %}" color="#FAEBD7">
   <link rel="apple-touch-icon" href="{% static 'CreeDictionary/images/itwewina-192.png' %}">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{% static 'CreeDictionary/css/styles.css' %}">
   {# magic that allows us to reverse urls in js  https://github.com/ierror/django-js-reverse #}
   <script src="{% url 'js_reverse' %}"></script>


### PR DESCRIPTION
It's what's recommended to you when you select the fonts on [Google Fonts](https://fonts.google.com/specimen/Open+Sans?query=open+&preview.text_type=custom&sidebar.open=true&selection.family=Open+Sans:ital,wght@0,400;0,700;1,400).

It includes:
 - `rel=preconnect` to <https://fonts.gstatic.com>, because that is where the fonts proper are downloaded; the API request is to a different origin.
 - `font-display: swap` so [rendering is not blocked while the page is downloading the fonts](https://css-tricks.com/font-display-masses/#most-of-the-time-youll-use-swap)