### PR TITLE
refactor: generate_paradigm()

### DIFF
--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -3,17 +3,14 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Literal, Optional
+from typing import Dict, Literal, Optional
 from urllib.parse import quote
 
 from django.db import models, transaction
 from django.db.models import Max, Q
 from django.urls import reverse
 from django.utils.functional import cached_property
-from paradigm import Layout
-from shared import expensive
 from utils import (
-    ParadigmSize,
     PartOfSpeech,
     WordClass,
     fst_analysis_parser,
@@ -118,19 +115,6 @@ class Wordform(models.Model):
             return WordClass(self.pos)
         except ValueError:
             return None
-
-    def get_paradigm_layouts(
-        self, size: ParadigmSize = ParadigmSize.BASIC
-    ) -> List[Layout]:
-        """
-        :param size: How detail the paradigm table is
-        """
-        wc = fst_analysis_parser.extract_word_class(self.analysis)
-        if wc is not None:
-            tables = expensive.paradigm_filler.fill_paradigm(self.text, wc, size)
-        else:
-            tables = []
-        return tables
 
     @property
     def md_only(self) -> bool:

--- a/CreeDictionary/CreeDictionary/generate_paradigm.py
+++ b/CreeDictionary/CreeDictionary/generate_paradigm.py
@@ -1,0 +1,25 @@
+"""
+Handles paradigm generation.
+"""
+
+import shared.expensive
+from paradigm import Layout
+from utils.fst_analysis_parser import extract_word_class
+from utils.enums import ParadigmSize
+from API.models import Wordform
+
+
+def generate_paradigm(lemma: Wordform, size: ParadigmSize) -> list[Layout]:
+    """
+    :param lemma: the lemma of the desired paradigm
+    :param size: the level of detail for the paradigm.
+    :return: A list of filled paradigm tables.
+    """
+    # TODO: is there a better way to determine if this lemma inflects?
+    word_class = extract_word_class(lemma.analysis)
+
+    if word_class is None:
+        # Cannot determine how the the lemma inflects; no paradigm :/
+        return []
+
+    return shared.expensive.paradigm_filler.fill_paradigm(lemma.text, word_class, size)

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -49,11 +49,7 @@ def lemma_details(request, lemma_text: str):
     if additional_filters := disambiguating_filter_from_query_params(request.GET):
         lemma = lemma.filter(**additional_filters)
 
-    paradigm_size = request.GET.get("paradigm-size")
-    if paradigm_size is None:
-        paradigm_size = ParadigmSize.BASIC
-    else:
-        paradigm_size = ParadigmSize(paradigm_size.upper())
+    paradigm_size = ParadigmSize.from_string(request.GET.get("paradigm-size"))
 
     if lemma.count() == 1:
         lemma = lemma.get()

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -51,24 +51,25 @@ def lemma_details(request, lemma_text: str):
 
     paradigm_size = ParadigmSize.from_string(request.GET.get("paradigm-size"))
 
-    if lemma.count() == 1:
-        lemma = lemma.get()
-        context = create_context_for_index_template(
-            "word-detail",
-            # TODO: rename this to wordform ID
-            lemma_id=lemma.id,
-            # TODO: remove this parameter in favour of...
-            lemma=lemma,
-            # ...this parameter
-            wordform=presentation.serialize_wordform(lemma),
-            paradigm_size=paradigm_size,
-            paradigm_tables=lemma.get_paradigm_layouts(size=paradigm_size)
-            if lemma
-            else None,
-        )
-        return HttpResponse(render(request, "CreeDictionary/index.html", context))
-    else:
+    if lemma.count() != 1:
+        # The result is either empty or ambiguous; either way, do a search!
         return redirect(url_for_query(lemma_text or ""))
+
+    lemma = lemma.get()
+    context = create_context_for_index_template(
+        "word-detail",
+        # TODO: rename this to wordform ID
+        lemma_id=lemma.id,
+        # TODO: remove this parameter in favour of...
+        lemma=lemma,
+        # ...this parameter
+        wordform=presentation.serialize_wordform(lemma),
+        paradigm_size=paradigm_size,
+        paradigm_tables=lemma.get_paradigm_layouts(size=paradigm_size)
+        if lemma
+        else None,
+    )
+    return HttpResponse(render(request, "CreeDictionary/index.html", context))
 
 
 def index(request):  # pragma: no cover

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -45,17 +45,15 @@ def lemma_details(request, lemma_text: str):
     """
 
     lemma = Wordform.objects.filter(text=lemma_text, is_lemma=True)
-
     if additional_filters := disambiguating_filter_from_query_params(request.GET):
         lemma = lemma.filter(**additional_filters)
-
-    paradigm_size = ParadigmSize.from_string(request.GET.get("paradigm-size"))
 
     if lemma.count() != 1:
         # The result is either empty or ambiguous; either way, do a search!
         return redirect(url_for_query(lemma_text or ""))
 
     lemma = lemma.get()
+    paradigm_size = ParadigmSize.from_string(request.GET.get("paradigm-size"))
     context = create_context_for_index_template(
         "word-detail",
         # TODO: rename this to wordform ID

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -294,6 +294,7 @@ def should_include_auto_definitions(request):
     # For now, show auto-translations if and only if the user is logged in
     return request.user.is_authenticated
 
+
 def disambiguating_filter_from_query_params(query_params: dict[str, str]):
     """
     Sometimes wordforms may have the same text (a.k.a., be homographs/homophones),

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -24,16 +24,26 @@ IndexPageMode = Literal["home-page", "search-page", "word-detail", "info-page"]
 # it should be used on the view functions that are well covered by integration tests
 
 
-def lemma_details(request, lemma_text: str = None):  # pragma: no cover
+def lemma_details(request, lemma_text: str = None):
     """
-    lemma detail page. Fall back to search page if no lemma is found or multiple lemmas are found
+    Head word detail page. Will render a paradigm, if applicable. Fall back to search page if no lemma is found or multiple lemmas are found
 
-    possible query params are "pos"/"inflectional_category"/"analysis"/"id" to further specify the lemma,
-    "paradigm-size" (default is BASIC) to specify the size of the paradigm
+    Possible query params:
+
+      To disambiguate the head word (see: Wordform.homograph_disambiguator):
+        - pos
+        - inflectional_category
+        - analysis
+        - id
+
+      To affect the paradigm size:
+
+        - paradigm-size (default is BASIC) to specify the size of the paradigm
 
     :param request: accepts query params `pos` `inflectional_category` `analysis` `id` to further specify query_string
     :param lemma_text: the exact form of the lemma (no spell relaxation)
     """
+
     extra_constraints = {
         k: v
         for k, v in request.GET.items()

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -63,9 +63,7 @@ def lemma_details(request, lemma_text: str):
         # ...this parameter
         wordform=presentation.serialize_wordform(lemma),
         paradigm_size=paradigm_size,
-        paradigm_tables=lemma.get_paradigm_layouts(size=paradigm_size)
-        if lemma
-        else None,
+        paradigm_tables=lemma.get_paradigm_layouts(size=paradigm_size),
     )
     return HttpResponse(render(request, "CreeDictionary/index.html", context))
 

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -11,8 +11,9 @@ from django.views.decorators.http import require_GET
 from utils import ParadigmSize
 
 from CreeDictionary.forms import WordSearchForm
+from CreeDictionary.generate_paradigm import generate_paradigm
 
-from .display_options import DISPLAY_MODES, DISPLAY_MODE_COOKIE
+from .display_options import DISPLAY_MODE_COOKIE, DISPLAY_MODES
 from .utils import url_for_query
 
 # The index template expects to be rendered in the following "modes";
@@ -63,7 +64,7 @@ def lemma_details(request, lemma_text: str):
         # ...this parameter
         wordform=presentation.serialize_wordform(lemma),
         paradigm_size=paradigm_size,
-        paradigm_tables=lemma.get_paradigm_layouts(size=paradigm_size),
+        paradigm_tables=generate_paradigm(lemma, paradigm_size),
     )
     return HttpResponse(render(request, "CreeDictionary/index.html", context))
 
