### PR TITLE
change: remove subparser for xmlimport

### DIFF
--- a/CreeDictionary/CreeDictionary/management/commands/ensuretestdb.py
+++ b/CreeDictionary/CreeDictionary/management/commands/ensuretestdb.py
@@ -35,7 +35,6 @@ def import_test_dictionary():
         print("No wordforms found, generating")
         call_command(
             "xmlimport",
-            "import",
             shared_res_dir / "test_dictionaries" / "crkeng.xml",
         )
 

--- a/CreeDictionary/DatabaseManager/management/commands/xmlimport.py
+++ b/CreeDictionary/DatabaseManager/management/commands/xmlimport.py
@@ -15,29 +15,19 @@ class Command(BaseCommand):
     """
 
     def add_arguments(self, parser: ArgumentParser):
-        subparsers = parser.add_subparsers(dest="command_name")
-        subparsers.required = True
-
-        import_parser = subparsers.add_parser(
-            "import",
-            help="Import from specified crkeng.xml. This assumes the database is at migration 0001",
-        )
-        import_parser.add_argument(
+        parser.add_argument(
             "xml_path", help="The XML file, or directory containing crkeng*.xml"
         )
-        import_parser.add_argument("--wipe-first", action="store_true")
+        parser.add_argument("--wipe-first", action="store_true")
 
-    def handle(self, *args, **options):
+    def handle(self, *, xml_path: str, wipe_first=False, **kwargs):
         from DatabaseManager.xml_importer import import_xmls
 
-        if options["command_name"] == "import":
-            if options["wipe_first"]:
-                call_command("wipedefinitions", yes_really=True)
+        if wipe_first:
+            call_command("wipedefinitions", yes_really=True)
 
-            import_xmls(Path(options["xml_path"]))
-            # As of 2021-05-10, the XML format does not specify explicit paradigm fields
-            # for, e.g., demonstrative pronouns or personal pronouns, so add them in
-            # here:
-            ensure_wordform_paradigms()
-        else:
-            raise NotImplementedError
+        import_xmls(Path(xml_path))
+        # As of 2021-05-10, the XML format does not specify explicit paradigm fields
+        # for, e.g., demonstrative pronouns or personal pronouns, so add them in
+        # here:
+        ensure_wordform_paradigms()

--- a/CreeDictionary/search_quality/management/commands/runsamplequeriesonbranches.py
+++ b/CreeDictionary/search_quality/management/commands/runsamplequeriesonbranches.py
@@ -3,7 +3,7 @@ import logging
 import os
 import shutil
 import subprocess
-from argparse import ArgumentParser, RawDescriptionHelpFormatter, BooleanOptionalAction
+from argparse import ArgumentParser, BooleanOptionalAction, RawDescriptionHelpFormatter
 from pathlib import Path
 from subprocess import check_call
 from time import strftime
@@ -107,7 +107,6 @@ class BranchSpecification:
                 "python",
                 "CreeDictionary/manage.py",
                 "xmlimport",
-                "import",
                 crkeng_xml,
             ]
         )
@@ -189,12 +188,12 @@ def git_blob_style_hash(data: bytes):
 class Command(BaseCommand):
     help = """
         Run sample queries across multiple branches
-    
+
         When the list of search queries we are using for evaluation changes, in
         order to see how older code performed on the newly-selected queries, we
         need to regenerate the search results by running queries against old
         versions of the code. That’s what this script does.
-        
+
         Note that this only needs to be done when query terms are added; changes
         in expected results do not require re-running, as evaluation is
         performed against saved search results in the query-results.json.gz

--- a/docker/README.md
+++ b/docker/README.md
@@ -44,7 +44,7 @@ if the container is already running.
 
   - Populate the test dictionary with
 
-        ./docker-django-manage.py xmlimport import \
+        ./docker-django-manage.py xmlimport \
             ../CreeDictionary/res/test_dictionaries/crkeng.xml
 
 ## Deployment on `altlab-itw`


### PR DESCRIPTION
The `xmlimport` command used to have obligate "subcommands":

 - `import [--wipe-first] path/to/crkeng.xml`

That's it. Those are all the subcommands.

I decided to remove the subcommand parser and make `xmlimport` do what `xmlimport import` used to do. 😄 