### PR TITLE
feat: parse pane layout files

### DIFF
--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -10,6 +10,7 @@ import sys
 from argparse import ArgumentParser
 from collections import defaultdict
 from pathlib import Path
+from typing import Protocol, Sequence
 
 from django.core.management import BaseCommand
 from utils import ParadigmSize
@@ -112,16 +113,26 @@ class Command(BaseCommand):
         return ParadigmTemplate(Pane(rows) for rows in panes)
 
 
-class UnknownLabelTagMixin:
+class _ExpectedMixinBase(Protocol):
     """
-    Mixin to a RowLabel or ColumnLabel to display <!ORIGINAL LABEL!> instead of an FST tag.
+    UnknownLabelTagMixin should be mixed into a class that looks like this:
+    """
+
+    prefix: str
+
+    def __init__(self, t: Sequence[str]) -> None:
+        ...
+
+
+class UnknownLabelTagMixin(_ExpectedMixinBase):
+    """
+    Mixin to a Label or a Header to display <!ORIGINAL LABEL!> instead of an FST tag.
     """
 
     UNANALYZABLE = ("?",)
 
-    def __init__(self, original):
+    def __init__(self, original: str):
         super().__init__(self.UNANALYZABLE)
-        assert self.prefix
         self.original = original
 
     def __str__(self):

--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -93,7 +93,7 @@ class Command(BaseCommand):
             for cell in row:
                 new_cell: Cell
                 if cell == "":
-                    new_cell = EmptyCell
+                    new_cell = EmptyCell()
                 elif hasattr(cell, "analysis"):
                     if analysis := cell.analysis:
                         new_cell = InflectionCell(analysis.template)

