### PR TITLE
change: rename remaining basic/traditional -> community/linguistic

### DIFF
--- a/CreeDictionary/CreeDictionary/display_options.py
+++ b/CreeDictionary/CreeDictionary/display_options.py
@@ -1,7 +1,7 @@
 """
 Display options. Currently controls:
 
- - "mode": either "basic" and "traditional"
+ - "mode": either "community" (default) or "linguistic"
 
 As of 2021-04-14, "mode" is a coarse mechanism for affecting the display; there are
 plans for more fine-grained control over the display of, e.g., search results.

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -87,7 +87,7 @@
       <ul class="unbullet">
         <li>
           <form method="POST" action={% url 'cree-dictionary-change-display-mode' %}>
-            <button class="unbutton linklike footer__link" type="submit" name="mode" value="community" data-cy="enable-basic-mode">
+            <button class="unbutton linklike footer__link" type="submit" name="mode" value="community" data-cy="enable-community-mode">
               Community mode
             </button>
             {% csrf_token %}
@@ -95,7 +95,7 @@
         </li>
         <li>
           <form method="POST" action={% url 'cree-dictionary-change-display-mode' %}>
-            <button class="unbutton linklike footer__link" type="submit" name="mode" value="linguistic" data-cy="enable-traditional-mode">
+            <button class="unbutton linklike footer__link" type="submit" name="mode" value="linguistic" data-cy="enable-linguistic-mode">
               Linguist mode
             </button>
             {% csrf_token %}

--- a/cypress/integration/search/header-display-options.spec.js
+++ b/cypress/integration/search/header-display-options.spec.js
@@ -16,7 +16,7 @@ context('Searching', () => {
       inflectionalClassInDefinitionTitle()
         .should('not.exist')
 
-      cy.get('[data-cy=enable-traditional-mode]')
+      cy.get('[data-cy=enable-linguistic-mode]')
         .click()
 
       inflectionalClassInDefinitionTitle()
@@ -31,7 +31,7 @@ context('Searching', () => {
 
   function setDefaultDisplayMode() {
     cy.visit('/')
-    cy.get('[data-cy=enable-basic-mode]')
+    cy.get('[data-cy=enable-community-mode]')
       .click()
   }
 })


### PR DESCRIPTION
I had left a few "basic"/"traditional" labels after merging #729; this renames the rest to "community"/"linguistic".