### PR TITLE
fix: use both +Ipv and IPV in crk.altlabel.tsv

### DIFF
--- a/src/CreeDictionary/res/crk.altlabel.tsv
+++ b/src/CreeDictionary/res/crk.altlabel.tsv
@@ -178,7 +178,8 @@ IPJ	Interjection	Interjection	like: hay hay	tâpiskôc: hay hay	⚡
 IPN	Prenoun	Prenoun	like: amisko-	tâpiskôc: amisko-	⚡		
 IPP	Particle	Particle	like: akâmi-	tâpiskîc: akâmi- 	⚡️		
 IPV	Preverb	Preverb	like: pê-	tâpiskôc: pê-	⚡️		
-	Imm		Immediate	now	mêkwâc/kîsac		
+Ipv	Preverb	Preverb	like: pê-	tâpiskôc: pê-	⚡️		
+Imm		Immediate	now	mêkwâc/kîsac		
 Imp		Imperative	command/request	nitotamâkêwin			
 Imp+Imm		Immediate imperative	command/request that something happens immediately	nitotamâkêwin piko ka-ispayik			
 Ind		Independent	ni-/ki- word	ni-/ki- itwêwin			

--- a/src/CreeDictionary/tests/API_tests/model_test.py
+++ b/src/CreeDictionary/tests/API_tests/model_test.py
@@ -27,10 +27,8 @@ def test_when_linguistic_breakdown_absent():
     result = search_results[0]
     assert result.wordform.text == "pê-"
     assert result.wordform.analysis == "pê-+Ipv"
-    assert (
-        result.friendly_linguistic_breakdown_head == []
-        and result.friendly_linguistic_breakdown_tail == ["like: pê-"]
-    )
+    assert result.friendly_linguistic_breakdown_head == []
+    assert result.friendly_linguistic_breakdown_tail == ["like: pê-"]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
~~Fixed the failing test by using the form of `+IPV`/`+Ipv` that is actually used within the application code: namely, `+Ipv`~~

**EDIT**: So `+Ipv` is the FST-style tag and _IPV_ is the _inflectional category_. N.B.: the FST does not produce a tag for `+Ipv`; it's purely invented in the database importer within itwêwina.

Please see #815 