--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -17,7 +17,6 @@ from utils import ParadigmSize
 from CreeDictionary.paradigm.filler import EmptyRow, TitleRow
 from CreeDictionary.paradigm.generation import paradigm_filler
 from CreeDictionary.paradigm.panes import (
-    BaseLabelCell,
     Cell,
     ColumnLabel,
     ContentRow,
@@ -27,7 +26,6 @@ from CreeDictionary.paradigm.panes import (
     MissingForm,
     Pane,
     ParadigmTemplate,
-    Row,
     RowLabel,
 )
 from CreeDictionary.relabelling import LABELS
@@ -73,7 +71,7 @@ class Command(BaseCommand):
         panes = [[]]
 
         # This is the old paradigm "layout" data structure:
-        # layout: list[ContentRow]
+        # layout: list[Row]
         # Row: list[Cell] | EmptyRow | TitleRow
         # Cell: Label | InflectionCell
         for row in layout:

--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -27,8 +27,8 @@ from CreeDictionary.paradigm.panes import (
     MissingForm,
     Pane,
     ParadigmTemplate,
+    Row,
     RowLabel,
-    _BaseRow,
 )
 from CreeDictionary.relabelling import LABELS
 
@@ -121,7 +121,7 @@ class UnknownLabelTagMixin:
 
     UNANALYZABLE = ("?",)
 
-    def __init__(self, original: str):
+    def __init__(self, original):
         super().__init__(self.UNANALYZABLE)
         assert self.prefix
         self.original = original

--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -20,13 +20,13 @@ from CreeDictionary.paradigm.panes import (
     BaseLabelCell,
     Cell,
     ColumnLabel,
+    ContentRow,
     EmptyCell,
     HeaderRow,
     InflectionCell,
     MissingForm,
     Pane,
     ParadigmTemplate,
-    Row,
     RowLabel,
     _BaseRow,
 )
@@ -73,7 +73,7 @@ class Command(BaseCommand):
         panes = [[]]
 
         # This is the old paradigm "layout" data structure:
-        # layout: list[Row]
+        # layout: list[ContentRow]
         # Row: list[Cell] | EmptyRow | TitleRow
         # Cell: Label | InflectionCell
         for row in layout:
@@ -109,7 +109,7 @@ class Command(BaseCommand):
                 cells.append(new_cell)
                 first_cell = False
 
-            rows.append(Row(cells))
+            rows.append(ContentRow(cells))
 
         return ParadigmTemplate(Pane(rows) for rows in panes)
 

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -27,6 +27,13 @@ class ParadigmTemplate:
     def panes(self):
         yield from self._panes
 
+    @property
+    def max_num_columns(self):
+        """
+        What is the largest amount of columns necessary for this entire paradigm.
+        """
+        return max(pane.num_columns for pane in self.panes())
+
     @classmethod
     def load(cls, layout_file: TextIO) -> ParadigmTemplate:
         """

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -234,7 +234,7 @@ class HeaderRow(Row):
 
     def __str__(self):
         tags = "+".join(self._tags)
-        return f"# {tags}"
+        return f"{self.prefix} {tags}"
 
     def __repr__(self):
         name = type(self).__qualname__

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -27,7 +27,7 @@ class ParadigmTemplate:
     @property
     def max_num_columns(self):
         """
-        What is the largest amount of columns necessary for this entire paradigm.
+        How many columns are necessary for this entire paradigm?
         """
         return max(pane.num_columns for pane in self.panes())
 
@@ -363,7 +363,7 @@ class BaseLabelCell(Cell):
     def parse(cls, text: str):
         splits = re.split(r" +", text)
         if len(splits) % 2 != 0:
-            raise ParseError(f"Uneven number of space separated segments in {text!r}")
+            raise ParseError(f"Uneven number of space-separated segments in {text!r}")
         tags = []
 
         for prefix, tag in pairs(splits):

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -296,7 +296,7 @@ def pairs(seq):
     """
     Returns pairs from the given sequence.
 
-    >>> pairs([1, 2, 3, 4, 5, 6])
+    >>> list(pairs([1, 2, 3, 4, 5, 6]))
     [(1, 2), (3, 4), (5, 6)]
     """
     return zip(seq[::2], seq[1::2])

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -165,12 +165,20 @@ class Row:
     def parse(text: str) -> Row:
         if text.startswith("# "):
             return HeaderRow.parse(text)
-        cell_texts = text.rstrip("\n").split("\t")
 
+        cell_texts = text.rstrip("\n").split("\t")
+        # Remove empty cells from the end.
         while cell_texts:
             if cell_texts[-1].strip() != "":
                 break
             cell_texts.pop()
+
+        if len(cell_texts) == 0:
+            # This would mean the line was empty, but empty lines in a paradigm file
+            # are used as pane separators.
+            # If we got here from ParadigmTemplate.parse(), something terrible has gone
+            # wrong.
+            raise ParseError("Refusing to parse empty row")
 
         return ContentRow(Cell.parse(t) for t in cell_texts)
 

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -89,7 +89,7 @@ class Pane:
 
     @property
     def num_columns(self) -> int:
-        return len(max(self._rows, key=len))
+        return max(row.num_cells for row in self.rows())
 
     def rows(self):
         yield from self._rows
@@ -119,9 +119,7 @@ class Pane:
 
 class Row:
     has_content: bool
-
-    def __len__(self) -> int:
-        raise NotImplementedError
+    num_cells: int
 
     @staticmethod
     def parse(text: str) -> Row:
@@ -163,7 +161,8 @@ class ContentRow(Row):
         cells_repr = ", ".join(repr(cell) for cell in self.cells())
         return f"{name}([{cells_repr}])"
 
-    def __len__(self):
+    @property
+    def num_cells(self):
         return len(self._cells)
 
 
@@ -174,6 +173,7 @@ class HeaderRow(Row):
 
     prefix = "#"
     has_content = False
+    num_cells = 0
 
     def __init__(self, tags):
         super().__init__()
@@ -183,16 +183,6 @@ class HeaderRow(Row):
         if isinstance(other, HeaderRow):
             return self._tags == other._tags
         return False
-
-    def __len__(self) -> int:
-        """
-        Headers do not contain any cells.
-        """
-        return 0
-
-    def __bool__(self) -> bool:
-        # Hack :/
-        return True
 
     def __str__(self):
         tags = "+".join(self._tags)

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -97,6 +97,15 @@ class Pane:
     def __str__(self):
         return "\n".join(str(row) for row in self.rows())
 
+    def __eq__(self, other) -> bool:
+        if isinstance(other, Pane):
+            return self._rows == other._rows
+
+    def __repr__(self):
+        name = type(self).__qualname__
+        rows = ", ".join(repr(row) for row in self.rows())
+        return f"{name}([{rows}])"
+
     @classmethod
     def parse(cls, text: str) -> Pane:
         lines = text.splitlines()
@@ -163,6 +172,11 @@ class HeaderRow(Row):
         else:
             self._tags = tuple(tags_or_header)
 
+    def __eq__(self, other) -> bool:
+        if isinstance(other, HeaderRow):
+            return self._tags == other._tags
+        return False
+
     def __len__(self) -> int:
         """
         Headers always have exactly one cell.
@@ -175,6 +189,11 @@ class HeaderRow(Row):
             return f"# {tags}"
         else:
             return f"# <!{self._original_title}!>"
+
+    def __repr__(self):
+        name = type(self).__qualname__
+        cells_repr = ", ".join(repr(cell) for cell in self._tags)
+        return f"{name}([{cells_repr}])"
 
     @staticmethod
     def parse(text: str) -> HeaderRow:

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -24,15 +24,15 @@ class ParadigmTemplate:
     def __init__(self, panes: Iterable[Pane]):
         self._panes = tuple(panes)
 
-    def panes(self):
-        yield from self._panes
-
     @property
     def max_num_columns(self):
         """
         What is the largest amount of columns necessary for this entire paradigm.
         """
         return max(pane.num_columns for pane in self.panes())
+
+    def panes(self):
+        yield from self._panes
 
     @classmethod
     def load(cls, layout_file: TextIO) -> ParadigmTemplate:

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -264,8 +264,8 @@ class BaseLabelCell(Cell):
         if len(splits) % 2 != 0:
             raise ParseError(f"Uneven number of space separated segments in {text!r}")
         tags = []
-        # TODO: factor out zip magic
-        for prefix, tag in zip(splits[::2], splits[1::2]):
+
+        for prefix, tag in pairs(splits):
             if prefix != cls.prefix:
                 raise ParseError(f"Expected prefix {cls.prefix!r} but saw {prefix!r}")
             tags.append(tag)
@@ -289,3 +289,13 @@ class ColumnLabel(BaseLabelCell):
 
     label_for = "column"
     prefix = "|"
+
+
+def pairs(seq):
+    """
+    Returns pairs from the given sequence.
+
+    >>> pairs([1, 2, 3, 4, 5, 6])
+    [(1, 2), (3, 4), (5, 6)]
+    """
+    return zip(seq[::2], seq[1::2])

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -138,7 +138,13 @@ class Row:
     def parse(text: str) -> Row:
         if text.startswith("# "):
             return HeaderRow.parse(text)
-        cell_texts = text.strip().split("\t")
+        cell_texts = text.rstrip("\n").split("\t")
+
+        while cell_texts:
+            if cell_texts[-1].strip() != "":
+                break
+            cell_texts.pop()
+
         return Row(Cell.parse(t) for t in cell_texts)
 
 
@@ -278,6 +284,11 @@ class BaseLabelCell(Cell):
 
     def __str__(self):
         return " ".join(f"{self.prefix} {tag}" for tag in self._tags)
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, type(self)):
+            return self._tags == other._tags
+        return False
 
     def __repr__(self):
         name = type(self).__qualname__

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -40,7 +40,7 @@ class ParadigmTemplate:
         """
         lines = string.splitlines(keepends=False)
 
-        pane_lines = [[]]
+        pane_lines: list[list[str]] = [[]]
         for line in lines:
             if line.strip() == "":
                 # empty line; start a new pane

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -116,7 +116,24 @@ class Pane:
         return Pane(Row.parse(line) for line in lines)
 
 
-class Row:
+class _BaseRow:
+    has_content: bool
+
+    @staticmethod
+    def parse(text: str) -> Row:
+        if text.startswith("# "):
+            return HeaderRow.parse(text)
+        cell_texts = text.rstrip("\n").split("\t")
+
+        while cell_texts:
+            if cell_texts[-1].strip() != "":
+                break
+            cell_texts.pop()
+
+        return Row(Cell.parse(t) for t in cell_texts)
+
+
+class Row(_BaseRow):
     """
     A single row from a pane. Rows contain cells.
     """
@@ -142,19 +159,6 @@ class Row:
 
     def __len__(self):
         return len(self._cells)
-
-    @staticmethod
-    def parse(text: str) -> Row:
-        if text.startswith("# "):
-            return HeaderRow.parse(text)
-        cell_texts = text.rstrip("\n").split("\t")
-
-        while cell_texts:
-            if cell_texts[-1].strip() != "":
-                break
-            cell_texts.pop()
-
-        return Row(Cell.parse(t) for t in cell_texts)
 
 
 class HeaderRow(Row):

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -179,7 +179,7 @@ class Cell:
     @staticmethod
     def parse(text: str) -> Cell:
         if text == "":
-            return EmptyCell
+            return EmptyCell()
         elif text == "--":
             return MissingForm()
         elif text.startswith("_ "):
@@ -221,11 +221,19 @@ class MissingForm(Cell):
 
     is_inflection = True
 
+    def __new__(cls) -> MissingForm:
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self):
+        return "MissingForm()"
+
     def __str__(self):
         return "--"
 
 
-class EmptyCellType(Cell):
+class EmptyCell(Cell):
     """
     A completely empty cell. This is used for spacing in the paradigm. There is no
     semantic content. Compare with MissingForm.
