### PR TITLE
Refactor search, part 2

### DIFF
--- a/CreeDictionary/API/helpers.py
+++ b/CreeDictionary/API/helpers.py
@@ -1,7 +1,0 @@
-def serialize_definitions(definitions, include_auto_definitions: bool):
-    ret = []
-    for definition in definitions:
-        serialized = definition.serialize()
-        if include_auto_definitions or "auto" not in serialized["source_ids"]:
-            ret.append(serialized)
-    return ret

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from functools import lru_cache
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 from urllib.parse import quote
 
 from django.db import models, transaction
@@ -354,21 +353,6 @@ class EnglishKeyword(models.Model):
 
     class Meta:
         indexes = [models.Index(fields=["text"])]
-
-
-@lru_cache(maxsize=MAX_SOURCE_ID_CACHE_ENTRIES)
-def get_all_source_ids_for_definition(definition_id: int) -> Tuple[str, ...]:
-    """
-    Returns all of the dictionary source IDs (e.g., "MD", "CW").
-    This is cached so to reduce the amount of duplicate queries made to the database,
-    especially during serialization.
-
-    See:
-     - https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/pull/558
-     - https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/531
-    """
-    dfn = Definition.objects.get(pk=definition_id)
-    return tuple(sorted(source.abbrv for source in dfn.citations.all()))
 
 
 class _WordformCache:

--- a/CreeDictionary/API/schema.py
+++ b/CreeDictionary/API/schema.py
@@ -1,7 +1,7 @@
 """
 this file contains `TypedDict` classes that effectively serves as json schema for serialized objects
 """
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Optional, Sequence
 
 from typing_extensions import Literal, TypedDict
 
@@ -10,7 +10,7 @@ from utils.types import FSTTag
 
 class SerializedDefinition(TypedDict):
     text: str
-    source_ids: Tuple[str, ...]
+    source_ids: Sequence[str]
 
 
 class SerializedWordform(TypedDict):
@@ -46,7 +46,9 @@ class SerializedLinguisticTag(TypedDict):
 
 class SerializedSearchResult(TypedDict):
     # the text of the match
-    matched_cree: str
+    wordform_text: str
+    # legacy name, deprecated
+    matched_cree: Optional[str]
 
     is_lemma: bool
 
@@ -70,11 +72,5 @@ class SerializedSearchResult(TypedDict):
 
     # This omits preverbs and other features displayed elsewhere
     relevant_tags: Tuple[SerializedLinguisticTag, ...]
-
-    # TODO: there are things to be figured out for this :/
-    # Sequence of all reduplication tags present, in order
-    reduplication_tags: Tuple[str, ...]
-    # Sequence of all initial change tags
-    initial_change_tags: Tuple[str, ...]
 
     definitions: Tuple[SerializedDefinition, ...]

--- a/CreeDictionary/API/search/__init__.py
+++ b/CreeDictionary/API/search/__init__.py
@@ -1,15 +1,7 @@
-from sortedcontainers import SortedSet
-
-from .lookup import (
-    WordformSearchWithAffixes,
-    WordformSearchWithExactMatch,
-)
-from .types import SearchResult
+from .runner import search
 
 
-def search_with_affixes(
-    query: str, include_auto_definitions=False
-) -> SortedSet[SearchResult]:
+def search_with_affixes(query: str, include_auto_definitions=False):
     """
     Search for wordforms matching:
      - the wordform text
@@ -18,18 +10,20 @@ def search_with_affixes(
      - affixes of the definition keyword text
     """
 
-    search = WordformSearchWithAffixes(query)
-    return search.perform(include_auto_definitions=include_auto_definitions)
+    return search(
+        query=query, include_auto_definitions=include_auto_definitions
+    ).serialized_presentation_results()
 
 
-def simple_search(
-    query: str, include_auto_definitions=False
-) -> SortedSet[SearchResult]:
+def simple_search(query: str, include_auto_definitions=False):
     """
     Search, trying to match full wordforms or keywords within definitions.
 
     Does NOT try to match affixes!
     """
 
-    search = WordformSearchWithExactMatch(query)
-    return search.perform(include_auto_definitions=include_auto_definitions)
+    return search(
+        query=query,
+        include_affixes=False,
+        include_auto_definitions=include_auto_definitions,
+    ).serialized_presentation_results()

--- a/CreeDictionary/API/search/lookup.py
+++ b/CreeDictionary/API/search/lookup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Iterable, Set
 
@@ -9,110 +11,16 @@ from API.models import (
 )
 from CreeDictionary import hfstol
 from utils import get_modified_distance, fst_analysis_parser, PartOfSpeech
+from utils.cree_lev_dist import remove_cree_diacritics
 from utils.english_keyword_extraction import stem_keywords
 from utils.types import ConcatAnalysis