@@ -166,7 +167,7 @@ def paradigm_internal(request):
         {
             "lemma": lemma,
             "paradigm_size": paradigm_size.value,
-            "paradigm_tables": lemma.get_paradigm_layouts(size=paradigm_size),
+            "paradigm_tables": generate_paradigm(lemma, paradigm_size),
         },
     )
 

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -24,7 +24,7 @@ IndexPageMode = Literal["home-page", "search-page", "word-detail", "info-page"]
 # it should be used on the view functions that are well covered by integration tests
 
 
-def lemma_details(request, lemma_text: str = None):
+def lemma_details(request, lemma_text: str):
     """
     Head word detail page. Will render a paradigm, if applicable. Fall back to search page if no lemma is found or multiple lemmas are found
 
@@ -44,14 +44,10 @@ def lemma_details(request, lemma_text: str = None):
     :param lemma_text: the exact form of the lemma (no spell relaxation)
     """
 
-    lemma = Wordform.objects.filter(is_lemma=True)
-
-    if lemma_text:
-        # TODO: is lemma_text really allowed to be blank?
-        lemma = lemma.filter(text=lemma_text)
+    lemma = Wordform.objects.filter(text=lemma_text, is_lemma=True)
 
     if additional_filters := disambiguating_filter_from_query_params(request.GET):
