### PR TITLE
Only show auto definitions to admins

### DIFF
--- a/CreeDictionary/API/helpers.py
+++ b/CreeDictionary/API/helpers.py
@@ -1,0 +1,7 @@
+def serialize_definitions(definitions, include_auto_definitions: bool):
+    ret = []
+    for definition in definitions:
+        serialized = definition.serialize()
+        if include_auto_definitions or "auto" not in serialized["source_ids"]:
+            ret.append(serialized)
+    return ret

--- a/CreeDictionary/API/views.py
+++ b/CreeDictionary/API/views.py
@@ -18,8 +18,8 @@ def click_in_text(request) -> HttpResponse:
         return HttpResponseBadRequest("query param q is an empty string")
 
     results: List[SerializedSearchResult] = []
-    for result in Wordform.simple_search(q):
-        results.append(result.serialize())
+    for result in Wordform.simple_search(q, include_auto_definitions=False):
+        results.append(result.serialize(include_auto_definitions=False))
 
     response = {"results": results}
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
@@ -22,7 +22,7 @@
       <h1 id="head" class="definition-title">
         <dfn class="definition__matched-head">
           <data id="data:head" value="{{ lemma.text }}">
-            {% orth lemma.text %}
+            {% orth wordform.text %}
           </data>
         </dfn>
       </h1>
@@ -32,6 +32,7 @@
 
     <section class="multiple-recordings definition__recordings--not-loaded" id="recordings-dropdown" data-cy="multiple-recordings">
       <p class="multiple-recordings__help-text explainer">Choose a name from the dropdown to hear the word said by the speaker.</p>
+
       <select name="recordings-dropdown" data-cy="recordings-dropdown" class="multiple-recordings__dropdown">
         <template id="template:speakerList">
           <option><slot name="speakerName"></slot>, <slot name="speakerDialect"></slot></option>
@@ -49,7 +50,7 @@
 
     <section class="definition__meanings">
       <ol class="meanings">
-        {% for def in lemma.definitions.all %}
+        {% for def in wordform.definitions %}
           <li class="meanings__meaning">{{ def.text }}
             {% for source in def.source_ids %}
               <cite class="cite-dict">{{ source }}</cite>

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -87,7 +87,10 @@ def index(request):  # pragma: no cover
             search_result.serialize(
                 include_auto_definitions=should_include_auto_definitions(request)
             )
-            for search_result in Wordform.search_with_affixes(user_query)
+            for search_result in Wordform.search_with_affixes(
+                user_query,
+                include_auto_definitions=should_include_auto_definitions(request),
+            )
         ]
         did_search = True
     else:

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -58,7 +58,9 @@ def lemma_details(request, lemma_text: str = None):  # pragma: no cover
             # TODO: remove this parameter in favour of...
             lemma=lemma,
             # ...this parameter
-            wordform=lemma.serialize(),
+            wordform=lemma.serialize(
+                include_auto_definitions=should_include_auto_definitions(request)
+            ),
             paradigm_size=paradigm_size,
             paradigm_tables=lemma.get_paradigm_layouts(size=paradigm_size)
             if lemma
@@ -82,7 +84,9 @@ def index(request):  # pragma: no cover
 
     if user_query:
         search_results = [
-            search_result.serialize()
+            search_result.serialize(
+                include_auto_definitions=should_include_auto_definitions(request)
+            )
             for search_result in Wordform.search_with_affixes(user_query)
         ]
         did_search = True
@@ -110,13 +114,20 @@ def search_results(request, query_string: str):  # pragma: no cover
     """
     returns rendered boxes of search results according to user query
     """
-    results = Wordform.search_with_affixes(query_string)
+    results = Wordform.search_with_affixes(
+        query_string, include_auto_definitions=should_include_auto_definitions(request)
+    )
     return render(
         request,
         "CreeDictionary/search-results.html",
         {
             "query_string": query_string,
-            "search_results": [r.serialize() for r in results],
+            "search_results": [
+                r.serialize(
+                    include_auto_definitions=should_include_auto_definitions(request)
+                )
+                for r in results
+            ],
         },
     )
 