@@ -233,19 +241,16 @@ class EmptyCellType(Cell):
 
     is_empty = True
 
-    def __new__(cls) -> EmptyCellType:
+    def __new__(cls) -> EmptyCell:
         if not hasattr(cls, "_instance"):
             cls._instance = super().__new__(cls)
         return cls._instance
 
+    def __repr__(self):
+        return "EmptyCell()"
+
     def __str__(self):
         return ""
-
-    def __repr__(self):
-        return "EmptyCell"
-
-
-EmptyCell = EmptyCellType()
 
 
 class BaseLabelCell(Cell):

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -211,7 +211,22 @@ class InflectionCell(Cell):
         return InflectionCell(text)
 
 
-class MissingForm(Cell):
+class SingletonMixin:
+    """
+    Mixin that makes any subclasses a singleton.
+    """
+
+    def __new__(cls):
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self):
+        name = type(self).__qualname__
+        return f"{name}()"
+
+
+class MissingForm(Cell, SingletonMixin):
     """
     A missing form from the paradigm that should show up in the template as a placeholder.
     Note: a missing form is a valid position in the paradigm, however, we display that
@@ -221,33 +236,17 @@ class MissingForm(Cell):
 
     is_inflection = True
 
-    def __new__(cls) -> MissingForm:
-        if not hasattr(cls, "_instance"):
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
-    def __repr__(self):
-        return "MissingForm()"
-
     def __str__(self):
         return "--"
 
 
-class EmptyCell(Cell):
+class EmptyCell(Cell, SingletonMixin):
     """
     A completely empty cell. This is used for spacing in the paradigm. There is no
     semantic content. Compare with MissingForm.
     """
 
     is_empty = True
-
-    def __new__(cls) -> EmptyCell:
-        if not hasattr(cls, "_instance"):
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
-    def __repr__(self):
-        return "EmptyCell()"
 
     def __str__(self):
         return ""

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -161,20 +161,16 @@ class Row(_BaseRow):
         return len(self._cells)
 
 
-class HeaderRow(Row):
+class HeaderRow(_BaseRow):
     """
     A row that acts as a header for the rest of the pane.
     """
 
-    def __init__(self, tags_or_header):
-        super().__init__(())
+    prefix = "#"
 
-        # TODO: this should only handle tags!
-        # TODO: drop support for _original_title
-        if isinstance(tags_or_header, str):
-            self._original_title = tags_or_header
-        else:
-            self._tags = tuple(tags_or_header)
+    def __init__(self, tags):
+        super().__init__()
+        self._tags = tuple(tags)
 
     def __eq__(self, other) -> bool:
         if isinstance(other, HeaderRow):
@@ -188,11 +184,8 @@ class HeaderRow(Row):
         return 1
 
     def __str__(self):
-        if hasattr(self, "_tags"):
-            tags = "+".join(self._tags)
-            return f"# {tags}"
-        else:
-            return f"# <!{self._original_title}!>"
+        tags = "+".join(self._tags)
+        return f"# {tags}"
 
     def __repr__(self):
         name = type(self).__qualname__

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -106,6 +106,11 @@ class Pane:
         yield from self._rows
 
     def dumps(self, require_num_columns: Optional[int] = None) -> str:
+        """
+        Returns a string representation that can be parsed again.
+        :param require_num_columns: if given, the pane must have at least this many columns.
+                                    Rows are padded with empty cells at the end.
+        """
         return "\n".join(row.dumps(require_num_columns) for row in self.rows())
 
     def __str__(self):
@@ -136,6 +141,12 @@ class Row:
     num_cells: int
 
     def dumps(self, require_num_columns: Optional[int] = None) -> str:
+        """
+        Returns a string representation of the row that can be parsed again.
+        :param require_num_columns: if given, the row must have at least this many columns.
+                                    The row is padded with empty cells at the end.
+        """
+
         row_as_string = str(self)
         if require_num_columns is None:
             return row_as_string
@@ -143,6 +154,7 @@ class Row:
         if require_num_columns < 1:
             raise ValueError("must require at least one column")
 
+        # Figure out how many tabs we need to add to the end.
         total_tabs = require_num_columns - 1
         tabs_present = row_as_string.count("\t")
         tabs_left = max(total_tabs - tabs_present, 0)

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -77,7 +77,7 @@ class Pane:
     A pane contains a number of rows.
     """
 
