### PR TITLE
feat: static paradigms (frontend implementation)

### DIFF
--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -540,6 +540,10 @@ class BaseLabelCell(Cell):
     def __init__(self, tags):
         self._tags = tuple(tags)
 
+    @property
+    def fst_tags(self) -> tuple[str]:
+        return self._tags
+
     def __str__(self):
         return " ".join(f"{self.prefix} {tag}" for tag in self._tags)
 

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -37,6 +37,9 @@ class Paradigm:
     table, organized by **rows**, and then each row contains **cells**.
     """
 
+    # TODO: delete this when the old ParadigmFiller classes are deleted.
+    uses_pane_based_layout = True
+
     def __init__(self, panes: Iterable[Pane]):
         self._panes = tuple(panes)
 

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -212,6 +212,7 @@ class Pane:
 
 
 class Row:
+    is_header: bool
     has_content: bool
     num_cells: int
 
@@ -278,6 +279,7 @@ class ContentRow(Row):
     A single row from a pane. Rows contain cells.
     """
 
+    is_header = False
     has_content = True
 
     def __init__(self, cells: Iterable[Cell]):
@@ -321,6 +323,7 @@ class HeaderRow(Row):
     """
 
     prefix = "#"
+    is_header = True
     has_content = False
     num_cells = 0
 
@@ -578,7 +581,7 @@ class ColumnLabel(BaseLabelCell):
     Labels for the cells in the current column within the pane.
     """
 
-    label_for = "column"
+    label_for = "col"
     prefix = "|"
 
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
@@ -23,8 +23,8 @@
   {% load relabelling %}
 
   <section class="definition__paradigm paradigm js-replaceable-paradigm" data-cy="paradigm">
