### PR TITLE
refactor: rename lemma_details -> entry_details

### DIFF
--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 # it should be used on the view functions that are well covered by integration tests
 
 
-def lemma_details(request, lemma_text: str):
+def entry_details(request, lemma_text: str):
     """
     Head word detail page. Will render a paradigm, if applicable. Fallback to search
     page if no head is found or multiple heads are found.

--- a/src/crkeng/site/urls.py
+++ b/src/crkeng/site/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     # "word" is a user-friendly alternative for the linguistic term "lemma"
     path(
         "word/<str:lemma_text>/",
-        views.lemma_details,
+        views.entry_details,
         name="cree-dictionary-index-with-lemma",
     ),
     path("about", views.about, name="cree-dictionary-about"),


### PR DESCRIPTION
This view displays the full details of a _dictionary entry_. This _may_ display the paradigm, but it also may not! @dwhieb Is this the correct terminology? `lemma_detail` was definitely wrong!