-    def __init__(self, rows: Iterable[ContentRow]):
+    def __init__(self, rows: Iterable[Row]):
         self._rows = tuple(rows)
 
     @property
@@ -100,6 +100,7 @@ class Pane:
     def __eq__(self, other) -> bool:
         if isinstance(other, Pane):
             return self._rows == other._rows
+        return False
 
     def __repr__(self):
         name = type(self).__qualname__
@@ -116,11 +117,14 @@ class Pane:
         return Pane(ContentRow.parse(line) for line in lines)
 
 
-class _BaseRow:
+class Row:
     has_content: bool
 
+    def __len__(self) -> int:
+        raise NotImplementedError
+
     @staticmethod
-    def parse(text: str) -> _BaseRow:
+    def parse(text: str) -> Row:
         if text.startswith("# "):
             return HeaderRow.parse(text)
         cell_texts = text.rstrip("\n").split("\t")
@@ -133,7 +137,7 @@ class _BaseRow:
         return ContentRow(Cell.parse(t) for t in cell_texts)
 
 
-class ContentRow(_BaseRow):
+class ContentRow(Row):
     """
     A single row from a pane. Rows contain cells.
     """
@@ -161,7 +165,7 @@ class ContentRow(_BaseRow):
         return len(self._cells)
 
 
