### PR TITLE
feat: convert current layouts to pane-based layouts

### DIFF
--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -99,8 +99,10 @@ class Command(BaseCommand):
                         new_cell = InflectionCell(analysis.template)
                     else:
                         new_cell = MissingForm()
-                elif cell.is_label:
+                elif cell.is_label or hasattr(cell, "text"):
                     new_cell = self.cell_template_from_text(cell.text, first_cell)
+                else:
+                    raise AssertionError("Not sure what type this is")
                 cells.append(new_cell)
                 first_cell = False
 

--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Converts all loaded paradigm templates and outputs them in the pane-style template.
 
@@ -12,8 +14,170 @@ from pathlib import Path
 from django.core.management import BaseCommand
 from utils import ParadigmSize, WordClass, shared_res_dir  # type: ignore
 
+from CreeDictionary.paradigm.filler import EmptyRow, TitleRow  # type: ignore
 from CreeDictionary.paradigm.generation import paradigm_filler  # type: ignore
 from CreeDictionary.relabelling import LABELS, _LabelFriendliness  # type: ignore
+
+
+class ErrorOnStr(str):
+    def __str__(self):
+        raise TypeError("Cannot render string")
+
+
+def identity(x):
+    return x
+
+
+class CellTemplate:
+    is_label: bool = False
+    is_inflection: bool = False
+    is_empty = bool = False
+
+
+class InflectionCellTemplate(CellTemplate):
+    is_inflection = True
+
+    def __init__(self, analysis: str):
+        self.analysis = analysis
+        assert "{{lemma}}" in analysis or "+" in analysis
+
+    def __str__(self):
+        return self.analysis
+
+
+class MissingForm(InflectionCellTemplate):
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return "--"
+
+
+class EmptyCellType(CellTemplate):
+    is_empty = True
+
+    def __new__(cls) -> EmptyCellType:
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __str__(self):
+        return ""
+
+    def __repr__(self):
+        return "EmptyCell"
+
+
+EmptyCell = EmptyCellType()
+del EmptyCellType
+
+
+class BaseLabelCell(CellTemplate):
+    is_label = True
+    label_for: str = ErrorOnStr()
+    prefix: str = ErrorOnStr()
+
+
+class LabelFromTagMixin(BaseLabelCell):
+    def __init__(self, tags):
+        self._tags = tags
+
+    def __str__(self):
+        return " ".join(f"{self.prefix} {tag}" for tag in self._tags)
+
+
+class UnknownLabelTagMixin(BaseLabelCell):
+    def __init__(self, original: str):
+        self.original = original
+
+    def __str__(self):
+        return f"{self.prefix} <!{self.original}!>"
+
+
+class BaseRowLabel(BaseLabelCell):
+    label_for = "row"
+    prefix = "_"
+
+
+class BaseColumnLabel(BaseLabelCell):
+    label_for = "column"
+    prefix = "|"
+
+
+class RowLabel(BaseRowLabel, LabelFromTagMixin):
+    ...
+
+
+class ColumnLabel(BaseColumnLabel, LabelFromTagMixin):
+    ...
+
+
+class UnknownRowLabel(BaseRowLabel, UnknownLabelTagMixin):
+    ...
+
+
+class UnknownColumnLabel(BaseColumnLabel, UnknownLabelTagMixin):
+    ...
+
+
+class RowTemplate:
+    def __init__(self, cells: list[CellTemplate]):
+        self._cells = tuple(cells)
+
+    def cells(self):
+        yield from self._cells
+
+    def __str__(self):
+        return "\t".join(str(cell) for cell in self.cells())
+
+
+class HeaderRow(RowTemplate):
+    def __init__(self, tags_or_header):
+        if isinstance(tags_or_header, tuple):
+            self._tags = tags_or_header
+        else:
+            assert isinstance(tags_or_header, str)
+            self._original_title = tags_or_header
+
+    def __str__(self):
+        if hasattr(self, "_tags"):
+            tags = "+".join(self._tags)
+            return f"= {tags}"
+        else:
+            return f"= <!{self._original_title}!>"
+
+
+class Pane:
+    def __init__(self, rows: list[RowTemplate]):
+        self._rows = tuple(rows)
+
+    def rows(self):
+        yield from self._rows
+
+    def __str__(self):
+        return "\n".join(str(row) for row in self.rows())
+
+
+class ParadigmTemplate:
+    def __init__(self, panes: list[Pane]):
+        self._panes = tuple(panes)
+
+    def panes(self):
+        yield from self._panes
+
+    @classmethod
+    def loads(cls, string):
+        raise NotImplementedError
+
+    def dumps(self):
+        pane_text = []
+        for pane in self.panes():
+            pane_text.append(str(pane))
+
+        return "\n\n".join(pane_text)
+
+    def __str__(self):
+        return self.dumps()
 
 
 class Command(BaseCommand):