-from .affix import (
-    do_cree_affix_seach,
-    do_english_affix_search,
-    query_would_return_too_many_results,
-)
-from .core import _BaseWordformSearch, fetch_preverbs
-from .types import (
-    CreeAndEnglish,
-    InternalForm,
-    CreeResult,
-    EnglishResult,
-    Lemma,
-    MatchedEnglish,
-)
+from .types import Result
+from . import core
 
 logger = logging.getLogger(__name__)
 
 
-class WordformSearchWithExactMatch(_BaseWordformSearch):
-    """
-    Searches for exact matches in both the wordforms and EnglishKeyword tables.
-    """
-
-    def fetch_bilingual_results(self) -> CreeAndEnglish:
-        return fetch_cree_and_english_results(self.cleaned_query, affix_search=False)
-
-
-class WordformSearchWithAffixes(_BaseWordformSearch):
-    """
-    Same as WordformSearchWithExactMatch, but augments results with searches on affixes.
-    """
-
-    def fetch_bilingual_results(self) -> CreeAndEnglish:
-        return fetch_cree_and_english_results(self.cleaned_query, affix_search=True)
-
-
-def filter_cw_wordforms(q: Iterable[Wordform]) -> Iterable[Wordform]:
-    """
-    return the wordforms that has definition from CW dictionary
-
-    :param q: an Iterable of Wordforms
-    """
-    for wordform in q:
-        for definition in wordform.definitions.all():
-            if "CW" in definition.source_ids:
-                yield wordform
-                break
-
-
-def fetch_cree_and_english_results(
-    user_query: InternalForm, affix_search: bool = True
-) -> CreeAndEnglish:
-    """
-    HERE BE DRAGONS!
-
-    Historically, this function has been the bulk of our search backend, performing both
-    Cree and English search. However, I honestly don't understand how it works. As of
-    this writing (2021-01-11), I am refactoring the function to bring some order to it
-    and hopefully understanding how it works.
-
-    Original documentation for fetch_lemma_by_user_query() as follows (I don't really understand it):
-
-    ---
-
-    treat the user query as cree and:
-
-    Give the analysis of user query and matched lemmas.
-    There can be multiple analysis for user queries
-    One analysis could match multiple lemmas as well due to underspecified database fields.
-    (inflectional_category and pos can be empty)
-
-    treat the user query as English keyword and:
-
-    Give a list of matched lemmas
-
-    :param affix_search: whether to perform affix search or not (both English and Cree)
-    :param user_query: can be English or Cree (syllabics or not)
-    """
-
-    # build up result_lemmas in 2 ways
-    # 1. affix search (return all results that ends/starts with the query string)
-    # 2. spell relax in descriptive fst
-    # 2. definition containment of the query word
-
-    cree_results: Set[CreeResult] = set()
-    english_results: Set[EnglishResult] = set()
-
-    # there will be too many matches for some shorter queries
-    if affix_search and not query_would_return_too_many_results(user_query):
-        do_cree_affix_seach(user_query, cree_results)
-        do_english_affix_search(user_query, english_results)
-
-    _fetch_results(user_query, cree_results, english_results)
-
-    return CreeAndEnglish(cree_results, english_results)
-
-
-def _fetch_results(
-    user_query: InternalForm,
-    cree_results: Set[CreeResult],
-    english_results: Set[EnglishResult],
-):
+def fetch_results(search_run: core.SearchRun):
     """
     The rest of this method is code Eddie has NOT refactored, so I don't really
     understand what's going on here:
@@ -121,7 +29,7 @@ def _fetch_results(
     #   e.g., "atchakosuk" becomes "acâhkos+N+A+Pl" --
     #         thus, we can match "acâhkos" in the dictionary!
     fst_analyses: Set[ConcatAnalysis] = set(
-        a.concatenate() for a in hfstol.analyze(user_query)
+        a.concatenate() for a in hfstol.analyze(search_run.internal_query)
     )
 
     all_standard_forms = []
@@ -135,9 +43,7 @@ def _fetch_results(
 
         if exactly_matched_wordforms.exists():
             for wf in exactly_matched_wordforms:
-                cree_results.add(
-                    CreeResult(ConcatAnalysis(wf.analysis), wf, Lemma(wf.lemma))
-                )
+                search_run.add_result(Result(wf, source_language_match=wf.text))
         else:
             # When the user query is outside of paradigm tables
             # e.g. mad preverb and reduplication: ê-mâh-misi-nâh-nôcihikocik
@@ -159,7 +65,7 @@ def _fetch_results(
                 )
             normatized_user_query = min(
                 normatized_form_for_analysis,
-                key=lambda f: get_modified_distance(f, user_query),
+                key=lambda f: get_modified_distance(f, search_run.internal_query),
             )
 
             lemma, word_class = lemma_wc
@@ -183,23 +89,27 @@ def _fetch_results(
 
                 # a more permanent fix requires every pronouns lemma to be listed and specified
                 for lemma_wordform in matched_lemma_wordforms:
-                    cree_results.add(
-                        CreeResult(
-                            ConcatAnalysis(analysis),
-                            normatized_user_query,
-                            Lemma(lemma_wordform),
-                        )
+                    synthetic_wordform = Wordform(
+                        text=normatized_user_query,
+                        pos=PartOfSpeech.PRON,
+                        analysis=analysis,
+                        lemma=lemma_wordform,
+                    )
+                    search_run.add_result(
+                        Result(synthetic_wordform, pronoun_as_is_match=True)
                     )
             else:
                 for lemma_wordform in matched_lemma_wordforms.filter(
                     as_is=False, pos=word_class.pos.name
                 ):
-                    cree_results.add(
-                        CreeResult(
-                            ConcatAnalysis(analysis),
-                            normatized_user_query,
-                            Lemma(lemma_wordform),
-                        )
+                    synthetic_wordform = Wordform(
+                        lemma=lemma_wordform,
+                        analysis=analysis,
+                        pos=word_class.pos.name,
+                        text=normatized_user_query,
+                    )
+                    search_run.add_result(
+                        Result(synthetic_wordform, analyzable_inflection_match=True)
                     )
 
     # we choose to trust CW and show those matches with definition from CW.
@@ -208,31 +118,19 @@ def _fetch_results(
     # text__in = [user_query] help matching entries with spaces in it, which fst can't analyze.
     for cw_as_is_wordform in filter_cw_wordforms(
         Wordform.objects.filter(
-            text__in=all_standard_forms + [user_query],
+            text__in=all_standard_forms + [search_run.internal_query],
             as_is=True,
             is_lemma=True,
         )
     ):
-        cree_results.add(
-            CreeResult(
-                ConcatAnalysis(cw_as_is_wordform.analysis),
-                cw_as_is_wordform,
-                Lemma(cw_as_is_wordform),
-            )
-        )
+        search_run.add_result(Result(cw_as_is_wordform, is_cw_as_is_wordform=True))
 
     # as per https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/161
     # preverbs should be presented
     # exhaustively search preverbs here (since we can't use fst on preverbs.)
 
-    for preverb_wf in fetch_preverbs(user_query):
-        cree_results.add(
-            CreeResult(
-                ConcatAnalysis(preverb_wf.analysis),
-                preverb_wf,
-                Lemma(preverb_wf),
-            )
-        )
+    for preverb_wf in fetch_preverbs(search_run.internal_query):
+        search_run.add_result(Result(preverb_wf, is_preverb_match=True))
 
     # Words/phrases with spaces in CW dictionary can not be analyzed by fst and are labeled "as_is".
     # However we do want to show them. We trust CW dictionary here and filter those lemmas that has any definition
@@ -242,16 +140,16 @@ def _fetch_results(
     # todo: remind user "are you searching in cree/english?"
     # todo: allow inflected forms to be searched through English. (requires database migration
     #  since now EnglishKeywords are bound to lemmas)
-    for stemmed_keyword in stem_keywords(user_query):
+    for stemmed_keyword in stem_keywords(search_run.internal_query):
 
         lemma_ids = EnglishKeyword.objects.filter(text__iexact=stemmed_keyword).values(
             "lemma__id"
         )
 
         for wordform in Wordform.objects.filter(id__in=lemma_ids):
-            english_results.add(
-                EnglishResult(MatchedEnglish(user_query), wordform, Lemma(wordform))
-            )  # will become  (user_query, inflection.text, inflection.lemma)
+            search_run.add_result(
+                Result(wordform, target_language_keyword_match=stemmed_keyword)
+            )
 
         # explained above, preverbs should be presented
         for wordform in Wordform.objects.filter(
@@ -259,8 +157,32 @@ def _fetch_results(
             id__in=lemma_ids,
             as_is=True,
         ):
-            english_results.add(
-                EnglishResult(MatchedEnglish(user_query), wordform, Lemma(wordform))
-            )  # will become  (user_query, inflection.text, wordform)
+            search_run.add_result(Result(wordform, is_preverb_match=True))
 
-    return CreeAndEnglish(cree_results, english_results)
+
+def filter_cw_wordforms(q: Iterable[Wordform]) -> Iterable[Wordform]:
+    """
+    return the wordforms that has definition from CW dictionary
+
+    :param q: an Iterable of Wordforms
+    """
+    for wordform in q:
+        for definition in wordform.definitions.all():
+            if "CW" in definition.source_ids:
+                yield wordform
+                break
+
+
+def fetch_preverbs(user_query: str) -> Set[Wordform]:
+    """
+    Search for preverbs in the database by matching the circumflex-stripped forms. MD only contents are filtered out.
+    trailing dash relaxation is used
+
+    :param user_query: unicode normalized, to_lower-ed
+    """
+
+    if user_query.endswith("-"):
+        user_query = user_query[:-1]
+    user_query = remove_cree_diacritics(user_query)
+
+    return Wordform.PREVERB_ASCII_LOOKUP[user_query]

--- a/CreeDictionary/API/search/lookup.py
+++ b/CreeDictionary/API/search/lookup.py
@@ -161,13 +161,13 @@ def fetch_results(search_run: core.SearchRun):
             search_run.add_result(Result(wordform, is_preverb_match=True))
 
 
-def filter_cw_wordforms(q: Iterable[Wordform]) -> Iterable[Wordform]:
+def filter_cw_wordforms(queryset: Iterable[Wordform]) -> Iterable[Wordform]:
     """
     return the wordforms that has definition from CW dictionary
 
