### PR TITLE
change: render paradigm declared in the paradigm

### DIFF
--- a/CreeDictionary/CreeDictionary/ensure_data.py
+++ b/CreeDictionary/CreeDictionary/ensure_data.py
@@ -1,0 +1,87 @@
+"""
+Ensure the database -- especially the test database -- has certain requisite data.
+"""
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+# Maps text with (legacy) part-of-speech to a paradigm.
+# See res/layouts/static for a list of valid paradigms.
+# Last updated: 2021-05-10
+WORDFORM_TO_PARADIGM = [
+    # Personal pronouns
+    ("niya", "PRON", "personal-pronouns"),
+    ("kiya", "PRON", "personal-pronouns"),
+    ("wiya", "PRON", "personal-pronouns"),
+    ("niyanân", "PRON", "personal-pronouns"),
+    ("kiyânaw", "PRON", "personal-pronouns"),
+    ("kiyawâw", "PRON", "personal-pronouns"),
+    ("wiyawâw", "PRON", "personal-pronouns"),
+    # Animate demonstratives
+    ("awa", "PRON", "demonstrative-pronouns"),
+    ("ana", "PRON", "demonstrative-pronouns"),
+    ("nâha", "PRON", "demonstrative-pronouns"),
+    ("ôki", "PRON", "demonstrative-pronouns"),
+    ("aniki", "PRON", "demonstrative-pronouns"),
+    ("nêki", "PRON", "demonstrative-pronouns"),
+    # Inanimate demonstratives
+    ("ôma", "PRON", "demonstrative-pronouns"),
+    ("ôhi", "PRON", "demonstrative-pronouns"),
+    ("anima", "PRON", "demonstrative-pronouns"),
+    ("anihi", "PRON", "demonstrative-pronouns"),
+    ("nêma", "PRON", "demonstrative-pronouns"),
+    ("nêhi", "PRON", "demonstrative-pronouns"),
+    # Inanimate/Obviative inanimate demonstratives
+    ("ôhi", "PRON", "demonstrative-pronouns"),
+    ("anihi", "PRON", "demonstrative-pronouns"),
+    ("nêhi", "PRON", "demonstrative-pronouns"),
+]
+
+
+def ensure_wordform_paradigms():
+    """
+    Ensures that at least one Wordform object has a paradigm.
+    """
+    from API.models import Wordform
+
+    if Wordform.objects.exclude(paradigm=None).exists():
+        # Has paradigms; don't bother updating
+        logger.info("there's at least one wordform with a paradigm; skipping update")
+        return
+
+    to_update = set_paradigm_for_demonstrative_and_personal_pronouns(
+        Wordform.objects.all()
+    )
+    Wordform.objects.bulk_update(to_update, ["paradigm"])
+
+
+def set_paradigm_for_demonstrative_and_personal_pronouns(query_set):
+    """
+    Given a query set of Wordform objects, updates all wordforms with a paradigm field.
+
+    Does NOT .save() or commit the objects to the database! You have to do that with the
+    list of returned objects.
+
+    Why does this object not directly use the Wordform class/model?
+    Because this function could be imported **before** Django could initialize the
+    database models (e.g., in migrations). The **caller** is completely reponsible for
+    providing the appropriate query_set and commiting the updates to the database.
+    """
+    objects_to_update = []
+
+    for text, pos, paradigm in WORDFORM_TO_PARADIGM:
+        for wordform in query_set.filter(text=text, pos=pos):
+            if wordform.paradigm:
+                logger.info(
+                    "Not replacing existing paradigm %r on %r",
+                    wordform.paradigm,
+                    wordform,
+                )
+                continue
+            wordform.paradigm = paradigm
+            objects_to_update.append(wordform)
+
+    return objects_to_update

--- a/CreeDictionary/CreeDictionary/management/commands/ensuretestdb.py
+++ b/CreeDictionary/CreeDictionary/management/commands/ensuretestdb.py
@@ -1,13 +1,14 @@
 import json
 import secrets
 
+from API.models import Definition, Wordform
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
-
-from API.models import Definition, Wordform
 from utils import shared_res_dir
+
+from CreeDictionary.ensure_data import ensure_wordform_paradigms
 
 
 class Command(BaseCommand):
