### PR TITLE
change: better names for docker compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+    image: itwewina
+    container_name: itwewina
     volumes:
       - "./db.sqlite3:/app/CreeDictionary/db.sqlite3"
       - "./.env:/app/.env"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,11 +1,9 @@
 version: "3"
 services:
-  app:
+  itwewina:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-    image: itwewina
-    container_name: itwewina
     volumes:
       - "./db.sqlite3:/app/CreeDictionary/db.sqlite3"
       - "./.env:/app/.env"


### PR DESCRIPTION
So our Docker image  for itwewina showed up in logs as "docker_app" and the container as "docker_app_1". This is bad! So I specified some explicit names.

Docs:
 - https://docs.docker.com/compose/compose-file/compose-file-v3/#build:~:text=If%20you%20specify%20image%20as%20well,and%20optional%20tag%20specified%20in%20image%3A
 - https://docs.docker.com/compose/compose-file/compose-file-v3/#container_name
