### PR TITLE
build: multi-stage Docker build

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,1 +1,0 @@
-nodesource.gpg.key

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ ARG NODE_VERSION=v12.20.2
 # (note: default npm is too old for the apt install'd version of NodeJS??!?!?!)
 WORKDIR /tmp
 ADD https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz /tmp/node.tar.gz
-RUN tar xf node.tar.gz\
+RUN tar xf node.tar.gz \
  && mv node-${NODE_VERSION}-linux-x64 /opt/node
 ENV PATH="/opt/node/bin:${PATH}"
 
@@ -34,14 +34,11 @@ RUN groupadd --system --gid ${UID_GID} itwewina \
 # Install and build dependencies,
 # then remove build-time dependencies to keep the image slim!
 RUN set -ex \
- && BUILD_DEPS=" \
-    build-essential \
-    " \
  && apt-get update \
- && apt-get install -y --no-install-recommends $BUILD_DEPS \
+ && apt-get install -y --no-install-recommends build-essential \
  && pip install pipenv \
- && mkdir /data/ /app/ \
- && chown itwewina /data /app
+ && mkdir /app/ \
+ && chown itwewina /app
 
 USER itwewina
 
@@ -79,8 +76,9 @@ RUN chmod +x /bin/tini
 # Create a NON-ROOT USER that will run the application code:
 RUN groupadd --system --gid ${UID_GID} itwewina \
  && useradd --no-log-init --system --gid itwewina --uid ${UID_GID} itwewina --create-home
-COPY --from=builder --chown=itwewina /app /app
 
+# Copy over the built application from the builder:
+COPY --from=builder --chown=itwewina /app /app
 WORKDIR /app/CreeDictionary
 
 # Gunicorn will listen on this port:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,6 @@ RUN set -ex \
  && BUILD_DEPS=" \
     build-essential \
     tini \
-    moreutils `# for sponge` \
     " \
  && apt-get update \
  && apt-get install -y --no-install-recommends $BUILD_DEPS \
@@ -54,26 +53,15 @@ RUN set -ex \
 USER itwewina
 
 WORKDIR /app/
-
-# Setup Python deps
-ADD --chown=itwewina Pipfile .
-ADD --chown=itwewina Pipfile.lock .
-
-RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy
-
-ADD --chown=itwewina package.json .
-ADD --chown=itwewina package-lock.json .
-# cypress is a big, heavy package that takes a long time to install and
-# that we absolutely don’t need in production
-RUN grep -Ev '"@?cypress' package.json | sponge package.json
-
-RUN npm install
-
-# Copy the application files. Make sure .dockerignore is setup properly so it
-# doesn't copy unnecessary files
 ADD --chown=itwewina . /app/
 
-RUN NODE_ENV=production npm run build \
+# Install Python and NodeJS apps
+RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy\
+ && npm install --only=production
+
+# Build the application:
+ENV NODE_ENV=production
+RUN npm run build \
  && /app/.venv/bin/python CreeDictionary/manage.py collectstatic --noinput
 
 # Gunicorn will listen on this port:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,28 +1,27 @@
-############################### Builder image ################################
-FROM python:3.9-slim-buster AS builder
-
-LABEL maintainer="Eddie Antonio Santos <Eddie.Santos@nrc-cnrc.gc.ca>"
-
-# (2021-01-15): This Dockerfile was derived from Gūnáhà:
-#  - https://github.com/UAlbertaALTLab/gunaha/blob/master/Dockerfile
+# = CHANGELOG =
 #
-# Changes:
+# 2021-02-19:
 #
+#  - Use a multi-stage build to keep the application image small
+#
+# 2021-01-15:
+#
+#  - This Dockerfile was derived from Gūnáhà:
+#    https://github.com/UAlbertaALTLab/gunaha/blob/master/Dockerfile
 #  - use Gunicorn instead of uwsgi; I'm not sure why I chose uwsgi for Gūnáhà,
 #    but I've got itwêwina working with Gunicorn, so I'm gonna stick with that
 #
 
+################################ Build stage #################################
+FROM python:3.9-slim-buster AS builder
 
-# Directories:
-#
-# /app — the app code will live here
-#
+LABEL maintainer="Eddie Antonio Santos <Eddie.Santos@nrc-cnrc.gc.ca>"
 
 ARG UID_GID=60003
 ARG NODE_VERSION=v12.20.2
 
 # Install Node + npm
-# (note: default npm is too old for the apt-install'd version of NodeJS??!?!?!)
+# (note: default npm is too old for the apt install'd version of NodeJS??!?!?!)
 WORKDIR /tmp
 ADD https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz /tmp/node.tar.gz
 RUN tar xf node.tar.gz\
@@ -48,9 +47,9 @@ USER itwewina
 
 WORKDIR /app/
 
-# Install Python and NodeJS apps
+# Install Python and NodeJS dependencies
 ADD Pipfile Pipfile.lock package.json package-lock.json /app/
-RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy\
+RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy \
  && npm install --only=production
 
 # Add everything else now:
@@ -77,9 +76,9 @@ ARG TINI_VERSION=v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
 RUN chmod +x /bin/tini
 
+# Create a NON-ROOT USER that will run the application code:
 RUN groupadd --system --gid ${UID_GID} itwewina \
  && useradd --no-log-init --system --gid itwewina --uid ${UID_GID} itwewina --create-home
-
 COPY --from=builder --chown=itwewina /app /app
 
 WORKDIR /app/CreeDictionary
@@ -87,8 +86,7 @@ WORKDIR /app/CreeDictionary
 # Gunicorn will listen on this port:
 EXPOSE 8000
 
-# Among other things -- see
-# https://github.com/krallin/tini#tini---a-tiny-but-valid-init-for-containers
-# -- this makes typing Ctrl-C into docker-compose work
+# Among other things, tini makes typing Ctrl-C into docker-compose work
+# see: https://github.com/krallin/tini#tini---a-tiny-but-valid-init-for-containers
 ENTRYPOINT ["tini", "--"]
 CMD ["/app/.venv/bin/gunicorn", "--access-logfile", "-", "--bind", "0.0.0.0:8000", "CreeDictionary.wsgi:application"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,13 +23,19 @@ LABEL maintainer="Eddie Antonio Santos <Eddie.Santos@nrc-cnrc.gc.ca>"
 ARG UID_GID=60003
 ARG EXPOSE_PORT=8000
 
+ARG NODE_VERSION=v12.20.2
+
+# Install Node + npm
+# (note: default npm is too old for the apt-install'd version of NodeJS??!?!?!)
+WORKDIR /tmp
+ADD https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz /tmp/node.tar.gz
+RUN tar xf node.tar.gz\
+ && mv node-${NODE_VERSION}-linux-x64 /opt/node
+ENV PATH="/opt/node/bin:${PATH}"
+
 # Create the user/group for the application
 RUN groupadd --system --gid ${UID_GID} itwewina \
  && useradd --no-log-init --system --gid itwewina --uid ${UID_GID} itwewina --create-home
-
-# TODO: move package.json dependences from build and test
-#  - [ ] must document in development guide
-
 # Install and build dependencies,
 # then remove build-time dependencies to keep the image slim!
 RUN set -ex \
@@ -37,7 +43,6 @@ RUN set -ex \
     build-essential \
     tini \
     moreutils `# for sponge` \
-    gnupg `# for verifying nodesource certificate` \
     " \
  && apt-get update \
  && apt-get install -y --no-install-recommends $BUILD_DEPS \
@@ -45,20 +50,6 @@ RUN set -ex \
  && rm -rf /var/lib/apt/lists/* \
  && mkdir /data/ /app/ \
  && chown itwewina /data /app
-
-# Install Node + npm
-# (note: default npm is too old for the apt-install'd version of NodeJS??!?!?!)
-# Using instructions from: https://github.com/nodesource/distributions/blob/master/README.md#manual-installation
-WORKDIR /tmp
-COPY docker/nodesource.gpg.key .
-RUN set -ex \
-    && VERSION=node_12.x \
-    && DISTRO="buster" `# must be in sync with Dockerfile` \
-    && apt-key add nodesource.gpg.key \
-    && (echo "deb https://deb.nodesource.com/$VERSION $DISTRO main" | tee /etc/apt/sources.list.d/nodesource.list) \
-    && (echo "deb-src https://deb.nodesource.com/$VERSION $DISTRO main" | tee -a /etc/apt/sources.list.d/nodesource.list) \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends nodejs
 
 USER itwewina
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.9-slim-buster
+############################### Builder image ################################
+FROM python:3.9-slim-buster AS builder
 
 LABEL maintainer="Eddie Antonio Santos <Eddie.Santos@nrc-cnrc.gc.ca>"
 
@@ -17,12 +18,7 @@ LABEL maintainer="Eddie Antonio Santos <Eddie.Santos@nrc-cnrc.gc.ca>"
 # /app — the app code will live here
 #
 
-# Choose an ID that will be consistent across all machines in the network
-# To avoid overlap with user IDs, use an ID over
-# /etc/login.defs:/UID_MAX/, which defaults to 60,000
 ARG UID_GID=60003
-ARG EXPOSE_PORT=8000
-
 ARG NODE_VERSION=v12.20.2
 
 # Install Node + npm
@@ -41,41 +37,58 @@ RUN groupadd --system --gid ${UID_GID} itwewina \
 RUN set -ex \
  && BUILD_DEPS=" \
     build-essential \
-    tini \
     " \
  && apt-get update \
  && apt-get install -y --no-install-recommends $BUILD_DEPS \
  && pip install pipenv \
- && rm -rf /var/lib/apt/lists/* \
  && mkdir /data/ /app/ \
  && chown itwewina /data /app
 
 USER itwewina
 
 WORKDIR /app/
-ADD --chown=itwewina . /app/
 
 # Install Python and NodeJS apps
+ADD Pipfile Pipfile.lock package.json package-lock.json /app/
 RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy\
  && npm install --only=production
+
+# Add everything else now:
+ADD --chown=itwewina . /app/
 
 # Build the application:
 ENV NODE_ENV=production
 RUN npm run build \
  && /app/.venv/bin/python CreeDictionary/manage.py collectstatic --noinput
 
+
+############################# Application image ##############################
+
+FROM python:3.9-slim-buster
+LABEL maintainer="Eddie Antonio Santos <Eddie.Santos@nrc-cnrc.gc.ca>"
+
+# Choose an ID that will be consistent across all machines in the network
+# To avoid overlap with user IDs, use an ID over
+# /etc/login.defs:/UID_MAX/, which defaults to 60,000
+ARG UID_GID=60003
+ARG TINI_VERSION=v0.19.0
+
+# Install tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /bin/tini
+RUN chmod +x /bin/tini
+
+RUN groupadd --system --gid ${UID_GID} itwewina \
+ && useradd --no-log-init --system --gid itwewina --uid ${UID_GID} itwewina --create-home
+
+COPY --from=builder --chown=itwewina /app /app
+
+WORKDIR /app/CreeDictionary
+
 # Gunicorn will listen on this port:
-EXPOSE ${EXPOSE_PORT}
+EXPOSE 8000
 
 # Among other things -- see
 # https://github.com/krallin/tini#tini---a-tiny-but-valid-init-for-containers
 # -- this makes typing Ctrl-C into docker-compose work
 ENTRYPOINT ["tini", "--"]
-
-WORKDIR /app/CreeDictionary
-ENV EXPOSE_PORT=${EXPOSE_PORT}
-
-CMD /app/.venv/bin/gunicorn \
-    --access-logfile - \
-    --bind 0.0.0.0:${EXPOSE_PORT} \
-    CreeDictionary.wsgi:application
+CMD ["/app/.venv/bin/gunicorn", "--access-logfile", "-", "--bind", "0.0.0.0:8000", "CreeDictionary.wsgi:application"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,7 +2,10 @@
 #
 # ## Commands ##
 #
-#  make run [default]
+#  make dev [default]
+#  		builds and starts the Docker container using docker-compose for
+#  		development.
+#  make run
 #  		builds and starts the Docker container using docker-compose
 #  		creates any necessary files for building the image/running the
 #  		container
@@ -16,11 +19,11 @@
 SYSTEMD_SERVICE = docker-compose-itwewina
 
 .PHONY: dev
-dev: db.sqlite3 nodesource.gpg.key .env
+dev: db.sqlite3 .env
 	docker-compose --file docker-compose.dev.yml up --build --remove-orphans
 
 .PHONY: run
-run: db.sqlite3 nodesource.gpg.key .env
+run: db.sqlite3 .env
 	docker-compose up --build
 
 .PHONY: unit-file
@@ -53,9 +56,3 @@ db.sqlite3:
 .env:
 	-echo '#' Creating an empty .env file
 	touch $@
-
-# Key used to verify Nodesource packages on apt.
-#
-# Required during **image build**
-nodesource.gpg.key:
-	curl -sSL -O https://deb.nodesource.com/gpgkey/nodesource.gpg.key

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,6 +15,10 @@
 
 SYSTEMD_SERVICE = docker-compose-itwewina
 
+.PHONY: dev
+dev: db.sqlite3 nodesource.gpg.key .env
+	docker-compose --file docker-compose.dev.yml up --build --remove-orphans
+
 .PHONY: run
 run: db.sqlite3 nodesource.gpg.key .env
 	docker-compose up --build

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,8 +34,3 @@ And then enable the service:
 
     sudo systemctl daemon-reload
     sudo systemctl enable docker-compose-itwewina
-
-## Future work
-
-  - smaller Docker image without dev dependencies through multi-stage
-    builds

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    volumes:
+      - "./db.sqlite3:/app/CreeDictionary/db.sqlite3"
+      - "./.env:/app/.env"
+    ports:
+      - 8000:8000

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -5,7 +5,12 @@ services:
       context: ..
       dockerfile: docker/Dockerfile
     volumes:
-      - "./db.sqlite3:/app/CreeDictionary/db.sqlite3"
+      # Unlike the production docker-compose.yml,
+      # use the given test database (no need to set USE_TEST_DB=True!)
+      - "../CreeDictionary/test_db.sqlite3:/app/CreeDictionary/db.sqlite3"
       - "./.env:/app/.env"
     ports:
+      # Unlike the production docker-compose.yml,
+      # expose port 8000, just like manage.py runserver so that Cypress
+      # integration tests can be run transparently on the Docker version.
       - 8000:8000


### PR DESCRIPTION
I've rearranged the Dockerfile such that it's a multi-stage build now. The total size of the application image is about ~248 MiB. 

**EDIT**: whereas the builder image is **~657MB**! 🤯 

Also, the Cypress tests can run on the `docker-compose.dev.yml` arrangement!

This PR builds off of #662.