@@ -25,13 +189,67 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        from pprint import pprint
-
         existing_paradigms = paradigm_filler()
         english_templates = snoop_all_plain_english_templates(existing_paradigms)
-        label_to_tag = snoop_unambiguous_plain_english_tags()
+        self.label_to_tags = snoop_unambiguous_plain_english_tags()
 
-        raise NotImplementedError("now to draw the rest of the owl...")
+        for word_class, full_paradigm in english_templates.items():
+            paradigm_template = self.convert_layout_to_new_format(full_paradigm)
+            print("=====", word_class, "======")
+            print(paradigm_template)
+            print()
+
+    def cell_template_from_text(self, text, is_first_cell):
+        if tags := self.label_to_tags.get(text):
+            if is_first_cell:
+                return RowLabel(tags)
+            else:
+                return ColumnLabel(tags)
+        else:
+            if is_first_cell:
+                return UnknownRowLabel(text)
+            else:
+                return UnknownColumnLabel(text)
+
+    def convert_layout_to_new_format(self, layout):
+        panes = [[]]
+
+        # This is the old paradigm "layout" data structure:
+        # layout: list[Row]
+        # Row: list[Cell] | EmptyRow | TitleRow
+        # Cell: Label | InflectionCell
+        for row in layout:
+            if row is EmptyRow:
+                # start a new pane
+                panes.append([])
+                continue
+
+            rows = panes[-1]
+
+            if isinstance(row, TitleRow):
+                tags = self.label_to_tags.get(row.title)
+                rows.append(HeaderRow(tags or row.title))
+                continue
+
+            cells = []
+            first_cell = True
+            for cell in row:
+                new_cell: CellTemplate
+                if cell == "":
+                    new_cell = EmptyCell
+                elif hasattr(cell, "analysis"):
+                    if analysis := cell.analysis:
+                        new_cell = InflectionCellTemplate(analysis.template)
+                    else:
+                        new_cell = MissingForm()
+                elif cell.is_label:
+                    new_cell = self.cell_template_from_text(cell.text, first_cell)
+                cells.append(new_cell)
+                first_cell = False
+
+            rows.append(RowTemplate(cells))
+
+        return ParadigmTemplate(Pane(rows) for rows in panes)
 
 
 def snoop_unambiguous_plain_english_tags():

--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -18,16 +18,16 @@ from CreeDictionary.paradigm.filler import EmptyRow, TitleRow
 from CreeDictionary.paradigm.generation import paradigm_filler
 from CreeDictionary.paradigm.panes import (
     BaseLabelCell,
-    CellTemplate,
+    Cell,
     ColumnLabel,
     EmptyCell,
     HeaderRow,
-    InflectionCellTemplate,
+    InflectionCell,
     MissingForm,
     Pane,
     ParadigmTemplate,
     RowLabel,
-    RowTemplate,
+    Row,
 )
 from CreeDictionary.relabelling import LABELS
 
@@ -91,12 +91,12 @@ class Command(BaseCommand):
             cells = []
             first_cell = True
             for cell in row:
-                new_cell: CellTemplate
+                new_cell: Cell
                 if cell == "":
                     new_cell = EmptyCell
                 elif hasattr(cell, "analysis"):
                     if analysis := cell.analysis:
-                        new_cell = InflectionCellTemplate(analysis.template)
+                        new_cell = InflectionCell(analysis.template)
                     else:
                         new_cell = MissingForm()
                 elif cell.is_label:
@@ -104,7 +104,7 @@ class Command(BaseCommand):
                 cells.append(new_cell)
                 first_cell = False
 
-            rows.append(RowTemplate(cells))
+            rows.append(Row(cells))
 
         return ParadigmTemplate(Pane(rows) for rows in panes)
 

--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -12,20 +12,11 @@ from collections import defaultdict
 from pathlib import Path
 
 from django.core.management import BaseCommand
-from utils import ParadigmSize, WordClass, shared_res_dir  # type: ignore
+from utils import ParadigmSize
 
