### PR TITLE
Mount FSTs from filesystem

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       # Mount vector models from git lfs checkout instead of building into
       # image
       - "../CreeDictionary/res/vector_models/:/app/CreeDictionary/res/vector_models/"
+      # Same for FSTs, as some can be large
+      - "../CreeDictionary/res/fst/:/app/CreeDictionary/res/fst/"
 
       # Use a persistent path for search sample results, so that they
       # remain across deployments and so that additional sample results can


### PR DESCRIPTION
The foma FSTs are checked in with git-lfs. The docker build currently doesn’t do an LFS checkout. There are a few different ways to tackle this; I’m leaning towards this quick fix on the theory that, if a file is big enough to warrant git-lfs, we probably don’t want to put copies into every docker image either.