### PR TITLE
change: a few tweaks and fixes for styling

### DIFF
--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -87,7 +87,7 @@
       <ul class="unbullet">
         <li>
           <form method="POST" action={% url 'cree-dictionary-change-display-mode' %}>
-            <button class="unbutton linklike footer__link" type="submit" name="mode" value="community" data-cy="enable-community-mode">
+            <button class="unbutton link footer__link" type="submit" name="mode" value="community" data-cy="enable-community-mode">
               Community mode
             </button>
             {% csrf_token %}
@@ -95,7 +95,7 @@
         </li>
         <li>
           <form method="POST" action={% url 'cree-dictionary-change-display-mode' %}>
-            <button class="unbutton linklike footer__link" type="submit" name="mode" value="linguistic" data-cy="enable-linguistic-mode">
+            <button class="unbutton link footer__link" type="submit" name="mode" value="linguistic" data-cy="enable-linguistic-mode">
               Linguist mode
             </button>
             {% csrf_token %}

--- a/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
+++ b/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
@@ -23,10 +23,10 @@
   {% load relabelling %}
 
   <section class="definition__paradigm paradigm js-replaceable-paradigm" data-cy="paradigm">
-    {% for pane in paradigm.panes %}
     {# TODO: use dynamic pane arrangements to get rid of this hacky class. #}
     <div class="HACK-overflow-x-scroll">
       <table class="paradigm__table">
+        {% for pane in paradigm.panes %}
           <tbody>
             {% for row in pane.rows %}
               {% if row.is_title %}
@@ -51,8 +51,8 @@
               {% endif %}
             {% endfor %} {# /rows #}
           </tbody>
+        {% endfor %} {# /paradigm.panes #}
       </table>
     </div>
-    {% endfor %} {# /paradigm.panes #}
   </section>
 {% endspaceless %}

--- a/CreeDictionary/res/layouts/static/personal-pronouns.tsv
+++ b/CreeDictionary/res/layouts/static/personal-pronouns.tsv
@@ -2,6 +2,7 @@
 _ 1Sg	niya+Pron+Pers+1Sg
 _ 2Sg	kiya+Pron+Pers+2Sg
 _ 3Sg	wiya+Pron+Pers+3Sg
+
 	| Pl
 _ 1Pl	niyanân+Pron+Pers+1Pl
 _ 12Pl	kiyânaw+Pron+Pers+12Pl

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -804,7 +804,8 @@ a.multiple-recordings__action-button {
 
 .paradigm-label--col {
   /* Sometimes the label is too dang wide, so just hide it. */
-  overflow-x: ellipsis;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 
 .paradigm-cell {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -798,11 +798,16 @@ a.multiple-recordings__action-button {
 
 .paradigm-label {
   text-align: left;
-  font-style: italic;
   font-weight: var(--body-font-weight);
 }
 
+.paradigm-label--row {
+  font-style: italic;
+}
+
 .paradigm-label--col {
+  font-weight: bold;
+
   /* Sometimes the label is too dang wide, so just hide it. */
   overflow-x: hidden;
   text-overflow: ellipsis;

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -900,14 +900,14 @@ a.multiple-recordings__action-button {
 }
 
 .footer a:link,
-.footer a:visited
-.footer .linklike:link,
-.footer .linklike:visited {
+.footer a:visited,
+.footer .link:link,
+.footer .link:visited {
   color: var(--footer-text-color);
 }
 
 .footer a:hover,
-.footer .linklike:hover {
+.footer .link:hover {
   color: var(--footer-link-hover-color);
 }
 

--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -37,7 +37,7 @@
   cursor: pointer;
 }
 
-.linklike {
+.link {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
# What's in this PR?

 - refactor: CSS class `.linklike` is now `.link`
 - fix: **visited links in the footer are no longer purple**!
 - fix: use correct CSS for when a column label is too wide (although, frankly, I don't recall this being a problem...)
 - change: make column headers **bold**
 - change: make each pane its own `<tbody>` because semantics
 - change: make the personal pronoun layout use two panes!