### PR TITLE
Run black on migrations

### DIFF
--- a/CreeDictionary/API/migrations/0001_initial.py
+++ b/CreeDictionary/API/migrations/0001_initial.py
@@ -8,63 +8,167 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
-            name='DictionarySource',
+            name="DictionarySource",
             fields=[
-                ('abbrv', models.CharField(max_length=8, primary_key=True, serialize=False)),
-                ('title', models.CharField(help_text='What is the primary title of the dictionary source?', max_length=256)),
-                ('author', models.CharField(blank=True, help_text='Separate multiple authors with commas. See also: editor', max_length=512)),
-                ('editor', models.CharField(blank=True, help_text='Who edited or compiled this volume? Separate multiple editors with commas.', max_length=512)),
-                ('year', models.IntegerField(blank=True, help_text='What year was this dictionary published?', null=True)),
-                ('publisher', models.CharField(blank=True, help_text='What was the publisher?', max_length=128)),
-                ('city', models.CharField(blank=True, help_text='What is the city of the publisher?', max_length=64)),
+                (
+                    "abbrv",
+                    models.CharField(max_length=8, primary_key=True, serialize=False),
+                ),
+                (
+                    "title",
+                    models.CharField(
+                        help_text="What is the primary title of the dictionary source?",
+                        max_length=256,
+                    ),
+                ),
+                (
+                    "author",
+                    models.CharField(
+                        blank=True,
+                        help_text="Separate multiple authors with commas. See also: editor",
+                        max_length=512,
+                    ),
+                ),
+                (
+                    "editor",
+                    models.CharField(
+                        blank=True,
+                        help_text="Who edited or compiled this volume? Separate multiple editors with commas.",
+                        max_length=512,
+                    ),
+                ),
+                (
+                    "year",
+                    models.IntegerField(
+                        blank=True,
+                        help_text="What year was this dictionary published?",
+                        null=True,
+                    ),
+                ),
+                (
+                    "publisher",
+                    models.CharField(
+                        blank=True, help_text="What was the publisher?", max_length=128
+                    ),
+                ),
+                (
+                    "city",
+                    models.CharField(
+                        blank=True,
+                        help_text="What is the city of the publisher?",
+                        max_length=64,
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
-            name='Wordform',
+            name="Wordform",
             fields=[
-                ('id', models.PositiveIntegerField(primary_key=True, serialize=False)),
-                ('text', models.CharField(max_length=40)),
-                ('inflectional_category', models.CharField(help_text='Inflectional category directly from source xml file', max_length=10)),
-                ('pos', models.CharField(choices=[('IPV', 'IPV'), ('PRON', 'PRON'), ('N', 'N'), ('IPC', 'IPC'), ('V', 'V'), ('', '')], help_text='Part of speech parsed from source. Can be unspecified', max_length=4)),
-                ('analysis', models.CharField(default='', help_text='fst analysis or the best possible generated if the source is not analyzable', max_length=50)),
-                ('is_lemma', models.BooleanField(default=False, help_text="The wordform is chosen as lemma. This field defaults to true if according to fst the wordform is not analyzable or it's ambiguous")),
-                ('as_is', models.BooleanField(default=False, help_text='The lemma of this wordform is not determined during the importing process.is_lemma defaults to true and lemma field defaults to self')),
-                ('stem', models.CharField(blank=True, max_length=128)),
-                ('lemma', models.ForeignKey(help_text='The identified lemma of this wordform. Defaults to self', on_delete=django.db.models.deletion.CASCADE, related_name='inflections', to='API.Wordform')),
+                ("id", models.PositiveIntegerField(primary_key=True, serialize=False)),
+                ("text", models.CharField(max_length=40)),
+                (
+                    "inflectional_category",
+                    models.CharField(
+                        help_text="Inflectional category directly from source xml file",
+                        max_length=10,
+                    ),
+                ),
+                (
+                    "pos",
+                    models.CharField(
+                        choices=[
+                            ("IPV", "IPV"),
+                            ("PRON", "PRON"),
+                            ("N", "N"),
+                            ("IPC", "IPC"),
+                            ("V", "V"),
+                            ("", ""),
+                        ],
+                        help_text="Part of speech parsed from source. Can be unspecified",
+                        max_length=4,
+                    ),
+                ),
+                (
+                    "analysis",
+                    models.CharField(
+                        default="",
+                        help_text="fst analysis or the best possible generated if the source is not analyzable",
+                        max_length=50,
+                    ),
+                ),
+                (
+                    "is_lemma",
+                    models.BooleanField(
+                        default=False,
+                        help_text="The wordform is chosen as lemma. This field defaults to true if according to fst the wordform is not analyzable or it's ambiguous",
+                    ),
+                ),
+                (
+                    "as_is",
+                    models.BooleanField(
+                        default=False,
+                        help_text="The lemma of this wordform is not determined during the importing process.is_lemma defaults to true and lemma field defaults to self",
+                    ),
+                ),
+                ("stem", models.CharField(blank=True, max_length=128)),
+                (
+                    "lemma",
+                    models.ForeignKey(
+                        help_text="The identified lemma of this wordform. Defaults to self",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="inflections",
+                        to="API.Wordform",
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
-            name='EnglishKeyword',
+            name="EnglishKeyword",
             fields=[
-                ('id', models.PositiveIntegerField(primary_key=True, serialize=False)),
-                ('text', models.CharField(max_length=20)),
-                ('lemma', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='english_keyword', to='API.Wordform')),
+                ("id", models.PositiveIntegerField(primary_key=True, serialize=False)),
+                ("text", models.CharField(max_length=20)),
+                (
+                    "lemma",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="english_keyword",
+                        to="API.Wordform",
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
-            name='Definition',
+            name="Definition",
             fields=[
-                ('id', models.PositiveIntegerField(primary_key=True, serialize=False)),
-                ('text', models.CharField(max_length=200)),
-                ('citations', models.ManyToManyField(to='API.DictionarySource')),
-                ('wordform', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='definitions', to='API.Wordform')),
+                ("id", models.PositiveIntegerField(primary_key=True, serialize=False)),
+                ("text", models.CharField(max_length=200)),
+                ("citations", models.ManyToManyField(to="API.DictionarySource")),
+                (
+                    "wordform",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="definitions",
+                        to="API.Wordform",
+                    ),
+                ),
             ],
         ),
         migrations.AddIndex(
-            model_name='wordform',
-            index=models.Index(fields=['analysis'], name='API_wordfor_analysi_57b0eb_idx'),
+            model_name="wordform",
+            index=models.Index(
+                fields=["analysis"], name="API_wordfor_analysi_57b0eb_idx"
+            ),
         ),
         migrations.AddIndex(
-            model_name='wordform',
-            index=models.Index(fields=['text'], name='API_wordfor_text_5ba76a_idx'),
+            model_name="wordform",
+            index=models.Index(fields=["text"], name="API_wordfor_text_5ba76a_idx"),
         ),
         migrations.AddIndex(
-            model_name='englishkeyword',
-            index=models.Index(fields=['text'], name='API_english_text_16bd44_idx'),
+            model_name="englishkeyword",
+            index=models.Index(fields=["text"], name="API_english_text_16bd44_idx"),
         ),
     ]

--- a/CreeDictionary/API/migrations/0005_wordform_paradigm.py
+++ b/CreeDictionary/API/migrations/0005_wordform_paradigm.py
@@ -6,13 +6,18 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('API', '0004_more_wordform_indexes'),
+        ("API", "0004_more_wordform_indexes"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='wordform',
-            name='paradigm',
-            field=models.CharField(default=None, help_text='If provided, this is the name of a static paradigm that this wordform belongs to. This name should match the filename in res/layouts/static/ WITHOUT the file extension.', max_length=50, null=True),
+            model_name="wordform",
+            name="paradigm",
+            field=models.CharField(
+                default=None,
+                help_text="If provided, this is the name of a static paradigm that this wordform belongs to. This name should match the filename in res/layouts/static/ WITHOUT the file extension.",
+                max_length=50,
+                null=True,
+            ),
         ),
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[tool.black]
-exclude = "migrations/"
-
-
 [tool.isort]
 # Match what Black will do:
 multi_line_output = 3


### PR DESCRIPTION
Although the migration files were excluded from checks, something in
PyCharm sometimes runs black on these files anyway. I’m not sure how to
turn that off, so it seems easier to just have black format migration files
as the usual practice.