-from CreeDictionary.paradigm.filler import EmptyRow, TitleRow  # type: ignore
-from CreeDictionary.paradigm.generation import paradigm_filler  # type: ignore
-from CreeDictionary.relabelling import LABELS, _LabelFriendliness  # type: ignore
-
-
-class ErrorOnStr(str):
-    def __str__(self):
-        raise TypeError("Cannot render string")
-
-
-def identity(x):
-    return x
+from CreeDictionary.paradigm.filler import EmptyRow, TitleRow
+from CreeDictionary.paradigm.generation import paradigm_filler
+from CreeDictionary.relabelling import LABELS
 
 
 class CellTemplate:
@@ -178,7 +169,7 @@ class ParadigmTemplate:
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: ArgumentParser):
         parser.add_argument("outdir", help="where to save the new panes", type=Path)
         parser.add_argument(
             "-f", "--force", help="overwrites files if present", action="store_true"

--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -74,11 +74,9 @@ del EmptyCellType
 
 class BaseLabelCell(CellTemplate):
     is_label = True
-    label_for: str = ErrorOnStr()
-    prefix: str = ErrorOnStr()
+    label_for: str
+    prefix: str
 
-
-class LabelFromTagMixin(BaseLabelCell):
     def __init__(self, tags):
         self._tags = tags
 
@@ -87,37 +85,36 @@ class LabelFromTagMixin(BaseLabelCell):
 
 
 class UnknownLabelTagMixin(BaseLabelCell):
+    UNANALYZABLE = ("?",)
+
     def __init__(self, original: str):
+        super().__init__(self.UNANALYZABLE)
         self.original = original
 
     def __str__(self):
         return f"{self.prefix} <!{self.original}!>"
 
 
-class BaseRowLabel(BaseLabelCell):
+class RowLabel(BaseLabelCell):
     label_for = "row"
     prefix = "_"
 
 
-class BaseColumnLabel(BaseLabelCell):
+class ColumnLabel(BaseLabelCell):
     label_for = "column"
     prefix = "|"
 
 
-class RowLabel(BaseRowLabel, LabelFromTagMixin):
-    ...
+class UnknownRowLabel(RowLabel, UnknownLabelTagMixin):
+    """
+    A row with a label that cannot be looked up
+    """
 
 
-class ColumnLabel(BaseColumnLabel, LabelFromTagMixin):
-    ...
-
-
-class UnknownRowLabel(BaseRowLabel, UnknownLabelTagMixin):
-    ...
-
-
-class UnknownColumnLabel(BaseColumnLabel, UnknownLabelTagMixin):
-    ...
+class UnknownColumnLabel(ColumnLabel, UnknownLabelTagMixin):
+    """
+    A column with a label that cannot be looked up
+    """
 
 
 class RowTemplate:

--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -1,0 +1,78 @@
+"""
+Converts all loaded paradigm templates and outputs them in the pane-style template.
+
+Note: this code is **temporary**! (2021-04-23)
+"""
+
+import sys
+from argparse import ArgumentParser
+from collections import defaultdict
+from pathlib import Path
+
+from django.core.management import BaseCommand
+from utils import ParadigmSize, WordClass, shared_res_dir  # type: ignore
+
+from CreeDictionary.paradigm.generation import paradigm_filler  # type: ignore
+from CreeDictionary.relabelling import LABELS, _LabelFriendliness  # type: ignore
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "outdir",
+            nargs="?",
+            help="where to save the new panes",
+        )
+
+    def handle(self, *args, **options):
+        from pprint import pprint
+
+        existing_paradigms = paradigm_filler()
+        english_templates = snoop_all_plain_english_templates(existing_paradigms)
+        label_to_tag = snoop_unambiguous_plain_english_tags()
+
+        raise NotImplementedError("now to draw the rest of the owl...")
+
+
+def snoop_unambiguous_plain_english_tags():
+    """
+    Peer into relabelling to convert linguistic labels back to tags.
+    """
+
+    from CreeDictionary.relabelling import _LabelFriendliness  # type: ignore
+
+    label_to_tags = defaultdict(list)
+    for tag, relabellings in LABELS._data.items():
+        label = relabellings.get(_LabelFriendliness.ENGLISH)
+        if label is None:
+            lazy_log("No English label for", tag)
+            continue
+        label_to_tags[label].append(tag)
+
+    label_to_unambiguous_tag = {}
+    for label, tags in label_to_tags.items():
+        if len(tags) == 1:
+            label_to_unambiguous_tag[label] = tags[0]
+        else:
+            lazy_log("Ambiguous label:", label)
+            lazy_log("   => maps to", tags)
+
+    return label_to_unambiguous_tag
+
+
+def snoop_all_plain_english_templates(filler):
+    """
+    Peers into ParadigmFiller's private internal data structures to recover ONLY the
+    plain English paradigms.
+    """
+    desired_layouts = {}
+    for (wordclass, category), layout in filler._layout_tables.items():
+        if category is not ParadigmSize.FULL:
+            continue
+        desired_layouts[wordclass] = layout
+
+    return desired_layouts
+
+
+def lazy_log(*args, **kwargs):
+    print(*args, **kwargs, file=sys.stderr)