-    :param q: an Iterable of Wordforms
+    :param queryset: an Iterable of Wordforms
     """
-    for wordform in q:
+    for wordform in queryset:
         for definition in wordform.definitions.all():
             if "CW" in definition.source_ids:
                 yield wordform

--- a/CreeDictionary/API/search/presentation.py
+++ b/CreeDictionary/API/search/presentation.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from typing import List, Tuple, Optional
+
+from django.forms import model_to_dict
+
+from utils import get_modified_distance
+from . import types, core, lookup
+from utils.fst_analysis_parser import LABELS, partition_analysis
+from utils.types import FSTTag, Label, ConcatAnalysis
+from .types import Preverb, LinguisticTag, linguistic_tag_from_fst_tags
+from ..schema import SerializedWordform
+
+
+class PresentationResult:
+    """
+    A result ready for user display, and serializable for templates
+
+    The non-presentation Result class is used for gathering features and ranking
+    results. When the results to show have been decided upon, this class adds
+    presentation things like labels.
+    """
+
+    def __init__(self, result: types.Result, *, search_run: core.SearchRun):
+        self._result = result
+        self._search_run = search_run
+
+        self.wordform = result.wordform
+        self.lemma_wordform = result.lemma_wordform
+        self.is_lemma = result.is_lemma
+        self.source_language_match = result.source_language_match
+
+        (
+            self.linguistic_breakdown_head,
+            self.linguistic_breakdown_tail,
+        ) = safe_partition_analysis(result.wordform.analysis)
+
+        self.preverbs = get_preverbs_from_head_breakdown(self.linguistic_breakdown_head)
+
+        self.friendly_linguistic_breakdown_head = tuple(
+            replace_user_friendly_tags(self.linguistic_breakdown_head)
+        )
+        self.friendly_linguistic_breakdown_tail = tuple(
+            replace_user_friendly_tags(self.linguistic_breakdown_tail)
+        )
+
+    def serialize(self):
+        ret = {
+            "lemma_wordform": serialize_wordform(self.lemma_wordform),
+            "is_lemma": self.is_lemma,
+            "definitions": serialize_definitions(
+                self.wordform.definitions.all(),
+                # This is the only place include_auto_definitions is used,
+                # because we only auto-translate non-lemmas, and this is the
+                # only place where a non-lemma search result appears.
+                include_auto_definitions=self._search_run.include_auto_definitions,
+            ),
+            "preverbs": [serialize_wordform(pv) for pv in self.preverbs],
+            "friendly_linguistic_breakdown_head": self.friendly_linguistic_breakdown_head,
+            "friendly_linguistic_breakdown_tail": self.friendly_linguistic_breakdown_tail,
+            "relevant_tags": tuple(t.serialize() for t in self.relevant_tags),
+        }
+        if isinstance(self.wordform, str):
+            ret["wordform_text"] = self.wordform
+        else:
+            ret["wordform_text"] = self.wordform.text
+
+        return ret
+
+    @property
+    def relevant_tags(self) -> Tuple[LinguisticTag, ...]:
+        """
+        Tags and features to display in the linguistic breakdown pop-up.
+        This omits preverbs and other features displayed elsewhere
+
+        In itwêwina, these tags are derived from the suffix features exclusively.
+        We chunk based on the English relabelleings!
+        """
+        return tuple(
+            linguistic_tag_from_fst_tags(fst_tags)
+            for fst_tags in LABELS.english.chunk(self.linguistic_breakdown_tail)
+        )
+
+    def __str__(self):
+        return f"PresentationResult<{self.wordform}:{self.wordform.id}>"
+
+
+def serialize_wordform(wordform) -> SerializedWordform:
+    """
+    Intended to be passed in a JSON API or into templates.
+
+    :return: json parsable result
+    """
+    result = model_to_dict(wordform)
+    result["definitions"] = serialize_definitions(wordform.definitions.all())
+    result["lemma_url"] = wordform.get_absolute_url()
+
+    # Displayed in the word class/inflection help:
+    result["inflectional_category_plain_english"] = LABELS.english.get(
+        wordform.inflectional_category
+    )
+    result["inflectional_category_linguistic"] = LABELS.linguistic_long.get(
+        wordform.inflectional_category
+    )
+    result["wordclass_emoji"] = wordform.get_emoji_for_cree_wordclass()
+    result["wordclass"] = wordform.wordclass_text
+
+    return result
+
+
+def serialize_definitions(definitions, include_auto_definitions=False):
+    ret = []
+    for definition in definitions:
+        serialized = definition.serialize()
+        if include_auto_definitions or "auto" not in serialized["source_ids"]:
+            ret.append(serialized)
+    return ret
+
+
+def safe_partition_analysis(analysis: ConcatAnalysis):
+    try:
+        (
+            linguistic_breakdown_head,
+            _,
+            linguistic_breakdown_tail,
+        ) = partition_analysis(analysis)
+    except ValueError:
+        linguistic_breakdown_head = []
+        linguistic_breakdown_tail = []
+    return linguistic_breakdown_head, linguistic_breakdown_tail
+
+
+def replace_user_friendly_tags(fst_tags: List[FSTTag]) -> List[Label]:
+    """ replace fst-tags to cute ones"""
+    return LABELS.english.get_full_relabelling(fst_tags)
+
+
+def get_preverbs_from_head_breakdown(
+    head_breakdown: List[FSTTag],
+) -> Tuple[Preverb, ...]:
+    results = []
+
+    for tag in head_breakdown:
+        preverb_result: Optional[Preverb] = None
+        if tag.startswith("PV/"):
+            # use altlabel.tsv to figure out the preverb
+
+            # ling_short looks like: "Preverb: âpihci-"
+            ling_short = LABELS.linguistic_short.get(tag)
+            if ling_short is not None and ling_short != "":
+                # looks like: "âpihci"
+                normative_preverb_text = ling_short[len("Preverb: ") : -1]
+                preverb_results = lookup.fetch_preverbs(normative_preverb_text)
+
+                # find the one that looks the most similar
+                if preverb_results:
+                    preverb_result = min(
+                        preverb_results,
+                        key=lambda pr: get_modified_distance(
+                            normative_preverb_text,
+                            pr.text.strip("-"),
+                        ),
+                    )
+
+                else:  # can't find a match for the preverb in the database
+                    preverb_result = normative_preverb_text
+
+        if preverb_result is not None:
+            results.append(preverb_result)
+    return tuple(results)

--- a/CreeDictionary/API/search/presentation.py
+++ b/CreeDictionary/API/search/presentation.py
@@ -9,6 +9,7 @@ from . import types, core, lookup
 from utils.fst_analysis_parser import LABELS, partition_analysis
 from utils.types import FSTTag, Label, ConcatAnalysis
 from .types import Preverb, LinguisticTag, linguistic_tag_from_fst_tags
+from ..models import Wordform
 from ..schema import SerializedWordform
 
 
@@ -162,8 +163,14 @@ def get_preverbs_from_head_breakdown(
                         ),
                     )
 
-                else:  # can't find a match for the preverb in the database
-                    preverb_result = normative_preverb_text
+                else:
+                    # Can't find a match for the preverb in the database.
+                    # This happens when searching against the test database for
+                    # ê-kî-nitawi-kâh-kîmôci-kotiskâwêyâhk, as the test database
+                    # lacks lacks ê and kî.
+                    preverb_result = Wordform(
+                        text=normative_preverb_text, is_lemma=True
+                    )
 
         if preverb_result is not None:
             results.append(preverb_result)

--- a/CreeDictionary/API/search/ranking.py
+++ b/CreeDictionary/API/search/ranking.py
@@ -22,10 +22,7 @@ def sort_search_result(
               <0: res_a should appear before res_b.
     """
 