@@ -24,6 +25,7 @@ class Command(BaseCommand):
         call_command("migrate", verbosity=0)
 
         import_test_dictionary()
+        ensure_wordform_paradigms()
         add_some_auto_translations()
         call_command("ensurecypressadminuser")
 

--- a/CreeDictionary/CreeDictionary/migrations/0003_add_wordform_paradigms.py
+++ b/CreeDictionary/CreeDictionary/migrations/0003_add_wordform_paradigms.py
@@ -1,33 +1,8 @@
 from django.db import migrations
 
-WORDFORM_TO_PARADIGM = {
-    # Personal pronouns
-    ("niya", "PRON"): "personal-pronouns",
-    ("kiya", "PRON"): "personal-pronouns",
-    ("wiya", "PRON"): "personal-pronouns",
-    ("niyanân", "PRON"): "personal-pronouns",
-    ("kiyânaw", "PRON"): "personal-pronouns",
-    ("kiyawâw", "PRON"): "personal-pronouns",
-    ("wiyawâw", "PRON"): "personal-pronouns",
-    # Animate demonstratives
-    ("awa", "PRON"): "demonstrative-pronouns",
-    ("ana", "PRON"): "demonstrative-pronouns",
-    ("nâha", "PRON"): "demonstrative-pronouns",
-    ("ôki", "PRON"): "demonstrative-pronouns",
-    ("aniki", "PRON"): "demonstrative-pronouns",
-    ("nêki", "PRON"): "demonstrative-pronouns",
-    # Inanimate demonstratives
-    ("ôma", "PRON"): "demonstrative-pronouns",
-    ("ôhi", "PRON"): "demonstrative-pronouns",
-    ("anima", "PRON"): "demonstrative-pronouns",
-    ("anihi", "PRON"): "demonstrative-pronouns",
-    ("nêma", "PRON"): "demonstrative-pronouns",
-    ("nêhi", "PRON"): "demonstrative-pronouns",
-    # Inanimate/Obviative inanimate demonstratives
-    ("ôhi", "PRON"): "demonstrative-pronouns",
-    ("anihi", "PRON"): "demonstrative-pronouns",
-    ("nêhi", "PRON"): "demonstrative-pronouns",
-}
+from CreeDictionary.ensure_data import (
+    set_paradigm_for_demonstrative_and_personal_pronouns,
+)
 
 
 def add_explicit_paradigm_field(apps, schema_editor):
@@ -35,21 +10,10 @@ def add_explicit_paradigm_field(apps, schema_editor):
     For the current (2021-05-07) paradigms, explicitly adds the paradigm filed.
     """
     Wordform = apps.get_model("API", "Wordform")
-
-    objects_to_update = []
-
-    for (text, pos), paradigm in WORDFORM_TO_PARADIGM.items():
-        for wordform in Wordform.objects.filter(text=text, pos=pos):
-            if wordform.paradigm:
-                print(
-                    "Not replacing existing paradigm on", wordform,
-                    wordform.paradigm
-                )
-                continue
-            wordform.paradigm = paradigm
-            objects_to_update.append(wordform)
-
-    Wordform.objects.bulk_update(objects_to_update, ["paradigm"])
+    to_update = set_paradigm_for_demonstrative_and_personal_pronouns(
+        Wordform.objects.all()
+    )
+    Wordform.objects.bulk_update(to_update, ["paradigm"])
 
 
 class Migration(migrations.Migration):

--- a/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -20,8 +20,16 @@ class ParadigmManager:
     def __init__(self, layout_directory: Path, generation_fst: TransducerFile):
         # TODO: technically str == ConcatAnalysis
         self._analysis_to_layout: dict[str, ParadigmLayout] = {}
+        self._name_to_layout: dict[str, Paradigm] = {}
         self._load_static_from(layout_directory / "static")
         self._generator = generation_fst
+
+    def static_paradigm_for(self, name: str) -> Optional[Paradigm]:
+        """
+        Returns a static paradigm with the given name.
+        Returns None if there is no paradigm with such a name.
+        """
+        return self._name_to_layout.get(name)
 
     def paradigm_for(self, analysis: str) -> Optional[Paradigm]:
         """