--- a/CreeDictionary/CreeDictionary/paradigm/filler.py
+++ b/CreeDictionary/CreeDictionary/paradigm/filler.py
@@ -315,8 +315,12 @@ class InflectionCell:
         if self.inflection or self.frequency and self.analysis is None:
             return super().__repr__()
 
-        assert self.analysis is not None  # mypy is dumb...
-        return f"{type(self).__name__}(analysis=Template({self.analysis.template!r})"
+        if self.analysis:
+            analysis_repr = f"Template({self.analysis.template!r}"
+        else:
+            analysis_repr = "None"
+
+        return f"{type(self).__name__}(analysis={analysis_repr})"
 
     def create_concat_analysis(self, lemma: str) -> ConcatAnalysis:
         """

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+
+class CellTemplate:
+    is_label: bool = False
+    is_inflection: bool = False
+    is_empty = bool = False
+
+
+class InflectionCellTemplate(CellTemplate):
+    is_inflection = True
+
+    def __init__(self, analysis: str):
+        self.analysis = analysis
+        assert "{{lemma}}" in analysis or "+" in analysis
+
+    def __str__(self):
+        return self.analysis
+
+
+class MissingForm(InflectionCellTemplate):
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return "--"
+
+
+class EmptyCellType(CellTemplate):
+    is_empty = True
+
+    def __new__(cls) -> EmptyCellType:
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __str__(self):
+        return ""
+
+    def __repr__(self):
+        return "EmptyCell"
+
+
+EmptyCell = EmptyCellType()
+
+
+class BaseLabelCell(CellTemplate):
+    is_label = True
+    label_for: str
+    prefix: str
+
+    def __init__(self, tags):
+        self._tags = tags
+
+    def __str__(self):
+        return " ".join(f"{self.prefix} {tag}" for tag in self._tags)
+
+
+class RowLabel(BaseLabelCell):
+    label_for = "row"
+    prefix = "_"
+
+
+class ColumnLabel(BaseLabelCell):
+    label_for = "column"
+    prefix = "|"
+
+
+class RowTemplate:
+    def __init__(self, cells: list[CellTemplate]):
+        self._cells = tuple(cells)
+
+    def cells(self):
+        yield from self._cells
+
+    def __str__(self):
+        return "\t".join(str(cell) for cell in self.cells())
+
+
+class HeaderRow(RowTemplate):
+    def __init__(self, tags_or_header):
+        if isinstance(tags_or_header, tuple):
+            self._tags = tags_or_header
+        else:
+            assert isinstance(tags_or_header, str)
+            self._original_title = tags_or_header
+
+    def __str__(self):
+        if hasattr(self, "_tags"):
+            tags = "+".join(self._tags)
+            return f"# {tags}"
+        else:
+            return f"# <!{self._original_title}!>"
+
+
+class Pane:
+    def __init__(self, rows: list[RowTemplate]):
+        self._rows = tuple(rows)
+
+    def rows(self):
+        yield from self._rows
+
+    def __str__(self):
+        return "\n".join(str(row) for row in self.rows())
+
+
+class ParadigmTemplate:
+    def __init__(self, panes: list[Pane]):
+        self._panes = tuple(panes)
+
+    def panes(self):
+        yield from self._panes
+
+    @classmethod
+    def loads(cls, string):
+        raise NotImplementedError
+
+    def dumps(self):
+        pane_text = []
+        for pane in self.panes():
+            pane_text.append(str(pane))
+
+        return "\n\n".join(pane_text)
+
+    def __str__(self):
+        return self.dumps()

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -1,13 +1,105 @@
 from __future__ import annotations
 
+"""
+Provides all classes for pane-based paradigms.
+"""
+
+
+class ParadigmTemplate:
+    """
+    Template for a particular word class. The template contains analyses with
+    placeholders that can be filled at runtime to generate a displayable paradigm.
+    """
+
+    def __init__(self, panes: list[Pane]):
+        self._panes = tuple(panes)
+
+    def panes(self):
+        yield from self._panes
+
+    @classmethod
+    def loads(cls, string):
+        raise NotImplementedError
+
+    def dumps(self):
+        """
+        Export the template as a string. This string can be by .loads().
+        """
+        # TODO: write property test: p == ParadigmTemplate.loads(p.dumps())
+        pane_text = []
+        for pane in self.panes():
+            pane_text.append(str(pane))
+
+        return "\n\n".join(pane_text)
+
+    def __str__(self):
+        return self.dumps()
+
+
+class Pane:
+    """
+    A self-contained table from the full paradigm.
+
+    A pane contains a number of rows.
+    """
+    def __init__(self, rows: list[RowTemplate]):
+        self._rows = tuple(rows)
+
+    def rows(self):
+        yield from self._rows
+
+    def __str__(self):
+        return "\n".join(str(row) for row in self.rows())
+
+
+class RowTemplate:
+    """
+    A single row from a pane. Rows contain cells.
+    """
+
+    def __init__(self, cells: list[CellTemplate]):
+        self._cells = tuple(cells)
+
+    def cells(self):
+        yield from self._cells
+
+    def __str__(self):
+        return "\t".join(str(cell) for cell in self.cells())
+
+
+class HeaderRow(RowTemplate):
+    """
+    A row that acts as a header for the rest of the pane.
+    """
+
+    def __init__(self, tags_or_header):
+        if isinstance(tags_or_header, tuple):
+            self._tags = tags_or_header
+        else:
+            assert isinstance(tags_or_header, str)
+            self._original_title = tags_or_header
+
+    def __str__(self):
+        if hasattr(self, "_tags"):
+            tags = "+".join(self._tags)
+            return f"# {tags}"
+        else:
+            return f"# <!{self._original_title}!>"
+
 
 class CellTemplate:
+    """
+    A single cell from a paradigm.
+    """
     is_label: bool = False
     is_inflection: bool = False
     is_empty = bool = False
 
 
 class InflectionCellTemplate(CellTemplate):
+    """
+    A cell that contains an inflection.
+    """
     is_inflection = True
 
     def __init__(self, analysis: str):
@@ -18,15 +110,24 @@ class InflectionCellTemplate(CellTemplate):
         return self.analysis
 
 
-class MissingForm(InflectionCellTemplate):
-    def __init__(self):
-        pass
+class MissingForm(CellTemplate):
+    """
+    A missing form from the paradigm that should show up in the template as a placeholder.
+    Note: a missing form is a valid position in the paradigm, however, we display that
+    this form cannot exist. This is not the same as an empty cell, which is used as a
+    spacer.
+    """
+    is_inflection = True
 
     def __str__(self):
         return "--"
 
 
 class EmptyCellType(CellTemplate):
+    """
+    A completely empty cell. This is used for spacing in the paradigm. There is no
+    semantic content. Compare with MissingForm.
+    """
     is_empty = True
 
     def __new__(cls) -> EmptyCellType:
@@ -57,70 +158,16 @@ class BaseLabelCell(CellTemplate):
 
 
 class RowLabel(BaseLabelCell):
+    """
+    Labels for the cells in the current row within the pane.
+    """
     label_for = "row"
     prefix = "_"
 
 
 class ColumnLabel(BaseLabelCell):
+    """
+    Labels for the cells in the current column within the pane.
+    """
     label_for = "column"
     prefix = "|"
-
-
-class RowTemplate:
-    def __init__(self, cells: list[CellTemplate]):
-        self._cells = tuple(cells)
-
-    def cells(self):
-        yield from self._cells
-
-    def __str__(self):
-        return "\t".join(str(cell) for cell in self.cells())
-
-
-class HeaderRow(RowTemplate):
-    def __init__(self, tags_or_header):
-        if isinstance(tags_or_header, tuple):
-            self._tags = tags_or_header
-        else:
-            assert isinstance(tags_or_header, str)
-            self._original_title = tags_or_header
-
-    def __str__(self):
-        if hasattr(self, "_tags"):
-            tags = "+".join(self._tags)
-            return f"# {tags}"
-        else:
-            return f"# <!{self._original_title}!>"
-
-
-class Pane:
-    def __init__(self, rows: list[RowTemplate]):
-        self._rows = tuple(rows)
-
-    def rows(self):
-        yield from self._rows
-
-    def __str__(self):
-        return "\n".join(str(row) for row in self.rows())
-
-
-class ParadigmTemplate:
-    def __init__(self, panes: list[Pane]):
-        self._panes = tuple(panes)
-
-    def panes(self):
-        yield from self._panes
-
-    @classmethod
-    def loads(cls, string):
-        raise NotImplementedError
-
-    def dumps(self):
-        pane_text = []
-        for pane in self.panes():
-            pane_text.append(str(pane))
-
-        return "\n\n".join(pane_text)
-
-    def __str__(self):
-        return self.dumps()

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Iterable
+
 """
 Provides all classes for pane-based paradigms.
 """
@@ -11,7 +13,7 @@ class ParadigmTemplate:
     placeholders that can be filled at runtime to generate a displayable paradigm.
     """
 
