### PR TITLE
fix: continue if wordform cannot be generated from analysis

### DIFF
--- a/CreeDictionary/API/search/lookup.py
+++ b/CreeDictionary/API/search/lookup.py
@@ -68,10 +68,14 @@ def fetch_results(search_run: core.SearchRun):
             # now we generate the standardized form of the user query for display purpose
             normatized_form_for_analysis = list(hfstol.generate(analysis))
             all_standard_forms.extend(normatized_form_for_analysis)
-            if len(all_standard_forms) == 0:
+            if len(normatized_form_for_analysis) == 0:
                 logger.error(
-                    f"can not generate standardized form for analysis {analysis}"
+                    "Cannot generate normative form for analysis: %s (query: %s)",
+                    analysis,
+                    search_run.internal_query,
                 )
+                continue
+
             normatized_user_query = min(
                 normatized_form_for_analysis,
                 key=lambda f: get_modified_distance(f, search_run.internal_query),

--- a/CreeDictionary/tests/API_tests/model_test.py
+++ b/CreeDictionary/tests/API_tests/model_test.py
@@ -1,11 +1,10 @@
 import json
 
 import pytest
-from hypothesis import assume, given
-
 from API.models import Wordform
 from API.search import search
 from API.search.util import to_sro_circumflex
+from hypothesis import assume, given
 from tests.conftest import lemmas
 
 
@@ -289,6 +288,21 @@ def test_search_results_order(query: str, top_result: str, later_result: str):
     assert (
         top_result_pos < later_result_pos
     ), f"{top_result} did not come before {later_result}"
+
+
+@pytest.mark.django_db
+def test_does_not_crash_on_analyzable_result_without_generated_string():
+    """
+    Ensures searching does not crash when given an analyzable result,
+
+    It used to raise: ValueError: min() arg is an empty sequence
+
+    See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/693
+
+
+    """
+    query = "bod"
+    results = search(query=query).presentation_results()
 
 
 ####################################### Helpers ########################################


### PR DESCRIPTION
Fixes #693

Note: I have NO IDEA how to reproduce this bug, but I've made the log dump more useful information to actually reproduce #693. 