@@ -233,3 +244,11 @@ def google_site_verification(request):
         f"google-site-verification: google{code}.html",
         content_type="text/html; charset=UTF-8",
     )
+
+
+## Helper functions
+
+
+def should_include_auto_definitions(request):
+    # For now, show auto-translations if and only if the user is logged in
+    return request.user.is_authenticated

--- a/CreeDictionary/phrase_translate/management/commands/translatewordforms.py
+++ b/CreeDictionary/phrase_translate/management/commands/translatewordforms.py
@@ -99,7 +99,8 @@ class Command(BaseCommand):
 
         wordform_count = Wordform.objects.count()
         for w in tqdm(
-            Wordform.objects.select_related("lemma").iterator(), total=wordform_count
+            Wordform.objects.filter(is_lemma=False).select_related("lemma").iterator(),
+            total=wordform_count,
         ):
             for definition in definitions.get(w.lemma_id, []):
                 if not w.analysis:

--- a/CreeDictionary/phrase_translate/translate.py
+++ b/CreeDictionary/phrase_translate/translate.py
@@ -132,6 +132,10 @@ def main():
             print(f"  lemma: {lemma.analysis}")
 
             for d in wordform.lemma.definitions.all():
+                # Don’t try to re-translate already-translated items
+                if [ds.abbrv for ds in d.citations.all()] == ["auto"]:
+                    continue
+
                 print(f"    definition: {d} →")
                 phrase = inflect_english_phrase(wordform_tags, d.text)
                 if phrase is None:

--- a/CreeDictionary/res/fst/transcriptor-cw-eng-noun-entry2inflected-phrase-w-flags.fomabin
+++ b/CreeDictionary/res/fst/transcriptor-cw-eng-noun-entry2inflected-phrase-w-flags.fomabin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c5a28b2ebbbca88b73ef9ef98d7399f46baf17f7e168cc81e74c5011566da971
-size 1095998
+oid sha256:89fb294bf0edf60ccc660f04a2c8ce5c90a7261ad5948ee4c11343d0e2a28ab4
+size 1096001

--- a/CreeDictionary/res/fst/transcriptor-cw-eng-verb-entry2inflected-phrase-w-flags.fomabin
+++ b/CreeDictionary/res/fst/transcriptor-cw-eng-verb-entry2inflected-phrase-w-flags.fomabin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35cc3817f5a4bdb8302d8f41b75292da3e32470a04c70087f89926373a0d62b1
-size 2844170
+oid sha256:7b8b2de91e52db7e8faf54e1eb21e9a3fe7903bceb0a216a590b05d86ead26a5
+size 3006141

--- a/CreeDictionary/search_quality/run_sample.py
+++ b/CreeDictionary/search_quality/run_sample.py
@@ -21,7 +21,10 @@ def gen_run_sample(sample_file: PathLike = DEFAULT_SAMPLE_FILE, *, out_file: Pat
         # multiple times in randomized orders to spread out the effects of
         # warmup and caching
         start_time = time.time()
-        results = [r.serialize() for r in Wordform.search_with_affixes(query)]
+        results = [
+            r.serialize(include_auto_definitions=False)
+            for r in Wordform.search_with_affixes(query)
+        ]
         time_taken = time.time() - start_time
 
         combined_results[query] = {

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -64,7 +64,7 @@ def test_search_for_exact_lemma(lemma: Wordform):
     assume(lemma.text == lemma_from_analysis)
 
     query = lemma.text
-    search_results = Wordform.search_with_affixes(query)
+    search_results = Wordform.search_with_affixes(query, include_auto_definitions=False)
 
     exact_matches = {
         result
@@ -221,7 +221,7 @@ def test_search_serialization_json_parsable(query):
     results = Wordform.search_with_affixes(query)
     for result in results:
 
-        serialized = result.serialize()
+        serialized = result.serialize(include_auto_definitions=False)
         try:
             json.dumps(serialized)
         except Exception as e:


### PR DESCRIPTION
This is a minimal set of changes so that auto-translated definitions are only shown to logged-in users for now.

While I can think of many ways to improve this code, I may just be making unnecessary work for myself.