-    def __init__(self, panes: list[Pane]):
+    def __init__(self, panes: Iterable[Pane]):
         self._panes = tuple(panes)
 
     def panes(self):
@@ -42,7 +44,7 @@ class Pane:
 
     A pane contains a number of rows.
     """
-    def __init__(self, rows: list[Row]):
+    def __init__(self, rows: Iterable[Row]):
         self._rows = tuple(rows)
 
     def rows(self):
@@ -57,7 +59,7 @@ class Row:
     A single row from a pane. Rows contain cells.
     """
 
-    def __init__(self, cells: list[Cell]):
+    def __init__(self, cells: Iterable[Cell]):
         self._cells = tuple(cells)
 
     def cells(self):

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -42,7 +42,7 @@ class Pane:
 
     A pane contains a number of rows.
     """
-    def __init__(self, rows: list[RowTemplate]):
+    def __init__(self, rows: list[Row]):
         self._rows = tuple(rows)
 
     def rows(self):
@@ -52,12 +52,12 @@ class Pane:
         return "\n".join(str(row) for row in self.rows())
 
 
-class RowTemplate:
+class Row:
     """
     A single row from a pane. Rows contain cells.
     """
 
-    def __init__(self, cells: list[CellTemplate]):
+    def __init__(self, cells: list[Cell]):
         self._cells = tuple(cells)
 
     def cells(self):
@@ -67,7 +67,7 @@ class RowTemplate:
         return "\t".join(str(cell) for cell in self.cells())
 
 
-class HeaderRow(RowTemplate):
+class HeaderRow(Row):
     """
     A row that acts as a header for the rest of the pane.
     """
@@ -87,7 +87,7 @@ class HeaderRow(RowTemplate):
             return f"# <!{self._original_title}!>"
 
 
-class CellTemplate:
+class Cell:
     """
     A single cell from a paradigm.
     """
@@ -96,7 +96,7 @@ class CellTemplate:
     is_empty = bool = False
 
 
-class InflectionCellTemplate(CellTemplate):
+class InflectionCell(Cell):
     """
     A cell that contains an inflection.
     """
@@ -110,7 +110,7 @@ class InflectionCellTemplate(CellTemplate):
         return self.analysis
 
 
-class MissingForm(CellTemplate):
+class MissingForm(Cell):
     """
     A missing form from the paradigm that should show up in the template as a placeholder.
     Note: a missing form is a valid position in the paradigm, however, we display that
