### PR TITLE
style: move __future__ imports below docstring

### DIFF
--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
 """
 Converts all loaded paradigm templates and outputs them in the pane-style template.
 
 Note: this code is **temporary**! (2021-04-23)
 """
+
+from __future__ import annotations
 
 import sys
 from argparse import ArgumentParser
@@ -27,7 +27,7 @@ from CreeDictionary.paradigm.panes import (
     MissingForm,
     Pane,
     ParadigmTemplate,
-    RowLabel,
+    RowLabel
 )
 from CreeDictionary.relabelling import LABELS
 

--- a/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
+++ b/CreeDictionary/CreeDictionary/management/commands/convertndstopanes.py
@@ -27,7 +27,7 @@ from CreeDictionary.paradigm.panes import (
     MissingForm,
     Pane,
     ParadigmTemplate,
-    RowLabel
+    RowLabel,
 )
 from CreeDictionary.relabelling import LABELS
 

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -1,8 +1,8 @@
-from __future__ import annotations
-
 """
 Provides all classes for pane-based paradigms.
 """
+
+from __future__ import annotations
 
 import re
 from itertools import zip_longest


### PR DESCRIPTION
I knew that `__future__` imports were a special case in the Python compiler; I knew they had to go at the _very top_ of a module, hence, I put them _before_ the module docstring. However, all conventional imports go _after_ the module docstring. This means the `__future__` import is separated from other `import` statements.

But then I read the Python docs: https://docs.python.org/3/reference/simple_stmts.html#:~:text=the%20module%20docstring

You _can_ place `from __future__ import FEATURE` _after_ the module docstring no problem. So here's an example of the module preamble I'm sticking to for new files:

```python
"""
This is a short description of the module
"""

from __future__ import annotations

import os   # these are Python standard library imports
import sys
from pathlib import Path
from typings import Sequence

import requests  # these are packages installed by pip
from django.http import HttpResponse

from .utils import clamp  # these are imports from the current project

# module code goes here!
```