### PR TITLE
Add google site verification

### DIFF
--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -142,6 +142,8 @@ if DEBUG and ENABLE_DJANGO_DEBUG_TOOLBAR:
 
     INTERNAL_IPS = ["127.0.0.1"]
 
+# Used for verification with https://search.google.com/search-console
+GOOGLE_SITE_VERIFICATION = "91c4e691b449e7e3"
 
 ############################## More Core Django settings ###############################
 

--- a/CreeDictionary/CreeDictionary/urls.py
+++ b/CreeDictionary/CreeDictionary/urls.py
@@ -55,6 +55,14 @@ urlpatterns = [
     path("jsreverse", urls_js, name="js_reverse"),
 ]
 
+if hasattr(settings, "GOOGLE_SITE_VERIFICATION"):
+    urlpatterns.append(
+        path(
+            f"google{settings.GOOGLE_SITE_VERIFICATION}.html",
+            views.google_site_verification,
+        )
+    )
+
 if settings.DEBUG:
     # saves the need to `manage.py collectstatic` in development
     urlpatterns += staticfiles_urlpatterns()

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -1,6 +1,8 @@
 from http import HTTPStatus
 from typing import Any, Dict, Literal
 
+from django.conf import settings
+
 from API.models import Wordform
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
 from django.shortcuts import redirect, render
@@ -223,3 +225,11 @@ def create_context_for_index_template(mode: IndexPageMode, **kwargs) -> Dict[str
     context.setdefault("did_search", False)
 
     return context
+
+
+def google_site_verification(request):
+    code = settings.GOOGLE_SITE_VERIFICATION
+    return HttpResponse(
+        f"google-site-verification: google{code}.html",
+        content_type="text/html; charset=UTF-8",
+    )

--- a/docker/deploy
+++ b/docker/deploy
@@ -8,5 +8,5 @@ from subprocess import check_call
 
 os.chdir(Path(__file__).parent)
 
-check_call(['git', 'pull'])
-check_call(['docker-compose', 'up', '--build', '-d', '--remove-orphans'])
+check_call(["git", "pull"])
+check_call(["docker-compose", "up", "--build", "-d", "--remove-orphans"])


### PR DESCRIPTION
I believe that how this will work is:
  - The included code will let me see details of the production site in the search console.
  - I will then be able to share that access with others.
  - The code is not secret because it is often included in meta tags.

If/when we get DNS-based site verification, this can be removed.