### PR TITLE
change(css): adjust link colours

### DIFF
--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -36,9 +36,10 @@
   --header-stripe-color:    var(--app-title-color); /* Color of the "stripe" to the left of the title. */
   --link-action-color:      #A568DB; /* A link that implies an immediate action. */
   --link-active-color:      #0E6790; /* Currently active link. */
-  --link-color:             #0F76B5; /* Regular links */
+  /* Triad based on #95211E */
+  --link-color:             #1685DE; /* Regular links */
   --link-hover-color:       #5E8DC3; /* Hover over a link. */
-  --link-visited-color:     #A568DB; /* Visited link */
+  --link-visited-color:     #941686; /* Visited link */
   --menu-caption-color:     #626262; /* Color of text for menu captions. */
   --menu-selected-color:    var(--box-bg-color);
   --menu-selected-bg-color: #0072C8;


### PR DESCRIPTION
@andrewdotn and played with the colours, using [Adobe Color](https://color.adobe.com/en/create/color-wheel) to pick less arbitrary shades, based on the header color.

This is what it looks like:

![Screen Shot 2021-02-25 at 10 00 59 AM](https://user-images.githubusercontent.com/2294397/109188849-9670dc80-7750-11eb-921d-054b03dc23f3.png)
