### PR TITLE
Fix yaml problem

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -157,7 +157,26 @@ jobs:
 
     steps:
     - name: send HTTP request to deploy.altlab.dev webhook
+      # Be careful with spacing here.
+      #
+      # What https://yaml-multiline.info *doesn’t* warn you about: although
+      # `>-` means “replace newlines with spaces,” if you have an extra
+      # space on the next line, the newline gets preserved!
+      #
+      # So although
+      #
+      #     foo: >-
+      #       a
+      #        a
+      #
+      # means `{ "foo": "a a" }`,
+      #
+      #     foo: >-
+      #       a
+      #        a
+      #
+      # turns into `{ "foo": "a\n a" }` !
       run: >-
-        curl -X POST https://deploy.altlab.dev/itwewina --fail -d '{
-        "secret": "${{ secrets.DEPLOY_ALTLAB_DEV_ITWEWINA_KEY }}" }' -H 'Content-Type:
-          application/json'
+        curl -X POST https://deploy.altlab.dev/itwewina --fail
+        -d '{ "secret": "${{ secrets.DEPLOY_ALTLAB_DEV_ITWEWINA_KEY }}" }'
+        -H 'Content-Type: application/json'


### PR DESCRIPTION
If you look really carefully at the logs in https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/runs/1964903183?check_suite_focus=true

    1 Run curl -X POST https://deploy.altlab.dev/itwewina --fail -d '{ "secret": "***" }' -H 'Content-Type:
    2 curl -X POST https://deploy.altlab.dev/itwewina --fail -d '{ "secret": "***" }' -H 'Content-Type:
    3 application/json'
    4 shell: /usr/bin/bash -e {0}

the curl command was failing because there’s a newline in the Content-Type
header, which comes from two extra spaces in the yaml block.