### PR TITLE
Make cypress tests work on full dictionary

### DIFF
--- a/CreeDictionary/CreeDictionary/management/commands/ensuretestdb.py
+++ b/CreeDictionary/CreeDictionary/management/commands/ensuretestdb.py
@@ -49,7 +49,7 @@ def ensure_cypress_admin_user():
     user_file_valid = False
     user_info_file = settings.BASE_PATH / ".cypress-user.json"
     if user_info_file.exists():
-        user_info = json.load(user_info_file.read_text())
+        user_info = json.loads(user_info_file.read_text())
         if cypress_user.check_password(user_info.get("password", "")):
             user_file_valid = True
 

--- a/CreeDictionary/res/test_dictionaries/crkeng.xml
+++ b/CreeDictionary/res/test_dictionaries/crkeng.xml
@@ -23698,7 +23698,7 @@
 			<l pos="V">nîpin</l>
 			
       
-			<lc>VII-n</lc>
+			<lc>VII-1n</lc>
 			
       
 			<stem>nîpin-</stem>
@@ -39343,7 +39343,7 @@
 			<l pos="V">wâpiw</l>
 			
       
-			<lc>VAI-v</lc>
+			<lc>VAI-1</lc>
 			
       
 			<stem>wâpi-</stem>

--- a/cypress/integration/word-details.spec.js
+++ b/cypress/integration/word-details.spec.js
@@ -4,9 +4,9 @@ context('Word details', () => {
     //
     const testCases = [
       {wc: 'VTA', ic: 'VTA-1', word: 'mowêw'},
-      {wc: 'VAI', ic: 'VAI-v', word: 'wâpiw'},
+      {wc: 'VAI', ic: 'VAI-1', word: 'wâpiw'},
       {wc: 'VTI', ic: 'VTI-3', word: 'mîciw'},
-      {wc: 'VII', ic: 'VII-n', word: 'nîpin'},
+      {wc: 'VII', ic: 'VII-1n', word: 'nîpin'},
       // TODO: pretty sure this should be NAD, but the labels say otherwise:
       {wc: 'NDA', ic: 'NDA-1', word: 'nôhkom'},
       // TODO: pretty sure this should be NID, but the labels say otherwise:


### PR DESCRIPTION
At some point the inflectional categories were renamed in the full
dictionary, and the test dictionary was not updated. That made these two
cypress tests fail when run against a database that has the full
dictionary. This is the minimal change to make those work again.