### PR TITLE
phrase_translate: update FSTs and remove parens

### DIFF
--- a/CreeDictionary/phrase_translate/README.md
+++ b/CreeDictionary/phrase_translate/README.md
@@ -1,0 +1,33 @@
+## Phrase translation
+
+The process to update the auto-translated phrases is as follows:
+
+ 1. First, get the latest FSTs. In the `lang-crk` repo, `cd src && make -f
+    quick.mk fsts.zip`
+
+ 2. Copy the generated `transcriptor-cw-eng*` files to
+    `CreeDictionary/res/fst` in this repo.
+
+ 3. Run the unit tests: `pipenv run pytest CreeDictionary`
+
+ 4. Run the translation script in jsonl-only mode to get a file containing
+    all the translations for review:
+
+        pipenv run CreeDictionary/manage.py translatewordforms --jsonl-only translations.jsonl
+
+    You will need to run this against a database that has had the full
+    dictionary imported for this to be very useful.
+
+ 5. Commit and make a pull request
+
+ 6. After the pull request passes tests, is reviewed, merged, and
+    auto-deployed to `itw.altlab.dev`, SSH there and run
+
+        cd /opt/docker-compose/itwewina/cree-intelligent-dictionary/docker \
+          && docker-compose exec itwewina ./manage.py translatewordforms
+
+    If the process fails partway with a “Database is Locked” error, you can
+    make a copy of the database, run the translation against it, then copy
+    the database back, at the risk of losing any changes made to the
+    production database between the two copies. Currently those lost
+    changes would be limited to user account creation and password updates.

--- a/CreeDictionary/phrase_translate/crk_translate_test.py
+++ b/CreeDictionary/phrase_translate/crk_translate_test.py
@@ -32,7 +32,7 @@ WAPAMEW_DEFINITION = "s/he sees s.o."
             WAPAMEW_DEFINITION,
             "let you and us see him/her now",
         ),
-        ("wâpamêw+V+TA+Imp+Del+2Sg+3PlO", WAPAMEW_DEFINITION, "let you see them later"),
+        ("wâpamêw+V+TA+Imp+Del+2Sg+3PlO", WAPAMEW_DEFINITION, "(you) see them later"),
         (
             "PV/ki+wâpamêw+V+TA+Ind+2Pl+1PlO",
             WAPAMEW_DEFINITION,

--- a/CreeDictionary/phrase_translate/definition_processing.py
+++ b/CreeDictionary/phrase_translate/definition_processing.py
@@ -1,0 +1,39 @@
+### TODO FIXME TEMPORARY
+# This really belongs in the dictionary database model processing code, not the
+# webapp, but is being put here temporarily.
+# https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/709
+
+import re
+
+_RE_UNWANTED_ENDING = re.compile(" (Also|Or|Animate|Inanimate).*")
+_RE_PARENTHETICAL = re.compile(
+    r"""
+    \( # in round brackets
+        (?! # docs: “Matches if ... doesn’t match next”
+            (
+                it/him
+                |it
+                |s\.o\.\ as
+                |s\.t\.(\ as)?
+            )
+        )
+        .*? # anything, but non-greedy
+    \)
+
+    | # or
+
+    \[ # in square brackets:
+        .*? # anything, but non-greedy
+    \]
+    """,
+    re.VERBOSE,
+)
+
+
+def remove_parentheticals(text):
+    text = _RE_UNWANTED_ENDING.sub("", text)
+    text = _RE_PARENTHETICAL.sub("", text)
+    text = text.strip()
+    if text.endswith(";"):
+        text = text[:-1]
+    return text

--- a/CreeDictionary/phrase_translate/definition_processing_test.py
+++ b/CreeDictionary/phrase_translate/definition_processing_test.py
@@ -1,0 +1,32 @@
+import pytest
+
+from phrase_translate.definition_processing import remove_parentheticals
+
+SHOULD_NOT_CHANGE = object()
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ("S/he sees it", SHOULD_NOT_CHANGE),
+        (
+            "He darkens quickly. Animate. E.g. the power went out.",
+            "He darkens quickly.",
+        ),
+        ("Those things. Inanimate.", "Those things."),
+        ("Earth. Also land.", "Earth."),
+        ("He knits. Or he braids.", "He knits."),
+        ("helmet (of metal)", "helmet"),
+        ("timber wolf; [canis lupus]", "timber wolf"),
+        ("s/he opens (it/him) for s.o.", SHOULD_NOT_CHANGE),
+        ("s/he embroiders (it) for people", SHOULD_NOT_CHANGE),
+        ("s/he has (s.o. as) a mother", SHOULD_NOT_CHANGE),
+        ("s/he has (s.t. as) a supply of food", SHOULD_NOT_CHANGE),
+        ("s/he runs to fetch (s.t.)", SHOULD_NOT_CHANGE),
+        ("He (it) turns or goes around. Animate.", "He (it) turns or goes around."),
+    ],
+)
+def test_remove_parentheticals(input, expected):
+    if expected == SHOULD_NOT_CHANGE:
+        expected = input
+    assert remove_parentheticals(input) == expected

--- a/CreeDictionary/res/fst/transcriptor-cw-eng-noun-entry2inflected-phrase-w-flags.fomabin
+++ b/CreeDictionary/res/fst/transcriptor-cw-eng-noun-entry2inflected-phrase-w-flags.fomabin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89fb294bf0edf60ccc660f04a2c8ce5c90a7261ad5948ee4c11343d0e2a28ab4
-size 1096001
+oid sha256:1de002516b24ed4285eb981cbddae251cea84b5aa87cd7e16735e3eeac07105b
+size 682892

--- a/CreeDictionary/res/fst/transcriptor-cw-eng-verb-entry2inflected-phrase-w-flags.fomabin
+++ b/CreeDictionary/res/fst/transcriptor-cw-eng-verb-entry2inflected-phrase-w-flags.fomabin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b8b2de91e52db7e8faf54e1eb21e9a3fe7903bceb0a216a590b05d86ead26a5
-size 3006141
+oid sha256:b944e6d7f194379ec7d82416733d90745b676fd6fe9d194d491d6d3c55bb469f
+size 3030821


### PR DESCRIPTION
This commit:
  - uses the latest phrase translation FSTs from lang-crk
  - updates the tests accordingly
  - removes parenthetical parts of source definitions before attempting
    translation
  - adds a file-only output mode for translatewordforms
  - adds some documentation and throws in something that might prevent the
    “Database is Locked” error