### PR TITLE
Make morpheme rankings / preverb cache lazy

### DIFF
--- a/CreeDictionary/API/apps.py
+++ b/CreeDictionary/API/apps.py
@@ -32,15 +32,12 @@ class APIConfig(AppConfig):
             self.perform_time_consuming_initializations()
 
     def perform_time_consuming_initializations(self):
-        logger.debug("loading affix caches")
+        logger.debug("preloading caches")
         from API.search import affix
-        from API.models import WordformCache
+        from API.models import wordform_cache
 
         affix.cache.preload()
-
-        # Accessing these cached properties will preload them
-        WordformCache.PREVERB_ASCII_LOOKUP
-        WordformCache.MORPHEME_RANKINGS
+        wordform_cache.preload()
 
         logger.debug("done")
 

--- a/CreeDictionary/API/apps.py
+++ b/CreeDictionary/API/apps.py
@@ -3,11 +3,8 @@ import os
 from pathlib import Path
 
 from django.apps import AppConfig, apps
-from django.db import OperationalError
-from django.db.models import Q
 
 from utils import shared_res_dir
-from utils.cree_lev_dist import remove_cree_diacritics
 
 logger = logging.getLogger(__name__)
 
@@ -37,14 +34,13 @@ class APIConfig(AppConfig):
     def perform_time_consuming_initializations(self):
         logger.debug("loading affix caches")
         from API.search import affix
+        from API.models import WordformCache
 
         affix.cache.preload()
 
-        logger.debug("calling initialize_preverb_search()")
-        initialize_preverb_search()
-
-        logger.debug("calling read_morpheme_rankings()")
-        read_morpheme_rankings()
+        # Accessing these cached properties will preload them
+        WordformCache.PREVERB_ASCII_LOOKUP
+        WordformCache.MORPHEME_RANKINGS
 
         logger.debug("done")
 
@@ -56,53 +52,3 @@ class APIConfig(AppConfig):
         This way you can get access to the affix searchers in other modules!
         """
         return apps.get_app_config(cls.name)
-
-
-def initialize_preverb_search():
-    from .models import Wordform
-
-    # Hashing to speed up exhaustive preverb matching
-    # so that we won't need to search from the database every time the user searches for a preverb or when the user
-    # query contains a preverb
-    # An all inclusive filtering mechanism is inflectional_category=IPV OR pos="IPV". Don't rely on a single one
-    # due to the inconsistent labelling in the source crkeng.xml.
-    # e.g. for preverb "pe", the source gives pos=Ipc ic=IPV.
-    # For "sa", the source gives pos=IPV ic="" (unspecified)
-    # after https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/pull/262
-    # many preverbs are normalized so that both inflectional_category and pos are set to IPV.
-
-    def has_non_md_non_auto_definitions(wordform):
-        "This may look slow, but isn’t if prefetch_related has been used"
-        for d in wordform.definitions.all():
-            for c in d.citations.all():
-                if c.abbrv not in ["auto", "MD"]:
-                    return True
-        return False
-
-    try:
-        queryset = Wordform.objects.filter(
-            Q(inflectional_category="IPV") | Q(pos="IPV")
-        ).prefetch_related("definitions__citations")
-        for preverb_wordform in queryset:
-            if has_non_md_non_auto_definitions(preverb_wordform):
-                Wordform.PREVERB_ASCII_LOOKUP[
-                    remove_cree_diacritics(preverb_wordform.text.strip("-"))
-                ].add(preverb_wordform)
-    except OperationalError:
-        # the ready function gets called during `$ manage-db import` when one builds the database from scratch
-        # At that time, while the migrations are not applied, Wordform tables does not exist.
-        pass
-
-
-def read_morpheme_rankings():
-    from .models import Wordform
-
-    lines = (
-        Path(shared_res_dir / "W_aggr_corp_morph_log_freq.txt").read_text().splitlines()
-    )
-    for line in lines:
-        cells = line.split("\t")
-        # todo: use the third row
-        if len(cells) >= 2:
-            freq, morpheme, *_ = cells
-            Wordform.MORPHEME_RANKINGS[morpheme] = float(freq)

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -1,23 +1,30 @@
+from __future__ import annotations
+
 import logging
-import typing
 from collections import defaultdict
-from functools import lru_cache
-from typing import Dict, List, Optional, Set, Tuple
+from functools import lru_cache, cached_property
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 from urllib.parse import quote
 
 from django.db import models, transaction
-from django.db.models import Max
+from django.db.models import Max, Q
 from django.forms import model_to_dict
 from django.urls import reverse
-from django.utils.functional import cached_property
+
 from paradigm import Layout
 from shared import expensive
-from sortedcontainers import SortedSet
-from utils import ParadigmSize, PartOfSpeech, WordClass, fst_analysis_parser
+from utils import (
+    ParadigmSize,
+    PartOfSpeech,
+    WordClass,
+    fst_analysis_parser,
+    shared_res_dir,
+)
+from utils.cree_lev_dist import remove_cree_diacritics
 from utils.fst_analysis_parser import LABELS
 from utils.types import FSTTag
 from .helpers import serialize_definitions
-
 from .schema import SerializedDefinition, SerializedWordform
 
 # Don't start evicting cache entries until we've seen over this many unique definitions:
@@ -27,14 +34,8 @@ logger = logging.getLogger(__name__)
 
 
 class Wordform(models.Model):
-    # this is initialized upon app ready.
-    # this helps speed up preverb match
-    # will look like: {"pe": {...}, "e": {...}, "nitawi": {...}}
-    # pure MD content won't be included
-    PREVERB_ASCII_LOOKUP: Dict[str, Set["Wordform"]] = defaultdict(set)
 
-    # this is initialized upon app ready.
-    MORPHEME_RANKINGS: Dict[str, float] = {}
+    PREVERB_ASCII_LOOKUP = None
 
     def get_absolute_url(self) -> str:
         """