@@ -38,6 +46,7 @@ class ParadigmManager:
 
         for layout_file in path.glob("*.tsv"):
             layout = ParadigmLayout.loads(layout_file.read_text(encoding="UTF-8"))
+            self._name_to_layout[layout_file.stem] = layout.as_static_paradigm()
 
             for inflection in layout.inflection_cells:
                 self._analysis_to_layout[inflection.analysis] = layout

--- a/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -18,11 +18,10 @@ class ParadigmManager:
     """
 
     def __init__(self, layout_directory: Path, generation_fst: TransducerFile):
-        # TODO: technically str == ConcatAnalysis
-        self._analysis_to_layout: dict[str, ParadigmLayout] = {}
-        self._name_to_layout: dict[str, Paradigm] = {}
-        self._load_static_from(layout_directory / "static")
         self._generator = generation_fst
+        self._name_to_layout: dict[str, Paradigm] = {}
+
+        self._load_static_from(layout_directory / "static")
 
     def static_paradigm_for(self, name: str) -> Optional[Paradigm]:
         """
@@ -30,14 +29,6 @@ class ParadigmManager:
         Returns None if there is no paradigm with such a name.
         """
         return self._name_to_layout.get(name)
-
-    def paradigm_for(self, analysis: str) -> Optional[Paradigm]:
-        """
-        Given an analysis, returns its paradigm.
-        """
-        if layout := self._analysis_to_layout.get(analysis):
-            return self._inflect(layout)
-        return None
 
     def _load_static_from(self, path: Path):
         """
@@ -47,9 +38,6 @@ class ParadigmManager:
         for layout_file in path.glob("*.tsv"):
             layout = ParadigmLayout.loads(layout_file.read_text(encoding="UTF-8"))
             self._name_to_layout[layout_file.stem] = layout.as_static_paradigm()