-class HeaderRow(_BaseRow):
+class HeaderRow(Row):
     """
     A row that acts as a header for the rest of the pane.
     """

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -204,6 +204,7 @@ class InflectionCell(Cell):
     def __str__(self):
         return self.analysis
 
+    @staticmethod
     def parse(text: str) -> InflectionCell:
         if "${lemma}" not in text or "+" not in text:
             raise ParseError(f"cell does not look like an inflection: {text!r}")

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -142,6 +142,8 @@ class ContentRow(Row):
     A single row from a pane. Rows contain cells.
     """
 
+    has_content = True
+
     def __init__(self, cells: Iterable[Cell]):
         self._cells = tuple(cells)
 
@@ -171,6 +173,7 @@ class HeaderRow(Row):
     """
 
     prefix = "#"
+    has_content = False
 
     def __init__(self, tags):
         super().__init__()
@@ -183,9 +186,13 @@ class HeaderRow(Row):
 
     def __len__(self) -> int:
         """
-        Headers always have exactly one cell.
+        Headers do not contain any cells.
         """
-        return 1
+        return 0
+
+    def __bool__(self) -> bool:
+        # Hack :/
+        return True
 
     def __str__(self):
         tags = "+".join(self._tags)
@@ -200,7 +207,7 @@ class HeaderRow(Row):
     def parse(text: str) -> HeaderRow:
         if not text.startswith("# "):
             raise ParseError("Not a header row: {text!r}")
