### PR TITLE
update deployment step of test-and-deploy workflow

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -158,6 +158,6 @@ jobs:
     steps:
     - name: send HTTP request to deploy.altlab.dev webhook
       run: >-
-        curl -X POST https://deploy.altlab.dev/korp-frontend-dev -d '{
-        "secret": "${{ secrets.DEPLOY_ALTLAB_DEV }}" }' -H 'Content-Type:
-        application/json'
+        curl -X POST https://deploy.altlab.dev/itwewina -d '{
+        "secret": "${{ secrets.DEPLOY_ALTLAB_DEV_ITWEWINA_KEY }}" }' -H 'Content-Type:
+          application/json'

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -158,6 +158,6 @@ jobs:
     steps:
     - name: send HTTP request to deploy.altlab.dev webhook
       run: >-
-        curl -X POST https://deploy.altlab.dev/itwewina -d '{
+        curl -X POST https://deploy.altlab.dev/itwewina --fail -d '{
         "secret": "${{ secrets.DEPLOY_ALTLAB_DEV_ITWEWINA_KEY }}" }' -H 'Content-Type:
           application/json'

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -102,8 +102,8 @@ jobs:
         npm run test:ci
 
   # This syncs up API/schema.py to our @altlab/types package
-  # If there is an update to the type output (index.ts), but the version number is untouched. This
-  # will fail. Because developer needs to choose which version to bump.
+  # If there is an update to the type output (index.ts), but the version number is untouched,
+  # this will fail because the developer needs to choose which version to bump.
   type-package-check:
     runs-on: ubuntu-20.04
 
@@ -146,7 +146,7 @@ jobs:
         package: ./types/package.json
         check-version: true # won't run if version is not bumped
 
-  deploy-to-sapir:
+  trigger-deployment:
     runs-on: ubuntu-20.04
 
     needs:
@@ -156,8 +156,8 @@ jobs:
     if: needs.should-deploy.outputs.should-run == 'true'
 
     steps:
-    - uses: actions/checkout@v2
-    - env:
-        SAPIR_REDEPLOY_KEY: ${{ secrets.SAPIR_REDEPLOY_KEY }}
-      run: |
-        curl --verbose --fail -dsecret=$SAPIR_REDEPLOY_KEY http://sapir.artsrn.ualberta.ca/redeploy/cree-dictionary
+    - name: send HTTP request to deploy.altlab.dev webhook
+      run: >-
+        curl -X POST https://deploy.altlab.dev/korp-frontend-dev -d '{
+        "secret": "${{ secrets.DEPLOY_ALTLAB_DEV }}" }' -H 'Content-Type:
+        application/json'


### PR DESCRIPTION
closes #665

The `test-and-deploy` workflow now sends a POST request to the deployment webhook (https://deploy.altlab.dev/itwewina), which in turn triggers deployment of itwêwina.

The POST request is currently sent using `curl`. If the deployment server returns a 5xx status, the workflow will fail silently (using the `--fail` option). This could be improved by using a script rather than `curl`, so that the workflow fails on 4xx errors as well. (There's a new `--fail-with-body` option that would exit with an error code on 4xx errors, but our server isn't running a high enough version of `curl`.)