@@ -383,3 +384,59 @@ def get_all_source_ids_for_definition(definition_id: int) -> Tuple[str, ...]:
     """
     dfn = Definition.objects.get(pk=definition_id)
     return tuple(sorted(source.abbrv for source in dfn.citations.all()))
+
+
+class _WordformCache:
+    @cached_property
+    def PREVERB_ASCII_LOOKUP(self) -> dict[str, set[models.Wordform]]:
+        logger.debug("initializing preverb search")
+        # Hashing to speed up exhaustive preverb matching
+        # will look like: {"pe": {...}, "e": {...}, "nitawi": {...}}
+        # so that we won't need to search from the database every time the user searches for a preverb or when the user
+        # query contains a preverb
+        # An all inclusive filtering mechanism is inflectional_category=IPV OR pos="IPV". Don't rely on a single one
+        # due to the inconsistent labelling in the source crkeng.xml.
+        # e.g. for preverb "pe", the source gives pos=Ipc ic=IPV.
+        # For "sa", the source gives pos=IPV ic="" (unspecified)
+        # after https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/pull/262
+        # many preverbs are normalized so that both inflectional_category and pos are set to IPV.
+
+        def has_non_md_non_auto_definitions(wordform):
+            "This may look slow, but isn’t if prefetch_related has been used"
+            for d in wordform.definitions.all():
+                for c in d.citations.all():
+                    if c.abbrv not in ["auto", "MD"]:
+                        return True
+            return False
+
+        lookup = defaultdict(set)
+        queryset = Wordform.objects.filter(
+            Q(inflectional_category="IPV") | Q(pos="IPV")
+        ).prefetch_related("definitions__citations")
+        for preverb_wordform in queryset:
+            if has_non_md_non_auto_definitions(preverb_wordform):
+                lookup[remove_cree_diacritics(preverb_wordform.text.strip("-"))].add(
+                    preverb_wordform
+                )
+        return lookup
+
+    @cached_property
+    def MORPHEME_RANKINGS(self) -> Dict[str, float]:
+        logger.debug("reading morpheme rankings")
+        ret = {}
+
+        lines = (
+            Path(shared_res_dir / "W_aggr_corp_morph_log_freq.txt")
+            .read_text()
+            .splitlines()
+        )
+        for line in lines:
+            cells = line.split("\t")
+            # todo: use the third row
+            if len(cells) >= 2:
+                freq, morpheme, *_ = cells
+                ret[morpheme] = float(freq)
+        return ret
+
+
+WordformCache = _WordformCache()

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -438,5 +438,10 @@ class _WordformCache:
                 ret[morpheme] = float(freq)
         return ret
 
+    def preload(self):
+        # Accessing these cached properties will preload them
+        self.PREVERB_ASCII_LOOKUP
+        self.MORPHEME_RANKINGS
 
-WordformCache = _WordformCache()
+
+wordform_cache = _WordformCache()

--- a/CreeDictionary/API/search/core.py
+++ b/CreeDictionary/API/search/core.py
@@ -9,7 +9,7 @@ from API.models import (
     Wordform,
     Definition,
     get_all_source_ids_for_definition,
-    WordformCache,
+    wordform_cache,
 )
 from utils import Language, get_modified_distance
 from utils.cree_lev_dist import remove_cree_diacritics
@@ -242,7 +242,7 @@ def fetch_preverbs(user_query: str) -> Set[Wordform]:
         user_query = user_query[:-1]
     user_query = remove_cree_diacritics(user_query)
 
-    return WordformCache.PREVERB_ASCII_LOOKUP[user_query]
+    return wordform_cache.PREVERB_ASCII_LOOKUP[user_query]
 
 
 def filter_auto_definitions(

--- a/CreeDictionary/API/search/core.py
+++ b/CreeDictionary/API/search/core.py
@@ -5,7 +5,12 @@ from typing import Tuple, cast, Set, Iterable, List, Callable, Any, Optional
 from cree_sro_syllabics import syllabics2sro
 from sortedcontainers import SortedSet
 
-from API.models import Wordform, Definition, get_all_source_ids_for_definition
+from API.models import (
+    Wordform,
+    Definition,
+    get_all_source_ids_for_definition,
+    WordformCache,
+)
 from utils import Language, get_modified_distance
 from utils.cree_lev_dist import remove_cree_diacritics
 from utils.fst_analysis_parser import LABELS, partition_analysis
@@ -237,7 +242,7 @@ def fetch_preverbs(user_query: str) -> Set[Wordform]:
         user_query = user_query[:-1]
     user_query = remove_cree_diacritics(user_query)
 
-    return Wordform.PREVERB_ASCII_LOOKUP[user_query]
+    return WordformCache.PREVERB_ASCII_LOOKUP[user_query]
 
 
 def filter_auto_definitions(

--- a/CreeDictionary/API/search/ranking.py
+++ b/CreeDictionary/API/search/ranking.py
@@ -1,5 +1,6 @@
 from utils import Language, get_modified_distance
 from .types import SearchResult
+from ..models import WordformCache
 
 
 def sort_search_result(
@@ -42,11 +43,10 @@ def sort_search_result(
         # a from English, b from Cree
         return 1
     else:
-        from ..models import Wordform
 
         # both from English
-        a_in_rankings = res_a.matched_cree in Wordform.MORPHEME_RANKINGS
-        b_in_rankings = res_b.matched_cree in Wordform.MORPHEME_RANKINGS
+        a_in_rankings = res_a.matched_cree in WordformCache.MORPHEME_RANKINGS
+        b_in_rankings = res_b.matched_cree in WordformCache.MORPHEME_RANKINGS
 
         if a_in_rankings and not b_in_rankings:
             return -1
@@ -56,6 +56,6 @@ def sort_search_result(
             return 0
         else:  # both in rankings
             return (
-                Wordform.MORPHEME_RANKINGS[res_a.matched_cree]
-                - Wordform.MORPHEME_RANKINGS[res_b.matched_cree]
+                WordformCache.MORPHEME_RANKINGS[res_a.matched_cree]
+                - WordformCache.MORPHEME_RANKINGS[res_b.matched_cree]
             )

--- a/CreeDictionary/API/search/ranking.py
+++ b/CreeDictionary/API/search/ranking.py
@@ -1,6 +1,6 @@
 from utils import Language, get_modified_distance
 from .types import SearchResult
-from ..models import WordformCache
+from ..models import wordform_cache
 
 
 def sort_search_result(
@@ -45,8 +45,8 @@ def sort_search_result(
     else:
 
         # both from English
-        a_in_rankings = res_a.matched_cree in WordformCache.MORPHEME_RANKINGS
-        b_in_rankings = res_b.matched_cree in WordformCache.MORPHEME_RANKINGS
+        a_in_rankings = res_a.matched_cree in wordform_cache.MORPHEME_RANKINGS
+        b_in_rankings = res_b.matched_cree in wordform_cache.MORPHEME_RANKINGS
 
         if a_in_rankings and not b_in_rankings:
             return -1
@@ -56,6 +56,6 @@ def sort_search_result(
             return 0
         else:  # both in rankings
             return (
-                WordformCache.MORPHEME_RANKINGS[res_a.matched_cree]
-                - WordformCache.MORPHEME_RANKINGS[res_b.matched_cree]
+                wordform_cache.MORPHEME_RANKINGS[res_a.matched_cree]
+                - wordform_cache.MORPHEME_RANKINGS[res_b.matched_cree]
             )

--- a/CreeDictionary/CreeDictionary/management/commands/ensuretestdb.py
+++ b/CreeDictionary/CreeDictionary/management/commands/ensuretestdb.py
@@ -49,7 +49,7 @@ def ensure_cypress_admin_user():
     user_file_valid = False
     user_info_file = settings.BASE_PATH / ".cypress-user.json"
     if user_info_file.exists():
-        user_info = json.load(user_info_file.read_text())
+        user_info = json.loads(user_info_file.read_text())
         if cypress_user.check_password(user_info.get("password", "")):
             user_file_valid = True
 

--- a/CreeDictionary/conftest.py
+++ b/CreeDictionary/conftest.py
@@ -53,6 +53,3 @@ def django_db_setup(request, django_db_blocker):
         with django_db_blocker.unblock():
             print("\nSyncing test database")
             call_command("ensuretestdb", verbosity=0)
-
-            # Tests that rely on affix search will fail without this
-            APIConfig.active_instance().perform_time_consuming_initializations()

--- a/CreeDictionary/search_quality/management/commands/runsamplequeries.py
+++ b/CreeDictionary/search_quality/management/commands/runsamplequeries.py
@@ -2,7 +2,6 @@ from argparse import ArgumentParser
 
 from django.core.management import BaseCommand
 
-from API.apps import APIConfig
 from ... import DEFAULT_SAMPLE_FILE, RESULTS_DIR
 from ...run_sample import gen_run_sample
 
@@ -22,8 +21,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        APIConfig.active_instance().perform_time_consuming_initializations()
-
         for status in gen_run_sample(
             options["csv_file"], out_file=options["query_results_file"]
         ):


### PR DESCRIPTION
The spooky-action-at-a-distance where these are initially set to empty
values that calling code can use and make invalid decisions based upon,
unless you call the right thing at startup from tests, has been causing
issues for me for a while.