-    if (
-        res_a.source_language_match is not None
-        and res_b.source_language_match is not None
-    ):
+    if res_a.did_match_source_language and res_b.did_match_source_language:
         # both from source
         a_dis = get_modified_distance(search_run.internal_query, res_a.wordform.text)
         b_dis = get_modified_distance(search_run.internal_query, res_b.wordform.text)

--- a/CreeDictionary/API/search/runner.py
+++ b/CreeDictionary/API/search/runner.py
@@ -1,0 +1,29 @@
+from API.search.affix import (
+    do_source_language_affix_search,
+    do_target_language_affix_search,
+    query_would_return_too_many_results,
+)
+from API.search.core import SearchRun
+from API.search.lookup import fetch_results
+
+
+def search(*, query: str, include_affixes=True, include_auto_definitions=False):
+    """
+    Perform an actual search, using the provided options.
+
+    This class encapsulates the logic of which search methods to try, and in
+    which order, to build up results in a SearchRun.
+    """
+    search_run = SearchRun(
+        query=query, include_auto_definitions=include_auto_definitions
+    )
+
+    fetch_results(search_run)
+
+    if include_affixes and not query_would_return_too_many_results(
+        search_run.internal_query
+    ):
+        do_source_language_affix_search(search_run)
+        do_target_language_affix_search(search_run)
+
+    return search_run

