### PR TITLE
MERGE THIS PULL REQUEST TO USE speech-db.altlab.app AS THE RECORDINGS SOURCE

### DIFF
--- a/src/recordings.js
+++ b/src/recordings.js
@@ -4,7 +4,7 @@ import SimpleTemplate from './simple-template.js'
 
 // the specific URL for a given wordform (refactored from previous commits).
 // TODO: should come from config.
-const BASE_URL = 'https://sapir.artsrn.ualberta.ca/validation'
+const BASE_URL = 'https://speech-db.altlab.app'
 
 export function fetchRecordings(wordform) {
   return fetch(`${BASE_URL}/recording/_search/${wordform}`)
@@ -26,7 +26,7 @@ export function retrieveListOfSpeakers() {
   // get the value of the wordform from the page
   let wordform = document.getElementById('data:head').value
   let derivedURL = `${BASE_URL}/recording/_search/${wordform}`
-  
+
   // select for our elements for playback and link-generation
   let recordingsDropdown = document.querySelector('.multiple-recordings select')
   let recordingsPlayback = document.querySelector('[data-action="play-current-recording"]')
@@ -49,14 +49,14 @@ export function retrieveListOfSpeakers() {
 
   // the function that displays an individual speaker's name
   function displaySpeakerList(recordings) {
-    for (let recordingData of recordings) {          
+    for (let recordingData of recordings) {
       // using a template, place the speaker's name and dialect into the dropdown
       let individualSpeaker = SimpleTemplate.fromId('template:speakerList')
       individualSpeaker.slot.speakerName = recordingData.speaker_name
       individualSpeaker.slot.speakerDialect = recordingData.dialect
       recordingsDropdown.appendChild(individualSpeaker.element)
     }
-      
+
     // audio playback for the specific speaker
     recordingsPlayback.addEventListener('click', () => {
       let speakerPosition = recordingsDropdown.selectedIndex
@@ -71,7 +71,7 @@ export function retrieveListOfSpeakers() {
     recordingsLink.addEventListener('click', () => {
       let speakerPosition = recordingsDropdown.selectedIndex
       let speakerBioLink = recordings[speakerPosition].speaker_bio_url
-          
+
       // change the URL of the selected speaker
       recordingsLink.href = speakerBioLink
     })


### PR DESCRIPTION
This _still_ uses the legacy, deprecate API ([for which there is no replacement](https://github.com/UAlbertaALTLab/recording-validation-interface/issues/103) 🤣 ) but there are more recordings on this version.

See: https://speech-db.altlab.app/