### PR TITLE
bandaid: load WSGI applications after uwsgi worker fork

### DIFF
--- a/CreeDictionary/uwsgi.ini
+++ b/CreeDictionary/uwsgi.ini
@@ -33,6 +33,14 @@ close-on-exec = true
 # With post-buffering off, the application MUST read EVERY POST body or else
 # the communication protocol could break :/
 post-buffering = true
+# 🩹 loads the wsgi application **AFTER** forking off workers.
+# The application can hang on startup and as of this writing (2021-03-17),
+# we don't know why.
+# (see: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/697)
+# If this hang happens BEFORE forking off the workers, then THE ENTIRE SITE
+# IS INACCESSIBLE!
+# See: https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html?highlight=lazy-apps#preforking-vs-lazy-apps-vs-lazy
+lazy-apps = true
 
 
 # Hooks


### PR DESCRIPTION
We'll probably want to babysit the deploy on this one.

**EDIT**: this is **NOT** a fix for #697, but it makes deploys less scary