### PR TITLE
Add featuredump manage command

### DIFF
--- a/CreeDictionary/API/migrations/0004_more_wordform_indexes.py
+++ b/CreeDictionary/API/migrations/0004_more_wordform_indexes.py
@@ -6,12 +6,12 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('API', '0003_wordform_indexes'),
+        ("API", "0003_wordform_indexes"),
     ]
 
     operations = [
         migrations.AddIndex(
-            model_name='wordform',
-            index=models.Index(fields=['is_lemma', 'text'], name='lemma_text_idx'),
+            model_name="wordform",
+            index=models.Index(fields=["is_lemma", "text"], name="lemma_text_idx"),
         ),
     ]

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Literal, Optional
+from typing import Dict, Optional, Union
+from typing import Literal
 from urllib.parse import quote
 
 from django.db import models, transaction
 from django.db.models import Max, Q
 from django.urls import reverse
 from django.utils.functional import cached_property
+
+from CreeDictionary.relabelling import LABELS
 from utils import (
     PartOfSpeech,
     WordClass,
@@ -17,9 +20,7 @@ from utils import (
     shared_res_dir,
 )
 from utils.cree_lev_dist import remove_cree_diacritics
-from CreeDictionary.relabelling import LABELS
 from utils.types import FSTTag
-
 from .schema import SerializedDefinition
 
 # Don't start evicting cache entries until we've seen over this many unique definitions:
@@ -36,6 +37,10 @@ class WordformLemmaManager(models.Manager):
 
     def get_queryset(self):
         return super().get_queryset().select_related("lemma")
+
+
+# This type is the int pk for a saved wordform, or (text, analysis) for an unsaved one.
+WordformKey = Union[int, tuple[str, str]]
 
 
 class Wordform(models.Model):
@@ -115,6 +120,16 @@ class Wordform(models.Model):
             return WordClass(self.pos)
         except ValueError:
             return None
+
+    @property
+    def key(self) -> WordformKey:
+        """A value to check if objects represent the ‘same’ wordform
+
+        Works even if the objects are unsaved.
+        """
+        if self.id is not None:
+            return self.id
+        return (self.text, self.analysis)
 
     # override pk to allow use of bulk_create
     # auto-increment is also implemented in the overridden save() method below

--- a/CreeDictionary/API/models.py
+++ b/CreeDictionary/API/models.py
@@ -3,16 +3,13 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Optional, Union
-from typing import Literal
+from typing import Dict, Literal, Optional, Union
 from urllib.parse import quote
 
 from django.db import models, transaction
 from django.db.models import Max, Q
 from django.urls import reverse
 from django.utils.functional import cached_property
-
-from CreeDictionary.relabelling import LABELS
 from utils import (
     PartOfSpeech,
     WordClass,
@@ -20,7 +17,9 @@ from utils import (
     shared_res_dir,
 )
 from utils.cree_lev_dist import remove_cree_diacritics
+from CreeDictionary.relabelling import LABELS
 from utils.types import FSTTag
+
 from .schema import SerializedDefinition
 
 # Don't start evicting cache entries until we've seen over this many unique definitions:

--- a/CreeDictionary/API/search/core.py
+++ b/CreeDictionary/API/search/core.py
@@ -1,20 +1,9 @@
-from typing import Union
-
 from django.db.models import prefetch_related_objects
 
-from API.models import Wordform
 from . import types, presentation, ranking
 from .query import Query
 from .util import first_non_none_value
-
-# This type is the int pk for a saved wordform, or (text, analysis) for an unsaved one.
-WordformKey = Union[int, tuple[str, str]]
-
-
-def _wordform_key(wordform: Wordform) -> WordformKey:
-    if wordform.id is not None:
-        return wordform.id
-    return (wordform.text, wordform.analysis)
+from ..models import WordformKey
 
 
 class SearchRun:
@@ -40,7 +29,7 @@ class SearchRun:
     def add_result(self, result: types.Result):
         if not isinstance(result, types.Result):
             raise TypeError(f"{result} is {type(result)}, not Result")
-        key = _wordform_key(result.wordform)
+        key = result.wordform.key
         if key in self._results:
             self._results[key].add_features_from(result)
         else:

--- a/CreeDictionary/API/search/core.py
+++ b/CreeDictionary/API/search/core.py
@@ -35,9 +35,13 @@ class SearchRun:
         else:
             self._results[key] = result
 
-    def presentation_results(self) -> list[presentation.PresentationResult]:
+    def sorted_results(self) -> list[types.Result]:
         results = list(self._results.values())
         results.sort(key=ranking.sort_by_user_query(self))
+        return results
+
+    def presentation_results(self) -> list[presentation.PresentationResult]:
+        results = self.sorted_results()
         try:
             prefetch_related_objects(
                 [r.wordform for r in results],

--- a/CreeDictionary/API/search/lookup.py
+++ b/CreeDictionary/API/search/lookup.py
@@ -157,7 +157,7 @@ def fetch_results(search_run: core.SearchRun):
 
         for wordform in Wordform.objects.filter(id__in=lemma_ids):
             search_run.add_result(
-                Result(wordform, target_language_keyword_match=stemmed_keyword)
+                Result(wordform, target_language_keyword_match=[stemmed_keyword])
             )
 
         # explained above, preverbs should be presented

--- a/CreeDictionary/API/search/types.py
+++ b/CreeDictionary/API/search/types.py
@@ -138,7 +138,7 @@ class Result:
         """
         assert self.wordform.key == other.wordform.key
 
-        for field_name, other_value in other._features():
+        for field_name, other_value in other.features().items():
             if other_value is not None:
                 self_value = getattr(self, field_name)
                 # combine lists, applying uniq
@@ -173,18 +173,18 @@ class Result:
 
     morpheme_ranking: Optional[float] = None
 
-    def _features(self):
+    def features(self):
+        ret = {}
         for field in dataclasses.fields(Result):
             if field.name not in ["wordform", "lemma_wordform"]:
-                yield field.name, getattr(self, field.name)
+                value = getattr(self, field.name)
+                if value is not None:
+                    ret[field.name] = value
+        return ret
 
     def features_json(self):
         return json.dumps(
-            {
-                field_name: value
-                for field_name, value in self._features()
-                if value is not None
-            },
+            self.features(),
             ensure_ascii=False,
             indent=2,
         )

--- a/CreeDictionary/API/search/types.py
+++ b/CreeDictionary/API/search/types.py
@@ -4,7 +4,7 @@ import dataclasses
 import json
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Union, NewType, Iterable, Tuple, Optional
+from typing import NewType, Iterable, Tuple, Optional
 
 from typing_extensions import Protocol
 
@@ -87,16 +87,6 @@ class Language(Enum):
     TARGET = "Target"
 
 
-def wordforms_match(w1: Wordform, w2: Wordform) -> bool:
-    """Return whether two wordform objects represent the same wordform
-
-    Either they both have IDs which match, or the text and analysis match.
-    """
-    if w1.id is not None or w2.id is not None:
-        return w1.id == w2.id
-    return w1.text == w2.text and w1.analysis == w2.analysis
-
-
 @dataclass
 class Result:
     """
@@ -146,11 +136,16 @@ class Result:
         features from a different result object for the same wordform into the
         current object.
         """
-        assert wordforms_match(self.wordform, other.wordform)
+        assert self.wordform.key == other.wordform.key
 
         for field_name, other_value in other._features():
             if other_value is not None:
-                setattr(self, field_name, other_value)
+                self_value = getattr(self, field_name)
+                # combine lists, applying uniq
+                if isinstance(self_value, list):
+                    self_value[:] = list(set(self_value + other_value))
+                else:
+                    setattr(self, field_name, other_value)
 
     wordform: Wordform
     lemma_wordform: Lemma = field(init=False)
@@ -164,7 +159,7 @@ class Result:
     source_language_affix_match: Optional[bool] = None
     target_language_affix_match: Optional[bool] = None
 
-    target_language_keyword_match: Optional[str] = None
+    target_language_keyword_match: list[str] = field(default_factory=list)
     pronoun_as_is_match: Optional[bool] = None
 
     analyzable_inflection_match: Optional[bool] = None
@@ -197,9 +192,8 @@ class Result:
     #: Was anything in the query a source-language match for this result?
     @property
     def did_match_source_language(self) -> bool:
-        return (
-            self.source_language_match is not None
-            or self.source_language_affix_match is not None
+        return bool(
+            self.source_language_match or self.source_language_affix_match is not None
         )
 
     def __str__(self):

--- a/CreeDictionary/search_quality/__init__.py
+++ b/CreeDictionary/search_quality/__init__.py
@@ -14,3 +14,5 @@ SampleSearchResultsJson = dict[str, SearchResult]
 
 RESULTS_DIR = Path(__file__).parent / "sample_results"
 DEFAULT_SAMPLE_FILE = Path(__file__).parent / "sample.csv"
+
+SURVEY_DIR = Path(__file__).parent / "survey_results"

--- a/CreeDictionary/search_quality/management/commands/featuredump.py
+++ b/CreeDictionary/search_quality/management/commands/featuredump.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
             survey = survey_collection.combined_results_for(query)
             top3 = survey[:3]
 
-            results = search(query=f"verbose:1 cvd:1 {query}")._results.values()
+            results = search(query=f"verbose:1 cvd:1 {query}").sorted_results()
             try:
                 prefetch_related_objects(
                     [r.wordform for r in results], "definitions__citations"
@@ -48,7 +48,7 @@ class Command(BaseCommand):
             for i, r in enumerate(results):
                 ret = json.loads(r.features_json())
                 ret["query"] = query
-                ret["candidate_number"] = i
+                ret["main_branch_sort_rank"] = i + 1
                 ret["wordform_text"] = r.wordform.text
                 ret["definitions"] = [
                     [d.text, ", ".join(c.abbrv for c in d.citations.all())]

--- a/CreeDictionary/search_quality/management/commands/featuredump.py
+++ b/CreeDictionary/search_quality/management/commands/featuredump.py
@@ -1,21 +1,30 @@
 import json
 import random
 from argparse import ArgumentParser, BooleanOptionalAction
+from contextlib import closing, contextmanager
 
+import sys
 from django.core.management import BaseCommand
 from django.db.models import prefetch_related_objects
 from tqdm import tqdm
 
 from API.search import search
 from ... import DEFAULT_SAMPLE_FILE
-from ...combine_samples import SurveyCollection
 from ...sample import load_sample_definition
 
 
 class Command(BaseCommand):
+    help = """Run search queries from survey, dumping JSON of features"""
+
     def add_arguments(self, parser: ArgumentParser):
         parser.add_argument("--csv-file", default=DEFAULT_SAMPLE_FILE)
+        parser.add_argument(
+            "--prefix-queries-with",
+            default="",
+            help="String to include in every; see the fancy queries help page for suggestions",
+        )
         parser.add_argument("--max", type=int, help="Only run this many queries")
+        parser.add_argument("--output-file", help="Only run this many queries")
         parser.add_argument(
             "--shuffle",
             action=BooleanOptionalAction,
@@ -29,34 +38,44 @@ class Command(BaseCommand):
         if options["max"] is not None:
             samples = samples[: options["max"]]
 
-        survey_collection = SurveyCollection()
+        with output_file(options["output_file"]) as out:
+            # Only display progress bar if output is redirected
+            if not out.isatty():
+                samples = tqdm(samples)
 
-        for entry in tqdm(samples):
-            query = entry["Query"]
+            for entry in samples:
+                query = entry["Query"]
 
-            survey = survey_collection.combined_results_for(query)
-            top3 = survey[:3]
-
-            results = search(query=f"verbose:1 cvd:1 {query}").sorted_results()
-            try:
+                results = search(
+                    query=f"verbose:1 {options['prefix_queries_with']} {query}"
+                ).sorted_results()
                 prefetch_related_objects(
                     [r.wordform for r in results], "definitions__citations"
                 )
-            except AttributeError:
-                # seems to be a django bug?
-                pass
-            for i, r in enumerate(results):
-                ret = json.loads(r.features_json())
-                ret["query"] = query
-                ret["main_branch_sort_rank"] = i + 1
-                ret["wordform_text"] = r.wordform.text
-                ret["definitions"] = [
-                    [d.text, ", ".join(c.abbrv for c in d.citations.all())]
-                    for d in r.wordform.definitions.all()
-                ]
-                ret["lemma_wordform"] = r.wordform.lemma.text
-                ret["keyword_match_len"] = len(r.target_language_keyword_match)
-                ret["is_lemma"] = 1 if r.is_lemma else 0
-                ret["is_top3"] = r.wordform.text in top3
-                ret["is_in_survey"] = r.wordform.text in survey
-                print(json.dumps(ret, ensure_ascii=False))
+                for i, r in enumerate(results):
+                    ret = r.features()
+                    ret["query"] = query
+                    ret["wordform_text"] = r.wordform.textq
+                    ret["lemma_wordform_text"] = r.wordform.lemma.text
+                    ret["definitions"] = [
+                        [d.text, ", ".join(c.abbrv for c in d.citations.all())]
+                        for d in r.wordform.definitions.all()
+                        if d.auto_translation_source_id is None
+                    ]
+                    ret["webapp_sort_rank"] = i + 1
+                    print(json.dumps(ret, ensure_ascii=False), file=out)
+
+
+@contextmanager
+def output_file(filename):
+    """Context manager that yields an open file, defaulting to sys.stdout"""
+    ret = sys.stdout
+    should_close = False
+    if filename:
+        ret = open(filename, "w")
+        should_close = True
+    try:
+        yield ret
+    finally:
+        if should_close:
+            ret.close()

--- a/CreeDictionary/search_quality/management/commands/featuredump.py
+++ b/CreeDictionary/search_quality/management/commands/featuredump.py
@@ -1,0 +1,38 @@
+import json
+import random
+from argparse import ArgumentParser, BooleanOptionalAction
+
+from django.core.management import BaseCommand
+
+from API.search import search
+from ... import DEFAULT_SAMPLE_FILE
+from ...sample import load_sample_definition
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser: ArgumentParser):
+        parser.add_argument("--csv-file", default=DEFAULT_SAMPLE_FILE)
+        parser.add_argument("--max", type=int, help="Only run this many queries")
+        parser.add_argument(
+            "--shuffle",
+            action=BooleanOptionalAction,
+            help="Shuffle sample before running, useful with --max",
+        )
+
+    def handle(self, *args, **options):
+        samples = load_sample_definition(options["csv_file"])
+        if options["shuffle"]:
+            random.shuffle(samples)
+        if options["max"] is not None:
+            samples = samples[:max]
+
+        for entry in samples:
+            query = entry["Query"]
+            for i, r in enumerate(search(query=f"verbose:1 {query}")._results.values()):
+                ret = json.loads(r.features_json())
+                ret["query"] = query
+                ret["candidate_number"] = i
+                ret["wordform_text"] = r.wordform.text
+                ret["lemma_wordform"] = r.wordform.lemma.text
+                ret["is_lemma"] = 1 if r.is_lemma else 0
+                print(json.dumps(ret, ensure_ascii=False))

--- a/CreeDictionary/search_quality/management/commands/featuredump.py
+++ b/CreeDictionary/search_quality/management/commands/featuredump.py
@@ -3,9 +3,12 @@ import random
 from argparse import ArgumentParser, BooleanOptionalAction
 
 from django.core.management import BaseCommand
+from django.db.models import prefetch_related_objects
+from tqdm import tqdm
 
 from API.search import search
 from ... import DEFAULT_SAMPLE_FILE
+from ...combine_samples import SurveyCollection
 from ...sample import load_sample_definition
 
 
@@ -24,15 +27,36 @@ class Command(BaseCommand):
         if options["shuffle"]:
             random.shuffle(samples)
         if options["max"] is not None:
-            samples = samples[:max]
+            samples = samples[: options["max"]]
 
-        for entry in samples:
+        survey_collection = SurveyCollection()
+
+        for entry in tqdm(samples):
             query = entry["Query"]
-            for i, r in enumerate(search(query=f"verbose:1 {query}")._results.values()):
+
+            survey = survey_collection.combined_results_for(query)
+            top3 = survey[:3]
+
+            results = search(query=f"verbose:1 cvd:1 {query}")._results.values()
+            try:
+                prefetch_related_objects(
+                    [r.wordform for r in results], "definitions__citations"
+                )
+            except AttributeError:
+                # seems to be a django bug?
+                pass
+            for i, r in enumerate(results):
                 ret = json.loads(r.features_json())
                 ret["query"] = query
                 ret["candidate_number"] = i
                 ret["wordform_text"] = r.wordform.text
+                ret["definitions"] = [
+                    [d.text, ", ".join(c.abbrv for c in d.citations.all())]
+                    for d in r.wordform.definitions.all()
+                ]
                 ret["lemma_wordform"] = r.wordform.lemma.text
+                ret["keyword_match_len"] = len(r.target_language_keyword_match)
                 ret["is_lemma"] = 1 if r.is_lemma else 0
+                ret["is_top3"] = r.wordform.text in top3
+                ret["is_in_survey"] = r.wordform.text in survey
                 print(json.dumps(ret, ensure_ascii=False))


### PR DESCRIPTION
The featuredump command runs searches for all the queries in the survey file, and writes out JSONL of the features, just like what you see with `verbose:1`. This allows bulk-loading search results into Jupyter for analysis and modelling.

Also includes a few semi-related things, which can be split into separate PRs if desired:
  - Converts `target_language_keyword_match` feature into a list, so that multiple keyword hits are remembered
  - Apply `black` to a migration file that PyCharm keeps re-editing. I know that `pyproject.toml` has a section to disable black for migrations, but PyCharm doesn’t seem to be following that.
  - Some refactoring to the search survey stuff