### PR TITLE
Don’t check in test db.sqlite3

### DIFF
--- a/CreeDictionary/.gitignore
+++ b/CreeDictionary/.gitignore
@@ -1,0 +1,1 @@
+/test_db.sqlite3

--- a/CreeDictionary/conftest.py
+++ b/CreeDictionary/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+from django.conf import settings
+
+# See “`conftest.py`: sharing fixtures across multiple files”
+# https://docs.pytest.org/en/stable/fixture.html#conftest-py-sharing-fixtures-across-multiple-files
+
+
+@pytest.fixture(scope="module")
+def django_db_setup():
+    """
+    Normally pytest-django creates a new, empty in-memory database and runs
+    all your migrations for you.
+
+    You can override that behaviour by creating your own `django_db_setup`
+    fixture: https://pytest-django.readthedocs.io/en/latest/database.html#django-db-setup
+
+    We do so to reuse the same database file every time because:
+      - there’s currently no mutation functionality in the app for which
+        we need a clean database to test against
+      - with the ~1400 entries in the test DB, it takes ~30 seconds to
+        generate all the wordforms, which would be too long to wait every
+        time you wanted to run a single unit test.
+
+    If you want different behaviour for some tests, you can create your own
+    django_db_setup fixture in a test file or per-directory conftest.py.
+
+    And to get back the django default behaviour, simply do
+
+        from pytest_django.fixtures import django_db_setup
+        django_db_setup # reference so import doesn’t appear unused
+
+    in a test or conftest.
+    """
+
+    # If this environment variable is set, a conditional in settings.py
+    # should have pointed the database at CreeDictionary/test_db.sqlite3
+    assert settings.USE_TEST_DB

--- a/CreeDictionary/conftest.py
+++ b/CreeDictionary/conftest.py
@@ -5,6 +5,7 @@ from django.conf import settings
 # https://docs.pytest.org/en/stable/fixture.html#conftest-py-sharing-fixtures-across-multiple-files
 from django.core.management import call_command
 
+from API.apps import initialize_preverb_search
 from API.models import Wordform
 from utils import shared_res_dir
 
@@ -24,6 +25,9 @@ def django_db_setup(request, django_db_blocker):
       - with the ~1400 entries in the test DB, it takes ~30 seconds to
         generate all the wordforms, which would be too long to wait every
         time you wanted to run a single unit test.
+
+    Also see the docs at
+    https://pytest-django.readthedocs.io/en/latest/database.html#examples
 
     If you want different behaviour for some tests, you can create your own
     django_db_setup fixture in a test file or per-directory conftest.py.
@@ -58,3 +62,4 @@ def django_db_setup(request, django_db_blocker):
                     "import",
                     shared_res_dir / "test_dictionaries" / "crkeng.xml",
                 )
+                initialize_preverb_search()

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -2,29 +2,13 @@ import json
 from typing import List
 
 import pytest
+from hypothesis import assume, given
+
 from API.models import Wordform
 from API.search import fetch_cree_and_english_results, to_internal_form
-from hypothesis import assume, given
 from paradigm import EmptyRowType, InflectionCell, Layout, TitleRow
 from tests.conftest import lemmas
 from utils.enums import Language
-
-from CreeDictionary import settings
-
-
-@pytest.fixture(scope="module")
-def django_db_setup():
-    """
-    This works with pytest-django plugin.
-    This fixture tells all functions marked with pytest.mark.django_db in this file
-    to use the database specified in settings.py
-    which is the existing test_db.sqlite3 if USE_TEST_DB=True is passed.
-
-    Instead of by default, an empty database in memory.
-    """
-
-    # all functions in this file should use the existing test_db.sqlite3
-    assert settings.USE_TEST_DB
 
 
 @pytest.mark.django_db

--- a/CreeDictionary/tests/API_tests/test_views.py
+++ b/CreeDictionary/tests/API_tests/test_views.py
@@ -1,24 +1,8 @@
 import pytest
-from django.conf import settings
 from django.urls import reverse
 
 ASCII_WAPAMEW = "wapamew"
 EXPECTED_SUFFIX_SEARCH_RESULT = "asawâpamêw"