-    {# XXX: we should find a better way to contain all the data in the table :/ #}
     {% for pane in paradigm.panes %}
+    {# TODO: use dynamic pane arrangements to get rid of this hacky class. #}
     <div class="HACK-overflow-x-scroll">
       <table class="paradigm__table">
           <tbody>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
@@ -1,0 +1,96 @@
+{% spaceless %}
+
+  {% comment %}
+    The paradigm table, including the button at the bottom.
+
+    Parameters:
+      paradigm_tables: List[List[Row]] (see paradigm.py)
+      paradigm_size: utils.enums.ParadigmSize (TODO: use str value directly)
+
+    Example:
+
+        | something is happening now |
+        | I    | ninipân | ê-nipâyân |
+        | You  | kinipân | ê-nipâyan |
+        | [       + show more      ] |
+
+    JavaScript hooks:
+     - .js-replaceable-paradigm: encapsulates the ENTIRE paradigm so that
+       JavaScript can replace the contents with a different paradigm.
+     - .js-paradigm-size-button: the button for advancing the paradigm size
+       (basic, full, linguistic, etc.)
+     - .js-plus-minus: the + or - sign in the [± show more/less] button
+     - .js-button-text: the text in the [± show more/less] button
+
+  {% endcomment %}
+
+  {% load morphodict_orth %}
+
+  <section class="definition__paradigm paradigm js-replaceable-paradigm" data-cy="paradigm">
+    {# XXX: we should find a better way to contain all the data in the table :/ #}
+    <div class="HACK-overflow-x-scroll">
+      <table class="paradigm__table">
+        {% for subtable in paradigm_tables %}
+          <tbody>
+            {% for row in subtable %}
+              {% if row.is_title %}
+                <th class="paradigm-title" colspan="{{ row.span }}">{{ row.title }}</th>
+              {% else %}
+                <tr class="paradigm-row">
+                  {% for cell in row %}
+                    {% if cell.is_label %}
+                      <th scope="row" class="paradigm-label paradigm-label--row">
+                        {{ cell }}
+                      </th>
+                    {% elif cell.is_heading %}
+                      <th scope="col" class="paradigm-label paradigm-label--col">
+                        {{ cell }}
+                      </th>
+                    {% elif cell == "" %}
+                      <td class="paradigm-cell paradigm-cell--empty"></td>
+                    {% else %}
+                      {# it's an InflectionCell #}
+                      {# TODO: split this over multiple rows #}
+                      {% if cell.inflection == "" %}
+                        {# use em dash to denote that the form doesn't exist #}
+                        <td class="paradigm-cell paradigm-cell--lacuna">
+                          —
+                        </td>
+                      {% elif cell.frequency > 0 %}
+                        {# observed form #}
+                      <td class="paradigm-cell paradigm-cell--observed">
+                        {% orth cell.inflection %}
+                      </td>
+                      {% else %}
+                        {# unobserved form #}
+                        {% if not cell.has_analysis %}
+                          <td class="paradigm-cell paradigm-cell--no-analysis">
+
+                          </td>
+                        {% else %}
+                          <td class="paradigm-cell paradigm-cell--unobserved">
+                            {% orth cell.inflection %}
+                          </td>
+                        {% endif %}
+
+                      {% endif %}
+                    {% endif %}
+                  {% endfor %}
+                </tr>
+              {% endif %}
+            {% endfor %} {# /rows #}
+          </tbody>
+        {% endfor %} {# /subtables #}
+      </table>
+    </div>
+
+    <button class="paradigm__size-toggle-button js-paradigm-size-button" data-cy="paradigm-toggle-button">
+      <span class="paradigm__size-toggle-plus-minus js-plus-minus">
+        {% if paradigm_size.value == 'LINGUISTIC' %}- {% else %}+ {% endif %}
+      </span>
+      <span class="paradigm__size-toggle-button-text js-button-text">
+        show {% if paradigm_size.value == 'LINGUISTIC' %}less{% else %}more{% endif %}
+      </span>
+    </button>
+  </section>
+{% endspaceless %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
@@ -1,26 +1,21 @@
 {% spaceless %}
 
   {% comment %}
-    The paradigm table, including the button at the bottom.
+    The paradigm table.
 
     Parameters:
-      paradigm_tables: List[List[Row]] (see paradigm.py)
-      paradigm_size: utils.enums.ParadigmSize (TODO: use str value directly)
+      paradigm_tables: Paradigm (see CreeDictionary.paradigm.panes.Paradigm)
 
     Example:
 
-        | something is happening now |
-        | I    | ninipân | ê-nipâyân |
-        | You  | kinipân | ê-nipâyan |
-        | [       + show more      ] |
+        |             | One     | Many      |
+        | Here        | awa     | ana       |
+        | There       | kinipân | ê-nipâyan |
+        | Over Yonder | kinipân | ê-nipâyan |
 
     JavaScript hooks:
      - .js-replaceable-paradigm: encapsulates the ENTIRE paradigm so that
        JavaScript can replace the contents with a different paradigm.
-     - .js-paradigm-size-button: the button for advancing the paradigm size
-       (basic, full, linguistic, etc.)
-     - .js-plus-minus: the + or - sign in the [± show more/less] button
-     - .js-button-text: the text in the [± show more/less] button
 
   {% endcomment %}
 
@@ -28,16 +23,16 @@
 
   <section class="definition__paradigm paradigm js-replaceable-paradigm" data-cy="paradigm">
     {# XXX: we should find a better way to contain all the data in the table :/ #}
+    {% for pane in paradigm.panes %}
     <div class="HACK-overflow-x-scroll">
       <table class="paradigm__table">
-        {% for subtable in paradigm_tables %}
           <tbody>
-            {% for row in subtable %}
+            {% for row in pane.rows %}
               {% if row.is_title %}
                 <th class="paradigm-title" colspan="{{ row.span }}">{{ row.title }}</th>
               {% else %}
                 <tr class="paradigm-row">
-                  {% for cell in row %}
+                  {% for cell in row.cells %}
                     {% if cell.is_label %}
                       <th scope="row" class="paradigm-label paradigm-label--row">
                         {{ cell }}
@@ -46,51 +41,20 @@
                       <th scope="col" class="paradigm-label paradigm-label--col">
                         {{ cell }}
                       </th>
-                    {% elif cell == "" %}
+                    {% elif cell.is_empty %}
                       <td class="paradigm-cell paradigm-cell--empty"></td>
                     {% else %}
-                      {# it's an InflectionCell #}
-                      {# TODO: split this over multiple rows #}
-                      {% if cell.inflection == "" %}
-                        {# use em dash to denote that the form doesn't exist #}
-                        <td class="paradigm-cell paradigm-cell--lacuna">
-                          —
-                        </td>
-                      {% elif cell.frequency > 0 %}
-                        {# observed form #}
-                      <td class="paradigm-cell paradigm-cell--observed">
+                      <td class="paradigm-cell paradigm-cell--unobserved">
                         {% orth cell.inflection %}
                       </td>
-                      {% else %}
-                        {# unobserved form #}
-                        {% if not cell.has_analysis %}
-                          <td class="paradigm-cell paradigm-cell--no-analysis">
-
-                          </td>
-                        {% else %}
-                          <td class="paradigm-cell paradigm-cell--unobserved">
-                            {% orth cell.inflection %}
-                          </td>
-                        {% endif %}
-
-                      {% endif %}
                     {% endif %}
                   {% endfor %}
                 </tr>
               {% endif %}
             {% endfor %} {# /rows #}
           </tbody>
-        {% endfor %} {# /subtables #}
       </table>
     </div>
-
-    <button class="paradigm__size-toggle-button js-paradigm-size-button" data-cy="paradigm-toggle-button">
-      <span class="paradigm__size-toggle-plus-minus js-plus-minus">
-        {% if paradigm_size.value == 'LINGUISTIC' %}- {% else %}+ {% endif %}
-      </span>
-      <span class="paradigm__size-toggle-button-text js-button-text">
-        show {% if paradigm_size.value == 'LINGUISTIC' %}less{% else %}more{% endif %}
-      </span>
-    </button>
+    {% endfor %} {# /paradigm.panes #}
   </section>
 {% endspaceless %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
@@ -9,9 +9,9 @@
     Example:
 
         |             | One     | Many      |
-        | Here        | awa     | ana       |
-        | There       | kinipân | ê-nipâyan |
-        | Over Yonder | kinipân | ê-nipâyan |
+        | Here        | ôma     | ôhi       |
+        | There       | anima   | anihi     |
+        | Over Yonder | nêma    | nêhi      |
 
     JavaScript hooks:
      - .js-replaceable-paradigm: encapsulates the ENTIRE paradigm so that
@@ -34,11 +34,8 @@
                 <tr class="paradigm-row">
                   {% for cell in row.cells %}
                     {% if cell.is_label %}
-                      <th scope="row" class="paradigm-label paradigm-label--row">
-                        {{ cell }}
-                      </th>
-                    {% elif cell.is_heading %}
-                      <th scope="col" class="paradigm-label paradigm-label--col">
+                      <th scope="{{ cell.label_for }}"
+                          class="paradigm-label paradigm-label--{{ cell.label_for }}">
                         {{ cell }}
                       </th>
                     {% elif cell.is_empty %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
@@ -20,6 +20,7 @@
   {% endcomment %}
 
   {% load morphodict_orth %}
+  {% load relabelling %}
 
   <section class="definition__paradigm paradigm js-replaceable-paradigm" data-cy="paradigm">
     {# XXX: we should find a better way to contain all the data in the table :/ #}
@@ -36,7 +37,7 @@
                     {% if cell.is_label %}
                       <th scope="{{ cell.label_for }}"
                           class="paradigm-label paradigm-label--{{ cell.label_for }}">
-                        {{ cell }}
+                          {% relabel cell.fst_tags %}
                       </th>
                     {% elif cell.is_empty %}
                       <td class="paradigm-cell paradigm-cell--empty"></td>

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
@@ -19,15 +19,13 @@
        JavaScript can replace the contents with a different paradigm.
      - .js-paradigm-size-button: the button for advancing the paradigm size
        (basic, full, linguistic, etc.)
-     - .js-plus-minus: the + or - sign in the [± show more/less] button
-     - .js-button-text: the text in the [± show more/less] button
 
   {% endcomment %}
 
   {% load morphodict_orth %}
 
   <section class="definition__paradigm paradigm js-replaceable-paradigm" data-cy="paradigm">
-    {# XXX: we should find a better way to contain all the data in the table :/ #}
+    {# TODO: use dynamic pane arrangements to get rid of this hacky class. #}
     <div class="HACK-overflow-x-scroll">
       <table class="paradigm__table">
         {% for subtable in paradigm_tables %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
@@ -19,6 +19,8 @@
        JavaScript can replace the contents with a different paradigm.
      - .js-paradigm-size-button: the button for advancing the paradigm size
        (basic, full, linguistic, etc.)
+     - .js-plus-minus: the + or - sign in the [± show more/less] button
+     - .js-button-text: the text in the [± show more/less] button
 
   {% endcomment %}
 

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
@@ -25,7 +25,7 @@
   {% load morphodict_orth %}
 
   <section class="definition__paradigm paradigm js-replaceable-paradigm" data-cy="paradigm">
-    {# TODO: use dynamic pane arrangements to get rid of this hacky class. #}
+    {# XXX: we should find a better way to contain all the data in the table :/ #}
     <div class="HACK-overflow-x-scroll">
       <table class="paradigm__table">
         {% for subtable in paradigm_tables %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
@@ -62,7 +62,11 @@
 
     <section id="paradigm">
       {% if paradigm_tables %}
-        {% include './components/paradigm.html' %}
+        {% if paradigm_tables.uses_pane_based_layout %}
+          {% include './components/paradigm-with-panes.html' with paradigm=paradigm_tables %}
+        {% else %}
+          {% include './components/paradigm.html' %}
+        {% endif %}
       {% endif %}
     </section>
   </article>

--- a/CreeDictionary/CreeDictionary/templatetags/relabelling.py
+++ b/CreeDictionary/CreeDictionary/templatetags/relabelling.py
@@ -1,0 +1,20 @@
+"""
+Access to relabelling from templates.
+"""
+from typing import Sequence, cast
+
+from django import template
+from utils.types import FSTTag
+
+from CreeDictionary.relabelling import LABELS
+
+register = template.Library()
+
+
+@register.simple_tag
+def relabel(thing: tuple[FSTTag]):
+    """
+    Gets the best matching label for the given object.
+    """
+    # TODO: take in request context; relabel according to current label preference
+    return LABELS.english.get_longest(thing)

--- a/CreeDictionary/CreeDictionary/templatetags/relabelling.py
+++ b/CreeDictionary/CreeDictionary/templatetags/relabelling.py
@@ -1,7 +1,6 @@
 """
 Access to relabelling from templates.
 """
-from typing import Sequence, cast
 
 from django import template
 from utils.types import FSTTag

--- a/CreeDictionary/tests/CreeDictionary_tests/test_relabelling_tag.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_relabelling_tag.py
@@ -14,7 +14,7 @@ def test_relabel_tag():
     plain_english = "someone"
 
     context = Context({"label": RowLabel(unspecified_actor)})
-    template = Template("{% load relabelling %}" "{% relabel label.fst_tags %}")
+    template = Template("{% load relabelling %} {% relabel label.fst_tags %}")
 
     rendered = template.render(context)
     assert plain_english in rendered.lower()

--- a/CreeDictionary/tests/CreeDictionary_tests/test_relabelling_tag.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_relabelling_tag.py
@@ -1,0 +1,19 @@
+from django.template import Context, Template
+
+from CreeDictionary.paradigm.panes import RowLabel
+
+
+def test_relabel_tag():
+    """
+    Test that simple relabelling works.
+    """
+    # XXX: note, this relies on the current contents of crk.altlabel.tsv;
+    # the contents could change, so try to choose a label that... is unlikely to change?
+    # I guess both the tag and label for "unspecified actor" are unlikely to change, so:
+    unspecified_actor = ("X",)
+    plain_english = "someone"
+    context = Context({"label": RowLabel(unspecified_actor)})
+    template = Template("{% load relabelling %}" "{% relabel label.fst_tags %}")
+
+    rendered = template.render(context)
+    assert plain_english in rendered.lower()

--- a/CreeDictionary/tests/CreeDictionary_tests/test_relabelling_tag.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_relabelling_tag.py
@@ -7,11 +7,12 @@ def test_relabel_tag():
     """
     Test that simple relabelling works.
     """
-    # XXX: note, this relies on the current contents of crk.altlabel.tsv;
-    # the contents could change, so try to choose a label that... is unlikely to change?
+    # NOTE: this relies on the current contents of crk.altlabel.tsv
+    # Its contents could change, so TRY to choose a label that is unlikely to change.
     # I guess both the tag and label for "unspecified actor" are unlikely to change, so:
     unspecified_actor = ("X",)
     plain_english = "someone"
+
     context = Context({"label": RowLabel(unspecified_actor)})
     template = Template("{% load relabelling %}" "{% relabel label.fst_tags %}")
 

--- a/cypress/integration/paradigm.spec.js
+++ b/cypress/integration/paradigm.spec.js
@@ -30,7 +30,7 @@ describe('I want to search for a Cree word and see its inflectional paradigm', (
     })
   }
 
-  it.only('should display the paradigm for personal pronouns', () => {
+  it('should display the paradigm for personal pronouns', () => {
     const head = 'niya'
     const inflections = ['kiya', 'wiya']
 

--- a/cypress/integration/paradigm.spec.js
+++ b/cypress/integration/paradigm.spec.js
@@ -1,4 +1,4 @@
-describe(' I want to search for a Cree word and see its inflectional paradigm', () => {
+describe('I want to search for a Cree word and see its inflectional paradigm', () => {
   // Test at least one word from each word class:
   const testCases = [
     {pos: 'VTA', lemma: 'mowêw', inflections: ['kimowin', 'kimowitin', 'ê-mowât']},
@@ -30,6 +30,25 @@ describe(' I want to search for a Cree word and see its inflectional paradigm', 
     })
   }
 
+  it.only('should display the paradigm for personal pronouns', () => {
+    const head = 'niya'
+    const inflections = ['kiya', 'wiya']
+
+    cy.visitSearch(head)
+    cy.get('[data-cy=search-results]')
+      .contains('a', head)
+      .click()
+
+    cy.get('[data-cy=paradigm]')
+      .as('paradigm')
+
+    let ctx = cy.get('@paradigm')
+      .should('contain', head)
+    for (let wordform of inflections) {
+      ctx = ctx.and('contain', wordform)
+    }
+  })
+
   // TODO: the next test should be here, but it is broken because the
   // upstream layouts are broken :/
   it.skip('should display titles within the paradigm', () => {
@@ -51,7 +70,7 @@ describe(' I want to search for a Cree word and see its inflectional paradigm', 
 })
 
 
-describe(' I want to know if a form is observed inside a paradigm table', () => {
+describe('I want to know if a form is observed inside a paradigm table', () => {
   // TODO: this test should be re-enabled in linguist mode!
   it.skip('shows inflection frequency as digits in brackets', ()=>{
     cy.visitLemma('nipâw')

--- a/cypress/integration/paradigm.spec.js
+++ b/cypress/integration/paradigm.spec.js
@@ -47,6 +47,19 @@ describe('I want to search for a Cree word and see its inflectional paradigm', (
     for (let wordform of inflections) {
       ctx = ctx.and('contain', wordform)
     }
+
+    const labels = [
+      { scope: "col", label: /\bone\b/i },
+      { scope: "col", label: /\bmany\b/i },
+      { scope: "row", label: "I" },
+      { scope: "row", label: /\byou\b/i },
+    ]
+
+    for (let {scope, label} of labels) {
+      cy.get("@paradigm")
+          .contains("th", label)
+          .should("have.attr", "scope", scope)
+    }
   })
 
   // TODO: the next test should be here, but it is broken because the


### PR DESCRIPTION
# What's in this PR?

**NOTE**: this is a **stacked PR** and must be reviewed _after_ #768

A very basic implementation of rendering the frontend with the new pane-based static paradigm layouts. It looks like this:

![Screenshot of the personal pronoun paradigm](https://user-images.githubusercontent.com/2294397/116771156-653db280-aa06-11eb-9f1b-c885cae03110.png)

 * added: very basic `{% relabel %}` tag — this will need to be expaned in the future, but it works for now
 * added: pane-based HTML template
 * added: checks if the analysis is in a known static layout; if so, then that static layout is fetched and rendered
 * added: unit tests AND end-to-end tests 😉 
 * changed: `ColumnLabel.label_for` was changed to `"col"` to match [the value in the HTML spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#attr-scope)


Fixes #164
Addresses #743 