@@ -123,7 +123,7 @@ class MissingForm(CellTemplate):
         return "--"
 
 
-class EmptyCellType(CellTemplate):
+class EmptyCellType(Cell):
     """
     A completely empty cell. This is used for spacing in the paradigm. There is no
     semantic content. Compare with MissingForm.
@@ -145,7 +145,7 @@ class EmptyCellType(CellTemplate):
 EmptyCell = EmptyCellType()
 
 
-class BaseLabelCell(CellTemplate):
+class BaseLabelCell(Cell):
     is_label = True
     label_for: str
     prefix: str

--- a/mypy.ini
+++ b/mypy.ini
@@ -21,6 +21,9 @@ ignore_missing_imports = True
 [mypy-debug_toolbar.*]
 ignore_missing_imports = True
 
+[mypy-sortedcontainers.*]
+ignore_missing_imports = True
+
 [mypy-django.*]
 # https://github.com/typeddjango/django-stubs exists, but attempts to use
 # it were fiddly enough that it didn’t seem worth the hassle


### PR DESCRIPTION
I created a management command `convertndslayoutstopanes` that... converts NDS-style paradigm layouts (i.e., the ones we're using right now) and converts them to the pane-based syntax (see: #167).

Although I think of the management command as throwaway code, I want to keep and build on the new classes introduced in `panes.py`. Please scrutinize!

Addresses #582... however converted layouts will need to be manually validated.