-        lemma = lemma.filter(additional_filters)
+        lemma = lemma.filter(**additional_filters)
 
     paradigm_size = request.GET.get("paradigm-size")
     if paradigm_size is None:

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -1,16 +1,12 @@
 import json
-from typing import List
 
 import pytest
-from CreeDictionary.generate_paradigm import generate_paradigm
 from hypothesis import assume, given
 
 from API.models import Wordform
 from API.search import search
 from API.search.util import to_sro_circumflex
-from paradigm import EmptyRowType, InflectionCell, Layout, TitleRow
 from tests.conftest import lemmas
-from utils import ParadigmSize
 
 
 @pytest.mark.django_db
@@ -185,31 +181,6 @@ def test_search_space_characters_in_matched_term(term):
     # Now try searching for it:
     cree_results = search(query=term).presentation_results()
     assert len(cree_results) > 0
-
-
-def _paradigms_contain_inflection(paradigms: List[Layout], inflection: str) -> bool:
-    for paradigm in paradigms:
-        for row in paradigm:
-            if isinstance(row, (EmptyRowType, TitleRow)):
-                continue
-            for cell in row:
-                if isinstance(cell, InflectionCell) and cell.inflection == inflection:
-                    return True
-    return False
-
-
-@pytest.mark.django_db
-def test_paradigm():
-    """
-    Test we can generate a paradigm from a given lemma.
-    """
-
-    nipaw = Wordform.objects.get(text="nipâw", is_lemma=True)
-    nipaw_paradigm = generate_paradigm(nipaw, ParadigmSize.BASIC)
-    assert _paradigms_contain_inflection(nipaw_paradigm, "ninipân")
-    assert _paradigms_contain_inflection(nipaw_paradigm, "kinipân")
-    assert _paradigms_contain_inflection(nipaw_paradigm, "nipâw")
-    assert _paradigms_contain_inflection(nipaw_paradigm, "ninipânân")
 
 
 @pytest.mark.django_db

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -2,6 +2,7 @@ import json
 from typing import List
 
 import pytest
+from CreeDictionary.generate_paradigm import generate_paradigm
 from hypothesis import assume, given
 
 from API.models import Wordform
@@ -9,6 +10,7 @@ from API.search import search
 from API.search.util import to_sro_circumflex
 from paradigm import EmptyRowType, InflectionCell, Layout, TitleRow
 from tests.conftest import lemmas
+from utils import ParadigmSize
 
 
 @pytest.mark.django_db
@@ -198,10 +200,12 @@ def _paradigms_contain_inflection(paradigms: List[Layout], inflection: str) -> b
 
 @pytest.mark.django_db
 def test_paradigm():
+    """
+    Test we can generate a paradigm from a given lemma.
+    """
 