-
-
-@pytest.fixture(scope="module")
-def django_db_setup():
-    """
-    This works with pytest-django plugin.
-    This fixture tells all functions marked with pytest.mark.django_db in this file
-    to use the database specified in settings.py
-    which is the existing test_db.sqlite3 if USE_TEST_DB=True is passed.
-
-    Instead of by default, an empty database in memory.
-    """
-
-    # all functions in this file should use the existing test_db.sqlite3
-    assert settings.USE_TEST_DB
 
 
 @pytest.mark.django_db

--- a/CreeDictionary/tests/CreeDictionary_tests/test_admin.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_admin.py
@@ -1,23 +1,7 @@
 import pytest
-from django.conf import settings
 from django.urls import reverse
 
 from API.models import Wordform
-
-
-@pytest.fixture(scope="module")
-def django_db_setup():
-    """
-    This works with pytest-django plugin.
-    This fixture tells all functions marked with pytest.mark.django_db in this file
-    to use the database specified in settings.py
-    which is the existing test_db.sqlite3 if USE_TEST_DB=True is passed.
-
-    Instead of by default, an empty database in memory.
-    """
-
-    # all functions in this file should use the existing test_db.sqlite3
-    assert settings.USE_TEST_DB
 
 
 @pytest.mark.django_db

--- a/CreeDictionary/tests/CreeDictionary_tests/test_views.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_views.py
@@ -2,7 +2,6 @@ import logging
 from typing import Dict, Optional
 
 import pytest
-from django.conf import settings
 from django.http import (
     HttpResponseBadRequest,
     HttpResponseNotAllowed,
@@ -10,21 +9,6 @@ from django.http import (
 )
 from django.test import Client
 from django.urls import reverse
-
-
-@pytest.fixture(scope="module")
-def django_db_setup():
-    """
-    This works with pytest-django plugin.
-    This fixture tells all functions marked with pytest.mark.django_db in this file
-    to use the database specified in settings.py
-    which is the existing test_db.sqlite3 if USE_TEST_DB=True is passed.
-
-    Instead of by default, an empty database in memory.
-    """
-
-    # all functions in this file should use the existing test_db.sqlite3
-    assert settings.USE_TEST_DB
 
 
 class TestLemmaDetailsInternal4xx:

--- a/CreeDictionary/tests/DatabaseManager_tests/conftest.py
+++ b/CreeDictionary/tests/DatabaseManager_tests/conftest.py
@@ -6,6 +6,8 @@ from django.db import connection
 from django.test.utils import setup_databases, teardown_databases
 from pytest_django.lazy_django import get_django_version
 
+from DatabaseManager.xml_importer import import_xmls
+
 
 @contextmanager
 def no_migration():
@@ -97,3 +99,12 @@ def django_db_setup(request, django_test_environment, django_db_blocker):
                 )
 
     request.addfinalizer(teardown_database)
+
+
+def migrate_and_import(dictionary_dir):
+    """
+    assuming a fresh in memory database
+    Do the initial migration and import the xml
+    """
+    call_command("migrate", "API", "0001")
+    import_xmls(dictionary_dir)

--- a/CreeDictionary/tests/DatabaseManager_tests/test_xml_importer_regressions.py
+++ b/CreeDictionary/tests/DatabaseManager_tests/test_xml_importer_regressions.py
@@ -1,6 +1,6 @@
 import pytest
 from API.models import EnglishKeyword, Wordform
-from tests.conftest import migrate_and_import
+from tests.DatabaseManager_tests.conftest import migrate_and_import
 
 
 @pytest.mark.django_db

--- a/CreeDictionary/tests/DatabaseManager_tests/xml_importer_test.py
+++ b/CreeDictionary/tests/DatabaseManager_tests/xml_importer_test.py
@@ -2,7 +2,7 @@ import pytest
 from API.models import Wordform
 from DatabaseManager.cree_inflection_generator import expand_inflections
 from DatabaseManager.xml_importer import find_latest_xml_file
-from tests.conftest import migrate_and_import
+from tests.DatabaseManager_tests.conftest import migrate_and_import
 from utils import PartOfSpeech, shared_res_dir
 
 