--- a/CreeDictionary/API/search/types.py
+++ b/CreeDictionary/API/search/types.py
@@ -13,7 +13,7 @@ from utils.fst_analysis_parser import LABELS
 from utils.types import FSTTag
 
 # it's a str when the preverb does not exist in the database
-Preverb = Union[Wordform, str]
+Preverb = Wordform
 Lemma = NewType("Lemma", Wordform)
 MatchedEnglish = NewType("MatchedEnglish", str)
 InternalForm = NewType("InternalForm", str)
@@ -162,7 +162,10 @@ class Result:
     #: Was anything in the query a source-language match for this result?
     @property
     def did_match_source_language(self) -> bool:
-        return self.source_language_match is not None
+        return (
+            self.source_language_match is not None
+            or self.source_language_affix_match is not None
+        )
 
     def __str__(self):
         return f"Result<wordform={self.wordform}>"

--- a/CreeDictionary/API/search/types.py
+++ b/CreeDictionary/API/search/types.py
@@ -101,14 +101,18 @@ class Result:
     """
     A target-language wordform and the features that link it to a query.
 
-    The features can be gathered together from multiple search methods to allow
-    better inferences about how good a result is.
+    Features of a wordform allow better inferences about how good a result is.
 
-    Some examples of the features to be used for ranking could include:
+    Some examples of these features could include:
       - Is this Result a match between a source-language query and wordform
         text, or between a target-language query term and a word in the
         definition text?
       - What is the edit distance between the query term and the wordform?
+      - What is the best cosine vector distance between a definition of the
+        result wordform and the query terms?
+
+    The best search results will presumably have better scores on more features
+    of greater importance.
 
     Search methods may generate candidate results that are ultimately not sent
     to users, so any user-friendly tagging/relabelling is instead done in

--- a/CreeDictionary/API/search/types.py
+++ b/CreeDictionary/API/search/types.py
@@ -12,7 +12,6 @@ from API.schema import SerializedLinguisticTag
 from utils.fst_analysis_parser import LABELS
 from utils.types import FSTTag
 
-# it's a str when the preverb does not exist in the database
 Preverb = Wordform
 Lemma = NewType("Lemma", Wordform)
 MatchedEnglish = NewType("MatchedEnglish", str)
@@ -102,9 +101,14 @@ class Result:
     """
     A target-language wordform and the features that link it to a query.
 