-        _prefix, _space, tags = text.partition(" ")
+        _prefix, _space, tags = text.rstrip().partition(" ")
         return HeaderRow(tags.split("+"))
 
 

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -77,7 +77,7 @@ class Pane:
     A pane contains a number of rows.
     """
 
-    def __init__(self, rows: Iterable[Row]):
+    def __init__(self, rows: Iterable[ContentRow]):
         self._rows = tuple(rows)
 
     @property
@@ -113,14 +113,14 @@ class Pane:
         if len(lines) == 0:
             raise ParseError("Not enough lines in pane")
 
-        return Pane(Row.parse(line) for line in lines)
+        return Pane(ContentRow.parse(line) for line in lines)
 
 
 class _BaseRow:
     has_content: bool
 
     @staticmethod
-    def parse(text: str) -> Row:
+    def parse(text: str) -> _BaseRow:
         if text.startswith("# "):
             return HeaderRow.parse(text)
         cell_texts = text.rstrip("\n").split("\t")
@@ -130,10 +130,10 @@ class _BaseRow:
                 break
             cell_texts.pop()
 
-        return Row(Cell.parse(t) for t in cell_texts)
+        return ContentRow(Cell.parse(t) for t in cell_texts)
 
 
-class Row(_BaseRow):
+class ContentRow(_BaseRow):
     """
     A single row from a pane. Rows contain cells.
     """
@@ -145,7 +145,7 @@ class Row(_BaseRow):
         yield from self._cells
 
     def __eq__(self, other) -> bool:
-        if not isinstance(other, Row):
+        if not isinstance(other, ContentRow):
             return False
         return all(a == b for a, b in zip_longest(self.cells(), other.cells()))
 

--- a/CreeDictionary/tests/CreeDictionary_tests/data/paradigm-layouts/NA.tsv
+++ b/CreeDictionary/tests/CreeDictionary_tests/data/paradigm-layouts/NA.tsv
@@ -1,0 +1,19 @@
+_ Sg	${lemma}+N+A+Sg		
+_ Pl	${lemma}+N+A+Pl		
+_ Obv	${lemma}+N+A+Obv		
+_ Loc	${lemma}+N+A+Loc		
+_ Distr	${lemma}+N+A+Distr		
+			
+# Der/Dim			
+_ Sg	${lemma}+N+A+Der/Dim+N+A+Sg		
+			
+# Px			
+	| Sg	| Pl	| Obv
+_ Px1Sg	${lemma}+N+A+Px1Sg+Sg	${lemma}+N+A+Px1Sg+Pl	${lemma}+N+A+Px1Sg+Obv
+_ Px2Sg	${lemma}+N+A+Px2Sg+Sg	${lemma}+N+A+Px2Sg+Pl	${lemma}+N+A+Px2Sg+Obv
+_ Px3Sg	--	--	${lemma}+N+A+Px3Sg+Obv
+_ Px1Pl	${lemma}+N+A+Px1Pl+Sg	${lemma}+N+A+Px1Pl+Pl	${lemma}+N+A+Px1Pl+Obv
+_ Px12Pl	${lemma}+N+A+Px12Pl+Sg	${lemma}+N+A+Px12Pl+Pl	${lemma}+N+A+Px12Pl+Obv
+_ Px2Pl	${lemma}+N+A+Px2Pl+Sg	${lemma}+N+A+Px2Pl+Pl	${lemma}+N+A+Px2Pl+Obv
+_ Px3Pl	--	--	${lemma}+N+A+Px3Pl+Obv
+_ Px4Sg/Pl	--	--	${lemma}+N+A+Px4Sg/Pl+Obv

--- a/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -8,13 +8,13 @@ import pytest
 
 from CreeDictionary.paradigm.panes import (
     ColumnLabel,
+    ContentRow,
     EmptyCell,
     HeaderRow,
     InflectionCell,
     MissingForm,
     Pane,
     ParadigmTemplate,
-    Row,
     RowLabel,
 )
 
@@ -57,8 +57,8 @@ def sample_pane():
     return Pane(
         [
             HeaderRow(("Der/Dim",)),
-            Row([EmptyCell(), ColumnLabel(["Sg"]), ColumnLabel(["Obv"])]),
-            Row([RowLabel("1Sg"), MissingForm(), InflectionCell("${lemma}+")]),
+            ContentRow([EmptyCell(), ColumnLabel(["Sg"]), ColumnLabel(["Obv"])]),
+            ContentRow([RowLabel("1Sg"), MissingForm(), InflectionCell("${lemma}+")]),
         ]
     )
 
@@ -73,8 +73,8 @@ def sample_pane():
         ColumnLabel(("Sg",)),
         RowLabel(("1Sg",)),
         HeaderRow(("Imp",)),
-        Row([EmptyCell(), ColumnLabel(["Sg"]), ColumnLabel(["Pl"])]),
-        Row([RowLabel("1Sg"), MissingForm(), InflectionCell("${lemma}+Pl")]),
+        ContentRow([EmptyCell(), ColumnLabel(["Sg"]), ColumnLabel(["Pl"])]),
+        ContentRow([RowLabel("1Sg"), MissingForm(), InflectionCell("${lemma}+Pl")]),
         sample_pane(),
     ],
 )

--- a/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -43,6 +43,8 @@ def test_parse_na_paradigm(na_layout_path: Path):
     assert possession_pane.header
     assert possession_pane.num_columns == 4
 
+    assert na_paradigm_template.max_num_columns == 4
+
 
 @pytest.mark.parametrize("cls", [EmptyCell, MissingForm])
 def test_singleton_classes(cls):

--- a/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -46,6 +46,15 @@ def test_parse_na_paradigm(na_layout_path: Path):
     assert na_paradigm_template.max_num_columns == 4
 
 
+def test_dump_equal_to_file_on_disk(na_layout_path: Path):
+    """
+    Dumping the file should yield the same file, modulo a trailing newline.
+    """
+    text = na_layout_path.read_text(encoding="UTF-8").rstrip("\n")
+    paradigm = ParadigmTemplate.loads(text)
+    assert paradigm.dumps() == text
+
+
 @pytest.mark.parametrize("cls", [EmptyCell, MissingForm])
 def test_singleton_classes(cls):
     """