--- a/CreeDictionary/tests/conftest.py
+++ b/CreeDictionary/tests/conftest.py
@@ -4,9 +4,7 @@ from pathlib import Path
 
 import pytest
 from API.models import Wordform
-from DatabaseManager.xml_importer import import_xmls
-from django.core.management import call_command
-from hypothesis import assume, settings
+from hypothesis import settings
 from hypothesis.strategies import SearchStrategy
 
 settings.register_profile("default", deadline=timedelta(milliseconds=5000))
@@ -53,12 +51,3 @@ def lemmas():
     Strategy to return lemmas from the database.
     """
     return WordformStrategy(is_lemma=True, as_is=False)
-
-
-def migrate_and_import(dictionary_dir):
-    """
-    assuming a fresh in memory database
-    Do the initial migration and import the xml
-    """
-    call_command("migrate", "API", "0001")
-    import_xmls(dictionary_dir)

--- a/Pipfile
+++ b/Pipfile
@@ -55,13 +55,8 @@ format = "black CreeDictionary"
 # so that we can move to a more continuous workflow where manual database modification can be persisted
 # example usage: pipenv run import-xml CreeDictionary/res/dictionaries/ --multi-process 2
 import-xml = "sh ./libexec/import.sh"
-# do this after you change the list of words in res/test_db_words.txt to rebuild test_db.sqlite3
-# Supply `-m|--multi-processing N` to speed up
-# Extra arguments will be passed to subcommand `build-test-db` of `manage-db`, use `manage-db build-test-db -h` to see
-# detailed help
-# It takes about half a minute with -m 2
-# example usage: `pipenv run build-test-db -m 2`
-build-test-db = "sh ./libexec/build_test_db.sh"
+# building the test db takes about half a minute
+build-test-db = "./libexec/build_test_db.sh"
 # warning: do not use these.
 # eventually we will scrap them and use a migration based work flow to preserve database changes AFTER a new
 # , well structured database is ready.

--- a/libexec/build_test_db.sh
+++ b/libexec/build_test_db.sh
@@ -1,19 +1,17 @@
-# should be called from pipfile
+#!/bin/bash
 
-# -i makes it interactive, ask user to comfirm before he deletes the database
-# "$@" passes extra arguments to subcommand build-test-db
-
-DB_FILE=CreeDictionary/test_db.sqlite3
-if [ -f "$DB_FILE" ]; then
-  rm -i $DB_FILE
+if [ -z "${PIPENV_ACTIVE}" ]; then
+    echo "Error: This script must be run in a pipenv." 1>&2
+    exit 1
 fi
 
-set -e
+set -eu
 
-echo "Creating test_db.sqlite3 from scratch..."
+export USE_TEST_DB=True
 
-"$(dirname "$0")"/remake-api-migrations.sh
+DIR="$(dirname -- "${0}")"
 
-pipenv run python CreeDictionary/manage.py migrate
+"${DIR}/../CreeDictionary/manage.py" migrate
+"${DIR}/../CreeDictionary/manage.py" xmlimport import \
+    "${DIR}/../CreeDictionary/res/test_dictionaries/crkeng.xml"
 
-manage-db build-test-db "$@"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "pipenv run dev & $(npm bin)/wait-on tcp:127.0.0.1:8000 && $(npm bin)/cypress run",
     "stop-only": "stop-only --folder cypress/integration",
     "cypress": "npx wait-on tcp:127.0.0.1:8000 && npx cypress run",
-    "test:ci": "pipenv run runserver_for_tests & trap 'kill %1' 0 1 2 3 15; $(npm bin)/wait-on tcp:127.0.0.1:8000 && $(npm bin)/cypress run $CYPRESS_OPTS"
+    "test:ci": "pipenv run build-test-db && (pipenv run runserver_for_tests & trap 'kill %1' 0 1 2 3 15; $(npm bin)/wait-on -t 30000 tcp:127.0.0.1:8000 && $(npm bin)/cypress run $CYPRESS_OPTS)"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Instead, just before the first DB-using test runs, if the database has no wordforms, build the test DB from XML.

This takes about 30s which will add to CI run time, but at least then we’ll know that building the test DB works.