-    nipaw_paradigm = Wordform.objects.get(
-        text="nipâw", is_lemma=True
-    ).get_paradigm_layouts()
+    nipaw = Wordform.objects.get(text="nipâw", is_lemma=True)
+    nipaw_paradigm = generate_paradigm(nipaw, ParadigmSize.BASIC)
     assert _paradigms_contain_inflection(nipaw_paradigm, "ninipân")
     assert _paradigms_contain_inflection(nipaw_paradigm, "kinipân")
     assert _paradigms_contain_inflection(nipaw_paradigm, "nipâw")

--- a/CreeDictionary/tests/CreeDictionary_tests/test_paradigm_generation.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_paradigm_generation.py
@@ -5,13 +5,16 @@ from paradigm import Layout, EmptyRowType, TitleRow, InflectionCell
 from utils import ParadigmSize
 
 
-@pytest.mark.parametrize("lemma,examples", [
-    # VAI
-    ("nipâw", ["nipâw", "ninipân", "kinipân",  "ninipânân"]),
-    # VTA
-    ("wâpamêw", ["wâpamêw", "niwâpamâw", "kiwâpamitin",  "ê-wâpamât"]),
-    # TODO: other word classes
-])
+@pytest.mark.parametrize(
+    "lemma,examples",
+    [
+        # VAI
+        ("nipâw", ["nipâw", "ninipân", "kinipân", "ninipânân"]),
+        # VTA
+        ("wâpamêw", ["wâpamêw", "niwâpamâw", "kiwâpamitin", "ê-wâpamât"]),
+        # TODO: other word classes
+    ],
+)
 @pytest.mark.django_db
 def test_paradigm(lemma: str, examples: list[str]):
     """

--- a/CreeDictionary/tests/CreeDictionary_tests/test_paradigm_generation.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_paradigm_generation.py
@@ -1,18 +1,30 @@
 import pytest
-from CreeDictionary.generate_paradigm import generate_paradigm
 from API.models import Wordform
-from paradigm import Layout, EmptyRowType, TitleRow, InflectionCell
+from paradigm import EmptyRowType, InflectionCell, Layout, TitleRow
 from utils import ParadigmSize
+
+from CreeDictionary.generate_paradigm import generate_paradigm
 
 
 @pytest.mark.parametrize(
     "lemma,examples",
     [
-        # VAI
-        ("nipâw", ["nipâw", "ninipân", "kinipân", "ninipânân"]),
         # VTA
         ("wâpamêw", ["wâpamêw", "niwâpamâw", "kiwâpamitin", "ê-wâpamât"]),
-        # TODO: other word classes
+        # VAI
+        ("nipâw", ["nipâw", "ninipân", "kinipân", "ninipânân"]),
+        # VTI
+        ("mîcisow", ["mîcisow", "nimîcison", "kimîcison", "ê-mîcisoyit"]),
+        # VII
+        ("nîpin", ["nîpin", "nîpin", "ê-nîpihk"]),
+        # NAD
+        ("nôhkom", ["nôhkom", "kôhkom", "ohkoma"]),
+        # NID
+        ("mîpit", ["mîpit", "nîpit", "kîpit", "wîpit"]),
+        # NA
+        ("minôs", ["minôs", "minôsak", "minôsa"]),
+        # NI
+        ("nipiy", ["nipiy", "nipîhk", "ninipiy", "kinipiy"]),
     ],
 )
 @pytest.mark.django_db

--- a/CreeDictionary/tests/CreeDictionary_tests/test_paradigm_generation.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_paradigm_generation.py
@@ -5,17 +5,22 @@ from paradigm import Layout, EmptyRowType, TitleRow, InflectionCell
 from utils import ParadigmSize
 
 
+@pytest.mark.parametrize("lemma,examples", [
+    # VAI
+    ("nipâw", ["nipâw", "ninipân", "kinipân",  "ninipânân"]),
+    # VTA
+    ("wâpamêw", ["wâpamêw", "niwâpamâw", "kiwâpamitin",  "ê-wâpamât"]),
+    # TODO: other word classes
+])
 @pytest.mark.django_db
-def test_paradigm():
+def test_paradigm(lemma: str, examples: list[str]):
     """
     Test we can generate a paradigm from a given lemma.
     """
-    nipaw = Wordform.objects.get(text="nipâw", is_lemma=True)
-    nipaw_paradigm = generate_paradigm(nipaw, ParadigmSize.BASIC)
-    assert paradigms_contain_inflection(nipaw_paradigm, "ninipân")
-    assert paradigms_contain_inflection(nipaw_paradigm, "kinipân")
-    assert paradigms_contain_inflection(nipaw_paradigm, "nipâw")
-    assert paradigms_contain_inflection(nipaw_paradigm, "ninipânân")
+    wordform = Wordform.objects.get(text=lemma, is_lemma=True)
+    paradigms = generate_paradigm(wordform, ParadigmSize.BASIC)
+    for inflection in examples:
+        assert paradigms_contain_inflection(paradigms, inflection)
 
 
 def paradigms_contain_inflection(paradigms: list[Layout], inflection: str) -> bool:

--- a/CreeDictionary/tests/CreeDictionary_tests/test_paradigm_generation.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_paradigm_generation.py
@@ -1,0 +1,29 @@
+import pytest
+from CreeDictionary.generate_paradigm import generate_paradigm
+from API.models import Wordform
+from paradigm import Layout, EmptyRowType, TitleRow, InflectionCell
+from utils import ParadigmSize
+
+
+@pytest.mark.django_db
+def test_paradigm():
+    """
+    Test we can generate a paradigm from a given lemma.
+    """
+    nipaw = Wordform.objects.get(text="nipâw", is_lemma=True)
+    nipaw_paradigm = generate_paradigm(nipaw, ParadigmSize.BASIC)
+    assert paradigms_contain_inflection(nipaw_paradigm, "ninipân")
+    assert paradigms_contain_inflection(nipaw_paradigm, "kinipân")
+    assert paradigms_contain_inflection(nipaw_paradigm, "nipâw")
+    assert paradigms_contain_inflection(nipaw_paradigm, "ninipânân")
+
+
+def paradigms_contain_inflection(paradigms: list[Layout], inflection: str) -> bool:
+    for paradigm in paradigms:
+        for row in paradigm:
+            if isinstance(row, (EmptyRowType, TitleRow)):
+                continue
+            for cell in row:
+                if isinstance(cell, InflectionCell) and cell.inflection == inflection:
+                    return True
+    return False

--- a/CreeDictionary/utils/enums.py
+++ b/CreeDictionary/utils/enums.py
@@ -1,10 +1,20 @@
+from __future__ import annotations
+
 from enum import Enum
+from typing import Optional
 
 
 class ParadigmSize(Enum):
     BASIC = "BASIC"
     FULL = "FULL"
+    # TODO: "Linguistic" isn't a size...
     LINGUISTIC = "LINGUISTIC"
+
+    @classmethod
+    def from_string(cls, value: Optional[str]) -> ParadigmSize:
+        if not value:
+            return cls.BASIC
+        return cls(value.upper())
 
 
 class PartOfSpeech(Enum):


### PR DESCRIPTION
# What's in this PR?

 - replaces `Wordform.get_paradigm_layouts()` with `generate_paradigm()`: this will make it easier to display "canned" paradigms #127
 - ~~start to write tests for more than one word class. I should add more classes, but I think I'll do that after lunch!~~ tests for most import inflecting word classes in nêhiyawêwin
 - simplify "word details" view function
 - shift responsibility of "getting paradigm size from string" to `ParadigmSize` enum. I have a plan on how to axe the "size" called "LINGUISTIC" 

# Why is this PR?

I want to start tackling the following paradigm-related business:
 - "canned" paradigms (#127) 
 - choose different labels in the paradigm (e.g., between Plain English, nêhiyawêwin, and linguistic labels) #743
 - the ever fabled "paradigm" panes feature

This PR helps me get my hands dirty in the paradigm code!

--- 

Part one of a series of PRs to embetter paradigm generation.