-    The features—is it an exact source-language match for the query? Is the edit
-    distance low? &c.—that make this a candidate result for a search query are
-    required to rank different results before showing them to the user.
+    The features can be gathered together from multiple search methods to allow
+    better inferences about how good a result is.
+
+    Some examples of the features to be used for ranking could include:
+      - Is this Result a match between a source-language query and wordform
+        text, or between a target-language query term and a word in the
+        definition text?
+      - What is the edit distance between the query term and the wordform?
 
     Search methods may generate candidate results that are ultimately not sent
     to users, so any user-friendly tagging/relabelling is instead done in

--- a/CreeDictionary/API/views.py
+++ b/CreeDictionary/API/views.py
@@ -1,8 +1,5 @@
-from typing import List
-
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 
-from API.schema import SerializedSearchResult
 from .search import simple_search
 
 
@@ -18,9 +15,7 @@ def click_in_text(request) -> HttpResponse:
     elif q == "":
         return HttpResponseBadRequest("query param q is an empty string")
 
-    results: List[SerializedSearchResult] = []
-    for result in simple_search(q, include_auto_definitions=False):
-        results.append(result.serialize(include_auto_definitions=False))
+    results = simple_search(q, include_auto_definitions=False)
 
     response = {"results": results}
 

--- a/CreeDictionary/CreeDictionary/management/commands/ensurecypressadminuser.py
+++ b/CreeDictionary/CreeDictionary/management/commands/ensurecypressadminuser.py
@@ -1,0 +1,43 @@
+import json
+import secrets
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = """Ensure there is a ‘cypress’ admin user
+
+    This user is for running cypress tests that require a login. The password is
+    saved in a JSON file to be read by cypress tests.
+    """
+
+    def handle(self, *args, **options):
+        cypress_user, created = User.objects.get_or_create(username="cypress")
+
+        user_file_valid = False
+        user_info_file = settings.BASE_PATH / ".cypress-user.json"
+
+        password = None
+        if user_info_file.exists():
+            user_info = json.loads(user_info_file.read_text())
+            # If there is an existing password in the JSON file, use it later so
+            # that the same JSON file can be used by cypress tests against both
+            # dev and test databases.
+            password = user_info.get("password", "")
+            if password and cypress_user.check_password(password):
+                user_file_valid = True
+
+        if created or not user_file_valid:
+            if not password:
+                password = secrets.token_hex(20)
+            user_info_file.write_text(
+                json.dumps({"username": "cypress", "password": password}, indent=2)
+                + "\n"
+            )
+            cypress_user.set_password(password)
+            # Our only login page is the admin login page, which only accepts logins
+            # from staff users.
+            cypress_user.is_staff = True
+            cypress_user.save()