-
-            for inflection in layout.inflection_cells:
-                self._analysis_to_layout[inflection.analysis] = layout
 
     def _inflect(self, layout: ParadigmLayout) -> Paradigm:
         analyses = layout.generate_fst_analysis_string(lemma="").splitlines(

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -145,7 +145,7 @@ class ParadigmLayout(Paradigm):
         return Paradigm(pane.fill(forms) for pane in self.panes)
 
     def as_static_paradigm(self) -> Paradigm:
-        f"""
+        """
         Returns a Paradigm that can be rendered without having to explicitly fill it.
         
         :raises ParadigmIsNotStaticError: when called on a dynamic paradigm
@@ -436,7 +436,7 @@ class WordformCell(Cell):
         return self.inflection == wordform
 
     def fill_one(self, forms: dict[str, Collection[str]]) -> Cell:
-        # No need to cell that already has contents!
+        # No need to fill a cell that already has contents!
         return self
 
     def __str__(self) -> str:

--- a/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -11,10 +11,9 @@ from functools import cached_property
 from itertools import zip_longest
 from typing import Collection, Iterable, Optional, TextIO
 
-from more_itertools import first
+from more_itertools import first, ilen
 
 logger = logging.getLogger(__name__)
-
 
 class ParseError(Exception):
     """
@@ -25,6 +24,12 @@ class ParseError(Exception):
 class ParadigmGenerationError(Exception):
     """
     Raised when there's some issue with generating/filling a paradigm.
+    """
+
+class ParadigmIsNotStaticError(Exception):
+    """
+    Raised when calling .as_static_paradigm() on a layout with unfilled
+    placeholders (i.e., on a dynamic paradigm).
     """
 
 
@@ -138,6 +143,17 @@ class ParadigmLayout(Paradigm):
         paradigm with all its InflectionTemplate cells replaced with WordformCells.
         """
         return Paradigm(pane.fill(forms) for pane in self.panes)
+
+    def as_static_paradigm(self) -> Paradigm:
+        f"""
+        Returns a Paradigm that can be rendered without having to explicitly fill it.
+        
+        :raises ParadigmIsNotStaticError: when called on a dynamic paradigm
+        """
+        if ilen(self.inflection_cells) > 0:
+            raise ParadigmIsNotStaticError("not a static paradigm; contains "
+                                           "inflection templates")
+        return self.fill({})
 
     def __str__(self):
         return self.dumps()
@@ -376,8 +392,10 @@ class Cell:
             return RowLabel.parse(text)
         elif text.startswith("| "):
             return ColumnLabel.parse(text)
-        else:
+        elif looks_like_analysis_string(text):
             return InflectionTemplate.parse(text)
+        else:
+            return WordformCell.parse(text)
 
     def contains_wordform(self, wordform: str) -> bool:
         if not self.is_inflection:
@@ -404,8 +422,8 @@ class WordformCell(Cell):
     called, converting all its InflectionTemplate instances to WordformCell instances.
 
     How this differs between **static** and **dynamic** paradigms:
-     - **static** paradigms still have InflectionTemplate instances; however, an entire
-       static paradigm can be filled once and be reused every subsequent time.
+     - **static** paradigms contain ZERO InflectionCell instances; they will all be
+        WordformCell instances.
      - **dynamic** paradigms must be filled for every unique FST lemma.
     """
 
@@ -418,7 +436,8 @@ class WordformCell(Cell):
         return self.inflection == wordform
 
     def fill_one(self, forms: dict[str, Collection[str]]) -> Cell:
-        raise AssertionError(f"Cannot fill a cell that already has content: {self}")
+        # No need to cell that already has contents!
+        return self
 
     def __str__(self) -> str:
         return self.inflection
@@ -434,9 +453,8 @@ class WordformCell(Cell):
 
     @classmethod
     def parse(cls, text: str):
-        raise AssertionError(
-            "A literal wordform can never be parsed from directly " "from a layout"
-        )
+        assert not looks_like_analysis_string(text)
+        return cls(text)
 
 
 class InflectionTemplate(Cell):
@@ -592,7 +610,7 @@ def looks_like_analysis_string(text: str) -> bool:
     """
     Returns true if the cell might be analysis.
     """
-    return "${lemma}" in text or "+" in text
+    return "${lemma}" in text
 
 
 def pairs(seq):

--- a/CreeDictionary/CreeDictionary/views.py
+++ b/CreeDictionary/CreeDictionary/views.py
@@ -326,7 +326,7 @@ def disambiguating_filter_from_query_params(query_params: dict[str, str]):
 
 
 def paradigm_for(
-    lemma: Wordform, paradigm_size: ParadigmSize
+    wordform: Wordform, paradigm_size: ParadigmSize
 ) -> Union[Paradigm, list[list[Row]]]:
     """
     Returns a paradigm for the given wordform at the desired size.
@@ -335,16 +335,16 @@ def paradigm_for(
     """
     # TODO: make this use the new-style ParadigmManager exclusively
 
-    if name := lemma.paradigm:
+    if name := wordform.paradigm:
         if static_paradigm := default_paradigm_manager().static_paradigm_for(name):
             return static_paradigm
         logger.warning(
             "Could not retrieve static paradigm %r " "associated with wordform %r",
             name,
-            lemma,
+            wordform,
         )
         # TODO: better return value for when a paradigm cannot be found
         return []
 
     # try returning an old-style paradigm: may return []
-    return generate_paradigm(lemma, paradigm_size)
+    return generate_paradigm(wordform, paradigm_size)

--- a/CreeDictionary/DatabaseManager/management/commands/xmlimport.py
+++ b/CreeDictionary/DatabaseManager/management/commands/xmlimport.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from django.core.management import BaseCommand, call_command
 
+from CreeDictionary.ensure_data import ensure_wordform_paradigms
+
 
 class Command(BaseCommand):
     help = """Import a dictionary .xml file into db search tables.
@@ -33,5 +35,9 @@ class Command(BaseCommand):
                 call_command("wipedefinitions", yes_really=True)
 
             import_xmls(Path(options["xml_path"]))
+            # As of 2021-05-10, the XML format does not specify explicit paradigm fields
+            # for, e.g., demonstrative pronouns or personal pronouns, so add them in
+            # here:
+            ensure_wordform_paradigms()
         else:
             raise NotImplementedError

--- a/CreeDictionary/res/layouts/static/demonstrative-pronouns.tsv
+++ b/CreeDictionary/res/layouts/static/demonstrative-pronouns.tsv
@@ -1,19 +1,19 @@
 	| A | Sg
-_ Sg _ Prox	awa+Pron+Dem+Prox+A+Sg
-_ Sg _ Med	awa+Pron+Dem+Med+A+Sg
-_ Sg _ Dist	awa+Pron+Dem+Dist+A+Sg
+_ Prox	awa
+_ Med	ana
+_ Dist	nâha
 	
 	| A | Pl
-_ Sg _ Prox	awa+Pron+Dem+Prox+A+Pl
-_ Sg _ Med	awa+Pron+Dem+Med+A+Pl
-_ Sg _ Dist	awa+Pron+Dem+Dist+A+Pl
+_ Prox	ôki
+_ Med	aniki
+_ Dist	nêki
 	
 	| I | Sg
-_ Pl _ Prox	ôma+Pron+Dem+Prox+I+Sg
-_ Pl _ Med	ôma+Pron+Dem+Med+I+Sg
-_ Pl _ Dist	ôma+Pron+Dem+Dist+I+Sg
+_ Prox	ôma
+_ Med	anima
+_ Dist	nêma
 	
 	| I | Pl
-_ Pl _ Prox	ôma+Pron+Dem+Prox+I+Pl
-_ Pl _ Med	ôma+Pron+Dem+Med+I+Pl
-_ Pl _ Dist	ôma+Pron+Dem+Dist+I+Pl
+_ Prox	ôhi
+_ Med	anihi
+_ Dist	nêhi

--- a/CreeDictionary/res/layouts/static/personal-pronouns.tsv
+++ b/CreeDictionary/res/layouts/static/personal-pronouns.tsv
@@ -1,10 +1,10 @@
 	| Sg
-_ 1Sg	niya+Pron+Pers+1Sg
-_ 2Sg	kiya+Pron+Pers+2Sg
-_ 3Sg	wiya+Pron+Pers+3Sg
+_ 1Sg	niya
+_ 2Sg	kiya
+_ 3Sg	wiya
 
 	| Pl
-_ 1Pl	niyanân+Pron+Pers+1Pl
-_ 12Pl	kiyânaw+Pron+Pers+12Pl
-_ 2Pl	kiyawâw+Pron+Pers+2Pl
-_ 3Pl	wiyawâw+Pron+Pers+3Pl
+_ 1Pl	niyanân
+_ 12Pl	kiyânaw
+_ 2Pl	kiyawâw
+_ 3Pl	wiyawâw

--- a/CreeDictionary/tests/CreeDictionary_tests/data/paradigm-layouts/static/demonstrative-pronouns.tsv
+++ b/CreeDictionary/tests/CreeDictionary_tests/data/paradigm-layouts/static/demonstrative-pronouns.tsv
@@ -1,4 +1,4 @@
 	| I	| A
-_ Prox	ôma+Pron+Dem+Prox+I+Sg	awa+Pron+Dem+Prox+A+Sg
-_ Med	anima+Pron+Dem+Med+I+Sg	ana+Pron+Dem+Med+A+Sg
-_ Dist	nêma+Pron+Dem+Dist+I+Sg	nâha+Pron+Dem+Dist+A+Sg
+_ Prox	ôma	awa
+_ Med	anima	ana
+_ Dist	nêma	nâha

--- a/CreeDictionary/tests/CreeDictionary_tests/data/paradigm-layouts/static/personal-pronouns.tsv
+++ b/CreeDictionary/tests/CreeDictionary_tests/data/paradigm-layouts/static/personal-pronouns.tsv
@@ -1,9 +1,9 @@
 	| Sg
-_ 1Sg	niya+Pron+Pers+1Sg
-_ 2Sg	kiya+Pron+Pers+2Sg
-_ 3Sg	wiya+Pron+Pers+3Sg
+_ 1Sg	niya
+_ 2Sg	kiya
+_ 3Sg	wiya
 	| Pl
-_ 1Pl	niyanân+Pron+Pers+1Pl
-_ 12Pl	kiyânaw+Pron+Pers+12Pl
-_ 2Pl	kiyawâw+Pron+Pers+2Pl
-_ 3Pl	wiyawâw+Pron+Pers+3Pl
+_ 1Pl	niyanân
+_ 12Pl	kiyânaw
+_ 2Pl	kiyawâw
+_ 3Pl	wiyawâw

--- a/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -95,13 +95,8 @@ def test_wordform_cell():
 
     assert cell.contains_wordform(wordform)
 
-    # It cannot be filled in — it's already filled in!
-    with pytest.raises(AssertionError):
-        cell.fill_one({})
-
-    # It should never be parsed from a layout
-    with pytest.raises(AssertionError):
-        WordformCell.parse(wordform)
+    # Trying to fill a cell returns the same cell back:
+    assert cell == cell.fill_one({})
 
 
 def sample_pane():
@@ -122,7 +117,7 @@ def sample_pane():
         EmptyCell(),
         MissingForm(),
         InflectionTemplate("${lemma}+N+A+Sg"),
-        WordformCell("ôma+Pron+Dem+Prox+I+Sg"),
+        WordformCell("ôma"),
         ColumnLabel(("Sg",)),
         RowLabel(("1Sg",)),
         HeaderRow(("Imp",)),

--- a/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -57,7 +57,9 @@ def test_parse_demonstrative_pronoun_paradigm(pronoun_paradigm_path: Path):
     production site... buuuuuuuuut, it's useful as a test fixture!
     """
     with pronoun_paradigm_path.open(encoding="UTF-8") as layout_file:
-        pronoun_paradigm = ParadigmLayout.load(layout_file)
+        pronoun_paradigm_layout = ParadigmLayout.load(layout_file)
+
+    pronoun_paradigm = pronoun_paradigm_layout.as_static_paradigm()
 
     assert count(pronoun_paradigm.panes) == 1
 
@@ -120,7 +122,7 @@ def sample_pane():
         EmptyCell(),
         MissingForm(),
         InflectionTemplate("${lemma}+N+A+Sg"),
-        InflectionTemplate("ôma+Pron+Dem+Prox+I+Sg"),
+        WordformCell("ôma+Pron+Dem+Prox+I+Sg"),
         ColumnLabel(("Sg",)),
         RowLabel(("1Sg",)),
         HeaderRow(("Imp",)),

--- a/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -16,6 +16,7 @@ from CreeDictionary.paradigm.panes import (
     InflectionTemplate,
     MissingForm,
     Pane,
+    ParadigmIsNotStaticError,
     ParadigmLayout,
     RowLabel,
     WordformCell,
@@ -66,6 +67,16 @@ def test_parse_demonstrative_pronoun_paradigm(pronoun_paradigm_path: Path):
     basic_pane = first(pronoun_paradigm.panes)
     assert basic_pane.num_columns == 3
     assert count(basic_pane.rows) == 4
+
+
+def test_as_static_paradigm_raises_on_dynamic_paradigm():
+    dynamic_layout = ParadigmLayout.loads("_ Prox\t${lemma}+Pron+I+Prox+Sg\n")
+    static_layout = ParadigmLayout.loads("_ Prox\tôma\n")
+
+    assert static_layout.as_static_paradigm()
+
+    with pytest.raises(ParadigmIsNotStaticError):
+        dynamic_layout.as_static_paradigm()
 
 
 def test_dump_equal_to_file_on_disk(na_layout_path: Path):

--- a/CreeDictionary/tests/CreeDictionary_tests/test_paradigm_manager.py
+++ b/CreeDictionary/tests/CreeDictionary_tests/test_paradigm_manager.py
@@ -7,7 +7,7 @@ from CreeDictionary.paradigm.manager import ParadigmManager
 
 
 def test_generates_personal_pronoun_paradigm(paradigm_manager) -> None:
-    paradigm = paradigm_manager.paradigm_for("niya+Pron+Pers+1Sg")
+    paradigm = paradigm_manager.static_paradigm_for("personal-pronouns")
     assert paradigm is not None
 
     # I don't know how many panes there will be, but the first should DEFINITELY have


### PR DESCRIPTION
# What's in this PR?

The dictionary now uses `Wordform.paradigm` to decided whether it should fetch/render a static paradigm.

- changed: **static paradigms are now explicitly declared**
- changed: `WordformCell`s can now be parsed from layouts
- added: `ParadigmLayout.as_static_paradigm()` returns a paradigm that can be rendered without any further paradigm filling
- added `ParadigmManager.static_paradigm_for()` returns a static paradigm given a name, e.g., from `Wordform.paradigm`
- removed: `ParadigmManager.paradigm_for(analysis)` — we no longer need the analysis to determine which paradigm to fetch

Follow up to #778.
