### PR TITLE
Adjust database path and production docker paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ local_settings.py
 db.sqlite3
 *.sqlite3.bak
 *.sqlite3-journal
+*.sqlite3-shm
+*.sqlite3-wal
 
 # pyenv
 .python-version

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -172,7 +172,7 @@ def defaultDatabasePath():
     The default is to store the production database in the repository. This might not be
     the best solution :/
     """
-    path = BASE_PATH / "db.sqlite3"
+    path = BASE_PATH / "db" / "db.sqlite3"
     return f"sqlite:///{path}"
 
 

--- a/CreeDictionary/CreeDictionary/settings.py
+++ b/CreeDictionary/CreeDictionary/settings.py
@@ -169,8 +169,22 @@ else:  # pragma: no cover
 
 def defaultDatabasePath():
     """
-    The default is to store the production database in the repository. This might not be
-    the best solution :/
+    The default is to store the database in the repository folder. In
+    production, docker can mount the database from elsewhere.
+
+    Note that we deviate from the default slightly by putting the database
+    in a dedicated `db` directory, and mounting the entire directory with
+    docker, instead of only mounting the `.sqlite3` file.
+
+    This is so that the additional `-shm` and `-wal` files that SQLite
+    creates if running in write-ahead-logging aka WAL mode are kept
+    together as one unit.
+
+    This also helps out in some situations with swapping out database files
+    that have had migrations applied offline. If `foo` is a file that is
+    also a docker mount, and you `mv foo bar && touch foo` from outside the
+    container, the container file `foo` now points at the outside `bar`.
+    Things are more normal with directory mounts.
     """
     path = BASE_PATH / "db" / "db.sqlite3"
     return f"sqlite:///{path}"

--- a/docker/docker-compose.staging-override-sample.yml
+++ b/docker/docker-compose.staging-override-sample.yml
@@ -1,0 +1,25 @@
+# A docker-compose override file more amenable to local work
+#
+# Run with
+#
+#     docker-compose
+#         -f docker-compose.yml \
+#         -f docker-compose.staging-override-sample.yml \
+#         up --build
+
+version: "3"
+
+services:
+  itwewina:
+    # In prod, we *always* want itwêwina running, including on boot; that’s
+    # not necessarily the case on our dev machines.
+    restart: "no"
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    # The tag that will automatically be applied on build:
+    image: itwewina:dev
+    volumes:
+      - "./.env:/app/.env"
+      - "../CreeDictionary/db/:/app/CreeDictionary/db"
+      - "../CreeDictionary/search_quality/sample_results/:/app/CreeDictionary/search_quality/sample_results/"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,5 +21,10 @@ services:
       - "9191:9191"
     volumes:
       - "./.env:/app/.env"
+      # Mount directory, not file, so that -shm and -wal files will be
+      # persisted outside the container if using WAL mode
       - "/data_local/application-data/itwewina/db/:/app/CreeDictionary/db/"
+      # Use a persistent path for search sample results, so that they
+      # remain across deployments and so that additional sample results can
+      # be uploaded from other sources for comparison purposes
       - "/data_local/application-data/itwewina/search-quality/:/app/CreeDictionary/search_quality/sample_results/"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,20 +1,4 @@
-# Base docker-compose for itwewina.
-#
-# NOTE!!!!!!!!!
-# This docker-compose file is useless standalone. You **MUST** combine it with
-# either ./production.yml or ./staging.yml.
-#
-# Why? Because docker-compose merges the `ports` setting in a sad way :(
-#
-# To use in experiment before running in production, use the following:
-#
-#     docker-compose -f docker-compose.yml -f staging.yml
-#
-# To use in production, use the following:
-#
-#     docker-compose -f docker-compose.yml -f production.yml
-#
-# See: https://docs.docker.com/compose/extends/#multiple-compose-files
+# Production docker-compose for itwewina.
 
 version: "3"
 
@@ -37,4 +21,5 @@ services:
       - "9191:9191"
     volumes:
       - "./.env:/app/.env"
-      - "/data_local/application-data/itwewina/db.sqlite3:/app/CreeDictionary/db.sqlite3"
+      - "/data_local/application-data/itwewina/db/:/app/CreeDictionary/db/"
+      - "/data_local/application-data/itwewina/search-quality/:/app/CreeDictionary/search_quality/sample_results/"


### PR DESCRIPTION
  - Mount the database from a directory, not a file, so that we can safely
    enable WAL mode, and to make some other database maintenance tasks a
    little easier

  - Use a persistent path for storing search sample results

Before deploying this change, hard-link the current database file to the
new location so that the transition is seamless.

And all developers will also need to move any existing database files to
the new path.