--- a/CreeDictionary/CreeDictionary/management/commands/ensuretestdb.py
+++ b/CreeDictionary/CreeDictionary/management/commands/ensuretestdb.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
 
         import_test_dictionary()
         add_some_auto_translations()
-        ensure_cypress_admin_user()
+        call_command("ensurecypressadminuser")
 
 
 def import_test_dictionary():
@@ -41,25 +41,3 @@ def import_test_dictionary():
 def add_some_auto_translations():
     if not Definition.objects.filter(auto_translation_source__isnull=False).exists():
         call_command("translatewordforms", wordforms=["acâhkosa"])
-
-
-def ensure_cypress_admin_user():
-    cypress_user, created = User.objects.get_or_create(username="cypress")
-
-    user_file_valid = False
-    user_info_file = settings.BASE_PATH / ".cypress-user.json"
-    if user_info_file.exists():
-        user_info = json.load(user_info_file.read_text())
-        if cypress_user.check_password(user_info.get("password", "")):
-            user_file_valid = True
-
-    if created or not user_file_valid:
-        password = secrets.token_hex(20)
-        user_info_file.write_text(
-            json.dumps({"username": "cypress", "password": password}, indent=2) + "\n"
-        )
-        cypress_user.set_password(password)
-        # Our only login page is the admin login page, which only accepts logins
-        # from staff users.
-        cypress_user.is_staff = True
-        cypress_user.save()

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/definition-title.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/definition-title.html
@@ -29,7 +29,7 @@
       {% if result.is_lemma %}
         <a data-cy="lemma-link" href="{{ result.lemma_wordform.lemma_url }}">{% orth result.lemma_wordform.text %}</a>
       {% else %}
-        {% orth result.matched_cree %}
+        {% orth result.wordform_text %}
       {% endif %}
     </h2>
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/definition__icons.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/definition__icons.html
@@ -11,7 +11,7 @@
 
   {% endcomment %}
 
