### PR TITLE
deps: install more-itertools directly and update secure

### DIFF
--- a/CreeDictionary/securemiddleware.py
+++ b/CreeDictionary/securemiddleware.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: UTF-8 -*-
-
 """
 Use secure.py to set OWASP approved headers.
 
@@ -10,15 +7,15 @@ See: https://owasp.org/www-project-secure-headers/
 Based on: https://secure.readthedocs.io/en/latest/frameworks.html#django
 """
 
-from secure import SecureHeaders
+import secure
 
-secure_headers = SecureHeaders()
+secure_headers = secure.Secure()
 
 
 def set_secure_headers(get_response):
     def middleware(request):
         response = get_response(request)
-        secure_headers.django(response)
+        secure_headers.framework.django(response)
         return response
 
     return middleware

--- a/Pipfile
+++ b/Pipfile
@@ -38,6 +38,7 @@ tqdm = "~=4.40"
 whitenoise = "*"
 foma = {subdirectory = "foma/python", git = "https://github.com/andrewdotn/foma"}
 uwsgi = "*"
+more-itertools = "~=8.7.0"
 
 [scripts]
 # unit tests

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bd4bffb032e4c3c0ffd2043824e593c150028557d124d79e24fd597264ad68ca"
+            "sha256": "e3fbccfd0ce2e2629cd74fa2a43efed180f5ca92251a63bde63d44da0909ec90"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -165,12 +165,20 @@
             "markers": "python_version >= '3.5'",
             "version": "==3.11.1"
         },
+        "more-itertools": {
+            "hashes": [
+                "sha256:5652a9ac72209ed7df8d9c15daf4e1aa0e3d2ccd3c87f8265a0673cd9cbc9ced",
+                "sha256:c5d6da9ca3ff65220c3bfd2a8db06d698f05d4d2b9be57e1deb2be5a45019713"
+            ],
+            "index": "pypi",
+            "version": "==8.7.0"
+        },
         "python-dotenv": {
             "hashes": [
-                "sha256:471b782da0af10da1a80341e8438fca5fadeba2881c54360d5fd8d03d03a4f4a",
-                "sha256:49782a97c9d641e8a09ae1d9af0856cc587c8d2474919342d5104d85be9890b2"
+                "sha256:00aa34e92d992e9f8383730816359647f358f4a3be1ba45e5a5cefd27ee91544",
+                "sha256:b1ae5e9643d5ed987fc57cc2583021e38db531946518130777734f9589b3141f"
             ],
-            "version": "==0.17.0"
+            "version": "==0.17.1"
         },
         "pytz": {
             "hashes": [
@@ -182,11 +190,11 @@
         },
         "secure": {
             "hashes": [
-                "sha256:4dc8dd4b548831c3ad7f94079332c41d67c781eccc32215ff5a8a49582c1a447",
-                "sha256:b3bf1e39ebf40040fc3248392343a5052aa14cb45fc87ec91b0bd11f19cc46bd"
+                "sha256:6e30939d8f95bf3b8effb8a36ebb5ed57f265daeeae905e3aa9677ea538ab64e",
+                "sha256:a93b720c7614809c131ca80e477263140107c6c212829d0a6e1f7bc8d859c608"
             ],
             "index": "pypi",
-            "version": "==0.2.1"
+            "version": "==0.3.0"
         },
         "snowballstemmer": {
             "hashes": [
@@ -263,10 +271,11 @@
         },
         "black": {
             "hashes": [
-                "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"
+                "sha256:bff7067d8bc25eb21dcfdbc8c72f2baafd9ec6de4663241a52fb904b304d391f",
+                "sha256:fc9bcf3b482b05c1f35f6a882c079dc01b9c7795827532f4cc43c0ec88067bbc"
             ],
             "index": "pypi",
-            "version": "==20.8b1"
+            "version": "==21.4b2"
         },
         "certifi": {
             "hashes": [
@@ -403,7 +412,7 @@
                 "sha256:5652a9ac72209ed7df8d9c15daf4e1aa0e3d2ccd3c87f8265a0673cd9cbc9ced",
                 "sha256:c5d6da9ca3ff65220c3bfd2a8db06d698f05d4d2b9be57e1deb2be5a45019713"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==8.7.0"
         },
         "mypy": {


### PR DESCRIPTION
Now the project _explicitly_ depends on `more-itertools` (it used to be a transitive development dependency). `secure` also upgraded its API and I kind of just let pipenv update that... so I updated the callsite to use the new API ¯\\\_(ツ)\_/¯ 

---

These updates came about from me working on paradigm generation.