### PR TITLE
change: improve orthography selector accessibility

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/language-selector__orthography.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/language-selector__orthography.html
@@ -1,13 +1,19 @@
 <section class="menu__category">
   <ul class="menu__choices" data-cy="orthography-choices">
     <li class="menu-choice menu-choice--selected">
-      <button data-orth-switch value="Latn" class="menu-choice__label unbutton">SRO (êîôâ)</button>
+      <button data-orth-switch value="Latn" class="unbutton fill-width">
+        <span class="menu-choice__label"> SRO (êîôâ) </span>
+      </button>
     </li>
     <li class="menu-choice">
-      <button data-orth-switch value="Latn-x-macron" class="menu-choice__label unbutton">SRO (ēīōā)</button>
+      <button data-orth-switch value="Latn-x-macron" class="unbutton fill-width">
+        <span class="menu-choice__label"> SRO (ēīōā) </span>
+      </button>
     </li>
     <li class="menu-choice">
-      <button data-orth-switch value="Cans" class="menu-choice__label unbutton">Syllabics</button>
+      <button data-orth-switch value="Cans" class="unbutton fill-width">
+        <span class="menu-choice__label"> Syllabics </span>
+      </button>
     </li>
   </ul>
 </section>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1130,9 +1130,10 @@ a.multiple-recordings__action-button {
 /* See also: https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html */
 
 .menu {
-  min-width: 10rem;
+  min-width: 24ch;
   border: solid 1px rgba(209, 209, 209, 0.33);
 
+  font-size: 1.2em;
   text-align: left;
 
   background-color: var(--box-bg-color);
@@ -1162,7 +1163,7 @@ a.multiple-recordings__action-button {
 
 .menu-choice__label {
   display: block;
-  padding: 9px;
+  padding: 1rem;
 }
 
 .menu-choice:hover {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1182,6 +1182,7 @@ a.menu-choice__label:active {
 .menu-choice--selected {
   font-weight: var(--strong-font-weight);
 
+  color: var(--menu-selected-color);
   background-color: var(--menu-selected-bg-color);
 }
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1182,7 +1182,7 @@ a.menu-choice__label:active {
 .menu-choice--selected {
   font-weight: var(--strong-font-weight);
 
-  background-color: #DEE4F9;
+  background-color: var(--menu-selected-bg-color);
 }
 
 /*********************************** BOX ************************************/

--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -38,6 +38,14 @@
 }
 
 /**
+ * Fill the width of the container.
+ */
+.fill-width {
+  width: 100%;
+}
+
+
+/**
  * Don't use this class.
  *
  * Instead, find a better way to wrap content in whatever this class is
@@ -50,3 +58,4 @@
 
   overflow-x: scroll;
 }
+

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -39,9 +39,10 @@
   --link-hover-color:       #5E8DC3; /* Hover over a link. */
   --link-visited-color:     #A568DB; /* Visited link */
   --menu-caption-color:     #626262; /* Color of text for menu captions. */
-  --menu-selected-bg-color: #DEE4F9;
-  --menu-hover-bg-color:    #0072C8; /* A dark background to contrast highlighted menu items. */
-  --menu-hover-color:       var(--box-bg-color); /* An inverted colour scheme */
+  --menu-selected-color:    var(--box-bg-color);
+  --menu-selected-bg-color: #0072C8;
+  --menu-hover-bg-color:    #DEE4F9; /* A dark background to contrast highlighted menu items. */
+  --menu-hover-color:       inherit;
   --paradigm-border-color:  #828A95; /* Color of the paradigm border and button. */
   --paradigm-button-color-alt:  #5A6FCC; /* ... when hovered or active */
   --paradigm-button-color:  #283C95; /* Color of the paradigm "show more" button. */

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -39,6 +39,7 @@
   --link-hover-color:       #5E8DC3; /* Hover over a link. */
   --link-visited-color:     #A568DB; /* Visited link */
   --menu-caption-color:     #626262; /* Color of text for menu captions. */
+  --menu-selected-bg-color: #DEE4F9;
   --menu-hover-bg-color:    #0072C8; /* A dark background to contrast highlighted menu items. */
   --menu-hover-color:       var(--box-bg-color); /* An inverted colour scheme */
   --paradigm-border-color:  #828A95; /* Color of the paradigm border and button. */

--- a/src/orthography.js
+++ b/src/orthography.js
@@ -45,17 +45,21 @@ export function changeOrth(which) {
  * Switches orthography and updates the UI.
  */
 function handleClickSwitchOrthography(evt) {
-  let target = evt.target
+  let target = findClosestOrthographySwitch(evt.target)
   // Determine that this is a orthography changing button.
-  if (target.dataset.orthSwitch === undefined) {
+  if (!target) {
     return
   }
 
-  // target is a <button data-orth-swith value="ORTHOGRAPHY">
+  // target is a <button data-orth-swith="ORTHOGRAPHY">
   let orth = target.value
   changeOrth(orth)
   updateUI(target)
   updateCookies(orth)
+}
+
+function findClosestOrthographySwitch(el) {
+  return el.closest('[data-orth-switch]')
 }
 
 /**


### PR DESCRIPTION
It's bugged me for a while that the "SRO/syllabics" buttons (orthograpgy selectors) buttons were too small on mobile, so I made the touch target much larger.