### PR TITLE
change: description in nêhiyawêwin

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/metatags.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/metatags.html
@@ -11,7 +11,7 @@
 
   {% load url_extras %}
 
-  {% with title_="itwêwina: the online Cree dictionary" desc_="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawi-masinahikan kâ-iyiniwâk" %}
+  {% with title_="itwêwina: the online Cree dictionary" desc_="A smart, online dictionary of Plains Cree (Y-Dialect) | nêhiyawêwasinahikan kâ-nipwâhkâmakahk" %}
   {% abstatic 'CreeDictionary/images/itwewina-social.png' as image_url %}
 
   {# Primary Meta Tags #}


### PR DESCRIPTION
> _The Cree language book that is clever_

Problem: neither wordform has a definition in itwêwina! I think this is a problem!

Close analyses:

 * [nêhiyawasinahikan](https://itwewina.altlab.app/word/n%C3%AAhiyawasinahikan/)
 * [kâ-nipwâhkât](https://itwewina.altlab.app/search?q=k%C3%A2-nipw%C3%A2hk%C3%A2t)