--- a/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from CreeDictionary.paradigm.panes import ParadigmTemplate, MissingForm, EmptyCell
+from CreeDictionary.paradigm.panes import ParadigmTemplate, MissingForm, EmptyCell, InflectionCell, ColumnLabel, Row
 
 
 def test_parse_na_paradigm(na_layout_path: Path):
@@ -41,6 +41,21 @@ def test_singleton_classes(cls):
     """
     assert cls() is cls()
     assert cls() == cls()
+
+
+@pytest.mark.parametrize("component", [
+    EmptyCell(),
+    MissingForm(),
+    InflectionCell("${lemma}"),
+    InflectionCell("ôma+Ipc"),
+    Row([EmptyCell(), ColumnLabel(["Sg"]), ColumnLabel(["Pl"])]),
+])
+def test_str_produces_parsable_result(component):
+    stringified = str(component)
+    parsed = type(component).parse(stringified)
+    assert component == parsed
+    assert stringified == str(parsed)
+
 
 
 @pytest.fixture

--- a/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -9,8 +9,10 @@ import pytest
 from CreeDictionary.paradigm.panes import (
     ColumnLabel,
     EmptyCell,
+    HeaderRow,
     InflectionCell,
     MissingForm,
+    Pane,
     ParadigmTemplate,
     Row,
     RowLabel,
@@ -51,6 +53,16 @@ def test_singleton_classes(cls):
     assert cls() == cls()
 
 
+def sample_pane():
+    return Pane(
+        [
+            HeaderRow(("Der/Dim",)),
+            Row([EmptyCell(), ColumnLabel(["Sg"]), ColumnLabel(["Obv"])]),
+            Row([RowLabel("1Sg"), MissingForm(), InflectionCell("${lemma}+")]),
+        ]
+    )
+
+
 @pytest.mark.parametrize(
     "component",
     [
@@ -60,7 +72,10 @@ def test_singleton_classes(cls):
         InflectionCell("ôma+Ipc"),
         ColumnLabel(("Sg",)),
         RowLabel(("1Sg",)),
+        HeaderRow(("Imp",)),
         Row([EmptyCell(), ColumnLabel(["Sg"]), ColumnLabel(["Pl"])]),
+        Row([RowLabel("1Sg"), MissingForm(), InflectionCell("${lemma}+Pl")]),
+        sample_pane(),
     ],
 )
 def test_str_produces_parsable_result(component):

--- a/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from CreeDictionary.paradigm.panes import ParadigmTemplate
+from CreeDictionary.paradigm.panes import ParadigmTemplate, MissingForm, EmptyCell
 
 
 def test_parse_na_paradigm(na_layout_path: Path):
@@ -32,6 +32,16 @@ def test_parse_na_paradigm(na_layout_path: Path):
     assert count(diminutive_pane.rows()) == 2
     assert possession_pane.header
     assert possession_pane.num_columns == 4
+
+
+@pytest.mark.parametrize("cls", [EmptyCell, MissingForm])
+def test_singleton_classes(cls):
+    """
+    A few classes should act like singletons.
+    """
+    assert cls() is cls()
+    assert cls() == cls()
+
 
 
 @pytest.fixture

--- a/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -6,7 +6,15 @@ from pathlib import Path
 
 import pytest
 
-from CreeDictionary.paradigm.panes import ParadigmTemplate, MissingForm, EmptyCell, InflectionCell, ColumnLabel, Row
+from CreeDictionary.paradigm.panes import (
+    ColumnLabel,
+    EmptyCell,
+    InflectionCell,
+    MissingForm,
+    ParadigmTemplate,
+    Row,
+    RowLabel,
+)
 
 
 def test_parse_na_paradigm(na_layout_path: Path):
@@ -43,19 +51,26 @@ def test_singleton_classes(cls):
     assert cls() == cls()
 
 
-@pytest.mark.parametrize("component", [
-    EmptyCell(),
-    MissingForm(),
-    InflectionCell("${lemma}"),
-    InflectionCell("ôma+Ipc"),
-    Row([EmptyCell(), ColumnLabel(["Sg"]), ColumnLabel(["Pl"])]),
-])
+@pytest.mark.parametrize(
+    "component",
+    [
+        EmptyCell(),
+        MissingForm(),
+        InflectionCell("${lemma}"),
+        InflectionCell("ôma+Ipc"),
+        ColumnLabel(("Sg",)),
+        RowLabel(("1Sg",)),
+        Row([EmptyCell(), ColumnLabel(["Sg"]), ColumnLabel(["Pl"])]),
+    ],
+)
 def test_str_produces_parsable_result(component):
+    """
+    Parsing the stringified component should result in an equal component.
+    """
     stringified = str(component)
     parsed = type(component).parse(stringified)
     assert component == parsed
     assert stringified == str(parsed)
-
 
 
 @pytest.fixture

--- a/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -1,0 +1,52 @@
+"""
+Test parsing panes.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from CreeDictionary.paradigm.panes import ParadigmTemplate
+
+
+def test_parse_na_paradigm(na_layout_path: Path):
+    """
+    Parses the Plains Cree NA paradigm.
+
+    This paradigm has three panes:
+     - basic (no header)
+     - diminutive (two rows: a header and one row of content)
+     - possession
+
+    With possession having the most columns.
+    """
+    with na_layout_path.open(encoding="UTF-8") as layout_file:
+        na_paradigm_template = ParadigmTemplate.load(layout_file)
+
+    assert count(na_paradigm_template.panes()) == 3
+    basic_pane, diminutive_pane, possession_pane = na_paradigm_template.panes()
+
+    assert basic_pane.header is None
+    assert basic_pane.num_columns == 2
+    assert diminutive_pane.num_columns == 2
+    assert count(diminutive_pane.rows()) == 2
+    assert possession_pane.header
+    assert possession_pane.num_columns == 4
+
+
+@pytest.fixture
+def na_layout_path(shared_datadir: Path) -> Path:
+    """
+    Return the path to the NA layout in the test fixture dir.
+    NOTE: this is **NOT** the NA paradigm used in production!
+    """
+    p = shared_datadir / "paradigm-layouts" / "NA.tsv"
+    assert p.exists()
+    return p
+
+
+def count(it):
+    """
+    Returns the number of items iterated in the paradigm
+    """
+    return sum(1 for _ in it)

--- a/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -43,7 +43,6 @@ def test_singleton_classes(cls):
     assert cls() == cls()
 
 
-
 @pytest.fixture
 def na_layout_path(shared_datadir: Path) -> Path:
     """


### PR DESCRIPTION
Wrote some ad hoc code to parse pane files.

**EDIT**: it can parse paradigm files and dump them back out exactly in a plain-text TSV format. Dumped paradigms have an equal number of tabs per line throughout the entire paradigm, even if panes differ in the amount of columns they have.