-  <div class="definition__icons" data-wordform="{{ result.matched_cree }}">
+  <div class="definition__icons" data-wordform="{{ result.wordform_text }}">
     {% include "CreeDictionary/components/linguistic-breakdown.html" %}
     {# NB: 🔊 Recording button is added here dynamically by JavaScript #}
   </div>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/linguistic-breakdown.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/linguistic-breakdown.html
@@ -21,7 +21,7 @@
   {% load morphodict_orth %}
   {% load static %}
 
-    {% if result.linguistic_breakdown_head or result.linguistic_breakdown_tail %}
+    {% if result.friendly_linguistic_breakdown_head or result.friendly_linguistic_breakdown_tail %}
       <div tabindex="0" class="definition__icon definition-title__tooltip-icon" data-has-tooltip data-cy="information-mark">
         <img
           src="{% static 'CreeDictionary/images/fa/info-circle-solid.svg' %}"

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -8,7 +8,7 @@ from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotFou
 from django.shortcuts import redirect, render
 from django.views.decorators.http import require_GET
 
-from API.search import search_with_affixes
+from API.search import search_with_affixes, presentation
 from utils import ParadigmSize
 
 from CreeDictionary.forms import WordSearchForm
@@ -60,9 +60,7 @@ def lemma_details(request, lemma_text: str = None):  # pragma: no cover
             # TODO: remove this parameter in favour of...
             lemma=lemma,
             # ...this parameter
-            wordform=lemma.serialize(
-                include_auto_definitions=should_include_auto_definitions(request)
-            ),
+            wordform=presentation.serialize_wordform(lemma),
             paradigm_size=paradigm_size,
             paradigm_tables=lemma.get_paradigm_layouts(size=paradigm_size)
             if lemma
@@ -85,15 +83,10 @@ def index(request):  # pragma: no cover
     user_query = request.GET.get("q", None)
 
     if user_query:
-        search_results = [
-            search_result.serialize(
-                include_auto_definitions=should_include_auto_definitions(request)
-            )
-            for search_result in search_with_affixes(
-                user_query,
-                include_auto_definitions=should_include_auto_definitions(request),
-            )
-        ]
+        search_results = search_with_affixes(
+            user_query,
+            include_auto_definitions=should_include_auto_definitions(request),
+        )
         did_search = True
     else:
         search_results = []
@@ -125,15 +118,7 @@ def search_results(request, query_string: str):  # pragma: no cover
     return render(
         request,
         "CreeDictionary/search-results.html",
-        {
-            "query_string": query_string,
-            "search_results": [
-                r.serialize(
-                    include_auto_definitions=should_include_auto_definitions(request)
-                )
-                for r in results
-            ],
-        },
+        {"query_string": query_string, "search_results": results},
     )
 
 

--- a/CreeDictionary/phrase_translate/management/commands/translatewordforms.py
+++ b/CreeDictionary/phrase_translate/management/commands/translatewordforms.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from dataclasses import dataclass, asdict
 
 from django.core.management import BaseCommand
+from django.db import transaction
 from django.db.models import Max, Q
 from tqdm import tqdm
 
@@ -114,11 +115,10 @@ class Command(BaseCommand):
 
         (ds, created_) = DictionarySource.objects.get_or_create(abbrv="auto")
 
+        extra_kwargs = {}
         if options["wordforms"]:
-            wordforms_queryset = Wordform.objects.filter(text__in=options["wordforms"])
-        else:
-            wordforms_queryset = Wordform.objects.all()
-        wordforms_queryset = wordforms_queryset.select_related("lemma")
+            extra_kwargs = dict(text__in=options["wordforms"])
+        wordforms_queryset = Wordform.objects.filter(is_lemma=False, **extra_kwargs)
 
         logger.info("Removing existing auto-definitions")
         if options["wordforms"]:

--- a/CreeDictionary/phrase_translate/translate.py
+++ b/CreeDictionary/phrase_translate/translate.py
@@ -166,7 +166,7 @@ def main():
     from API.models import Wordform
 
     def do_lookup(to_lookup: str):
-        wordforms = Wordform.objects.filter(text=to_lookup).select_related("lemma")
+        wordforms = Wordform.objects.filter(text=to_lookup)
 
         if wordforms.count() == 0:
             print("not found in database :/")

--- a/CreeDictionary/search_quality/analysis_test.py
+++ b/CreeDictionary/search_quality/analysis_test.py
@@ -12,28 +12,25 @@ def test_count_no_dupes_on_empty_list():
 
 
 ACÂKHOS_1: DuplicateAnnotatedSearchResult = {
-    "matched_cree": "acâhkos",
+    "wordform_text": "acâhkos",
     "lemma_wordform": {
         "text": "atâhk",
         "inflectional_category": "NA-3",
     },
-    "raw_suffix_tags": tuple(map(FSTTag, ["N", "A", "Sg"])),
 }
 ACÂKHOS_2: DuplicateAnnotatedSearchResult = {
-    "matched_cree": "acâhkos",
+    "wordform_text": "acâhkos",
     "lemma_wordform": {
         "text": "acâhkos",
         "inflectional_category": "NA-1",
     },
-    "raw_suffix_tags": tuple(map(FSTTag, ["N", "A", "Sg"])),
 }
 MISATIM_1: DuplicateAnnotatedSearchResult = {
-    "matched_cree": "misatim",
+    "wordform_text": "misatim",
     "lemma_wordform": {
         "text": "misatim",
         "inflectional_category": "NA-3",
     },
-    "raw_suffix_tags": tuple(map(FSTTag, ["N", "A", "Sg"])),
 }
 
 

--- a/CreeDictionary/search_quality/run_sample.py
+++ b/CreeDictionary/search_quality/run_sample.py
@@ -21,10 +21,7 @@ def gen_run_sample(sample_file: PathLike = DEFAULT_SAMPLE_FILE, *, out_file: Pat
         # multiple times in randomized orders to spread out the effects of
         # warmup and caching
         start_time = time.time()
-        results = [
-            r.serialize(include_auto_definitions=False)
-            for r in search_with_affixes(query)
-        ]
+        results = search_with_affixes(query)
         time_taken = time.time() - start_time
 
         combined_results[query] = {

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -25,8 +25,8 @@ def test_when_linguistic_breakdown_absent():
 
     result = search_results[0]
     assert (
-        result.friendly_linguistic_breakdown_head == ()
-        and result.friendly_linguistic_breakdown_tail == ("like: pê-",)
+        result.friendly_linguistic_breakdown_head == []
+        and result.friendly_linguistic_breakdown_tail == ["like: pê-"]
     )
 
 

--- a/CreeDictionary/utils/enums.py
+++ b/CreeDictionary/utils/enums.py
@@ -1,11 +1,6 @@
 from enum import Enum
 
 
-class Language(Enum):
-    ENGLISH = "ENGLISH"
-    CREE = "CREE"
-
-
 class ParadigmSize(Enum):
     BASIC = "BASIC"
     FULL = "FULL"


### PR DESCRIPTION
Building on the previous move into separate files, this introduces more
classes and objects. The general workflow is:

  - Search methods generate candidate Result objects, recording the
    features that indicate why a given Result may be a good match for the
    query

  - Features for the same results are aggregated together and can be used
    for ranking. If *multiple* search methods select a given result, that
    can be used as a signal to prioritize that result.

  - Presentation features like relabelling are handled separately in a
    later phase of the process

Again, user-facing changes should be minimal at this time. This is just
rearranging stuff so that there is room to add new functionality later.

The main outstanding issue that I am aware of at this point is that
changing the search result serialization may break click-in-text, in which
case I will have to add legacy compatibility keys.