### PR TITLE
change: both paradigm views use the same code path

### DIFF
--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-size-button.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-size-button.html
@@ -1,0 +1,29 @@
+{% spaceless %}
+
+  {% comment %}
+    The button
+
+    Parameters:
+      paradigm_size: utils.enums.ParadigmSize
+
+    Example:
+
+        | [       + show more      ] |
+
+    JavaScript hooks:
+     - .js-paradigm-size-button: the entire button.
+     - .js-plus-minus: the + or - sign in the [± show more/less] button
+     - .js-button-text: the text in the [± show more/less] button
+
+  {% endcomment %}
+
+  <button class="paradigm__size-toggle-button js-paradigm-size-button"
+         data-cy="paradigm-toggle-button">
+      <span class="paradigm__size-toggle-plus-minus js-plus-minus">
+        {% if paradigm_size.value == 'LINGUISTIC' %}- {% else %}+ {% endif %}
+      </span>
+    <span class="paradigm__size-toggle-button-text js-button-text">
+        show {% if paradigm_size.value == 'LINGUISTIC' %}less{% else %}more{% endif %}
+      </span>
+  </button>
+{% endspaceless %}

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
@@ -57,5 +57,7 @@
         {% endfor %} {# /paradigm.panes #}
       </table>
     </div>
+
+    {% include "CreeDictionary/components/paradigm-size-button.html" %}
   </section>
 {% endspaceless %}

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
@@ -84,13 +84,6 @@
       </table>
     </div>
 
-    <button class="paradigm__size-toggle-button js-paradigm-size-button" data-cy="paradigm-toggle-button">
-      <span class="paradigm__size-toggle-plus-minus js-plus-minus">
-        {% if paradigm_size.value == 'LINGUISTIC' %}- {% else %}+ {% endif %}
-      </span>
-      <span class="paradigm__size-toggle-button-text js-button-text">
-        show {% if paradigm_size.value == 'LINGUISTIC' %}less{% else %}more{% endif %}
-      </span>
-    </button>
+    {% include "CreeDictionary/components/paradigm-size-button.html" %}
   </section>
 {% endspaceless %}

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm.html
@@ -4,7 +4,7 @@
     The paradigm table, including the button at the bottom.
 
     Parameters:
-      paradigm_tables: List[List[Row]] (see paradigm.py)
+      paradigm: List[List[Row]] (see CreeDictionary/paradigm/filler.py)
       paradigm_size: utils.enums.ParadigmSize (TODO: use str value directly)
 
     Example:
@@ -30,7 +30,7 @@
     {# XXX: we should find a better way to contain all the data in the table :/ #}
     <div class="HACK-overflow-x-scroll">
       <table class="paradigm__table">
-        {% for subtable in paradigm_tables %}
+        {% for subtable in paradigm %}
           <tbody>
             {% for row in subtable %}
               {% if row.is_title %}

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
@@ -61,9 +61,9 @@
     </section>
 
     <section id="paradigm">
-      {% if paradigm_tables %}
-        {% if paradigm_tables.uses_pane_based_layout %}
-          {% include './components/paradigm-with-panes.html' with paradigm=paradigm_tables %}
+      {% if paradigm %}
+        {% if paradigm.uses_pane_based_layout %}
+          {% include './components/paradigm-with-panes.html' %}
         {% else %}
           {% include './components/paradigm.html' %}
         {% endif %}

--- a/src/CreeDictionary/CreeDictionary/test_views.py
+++ b/src/CreeDictionary/CreeDictionary/test_views.py
@@ -112,7 +112,7 @@ def test_retrieve_paradigm(client: Client, lexeme: str, query, example_forms: st
         assertInHTML(wordform, body)
 
 
-@pytest.mark.skip(reason="Django does not like this test case :(")
+@pytest.mark.django_db
 def test_paradigm_from_full_page_and_api(client: Client):
     """
     The paradigm returned from the full details page and the API endpoint should

--- a/src/CreeDictionary/CreeDictionary/test_views.py
+++ b/src/CreeDictionary/CreeDictionary/test_views.py
@@ -15,6 +15,12 @@ from pytest_django.asserts import assertInHTML
 
 from crkeng.app.preferences import DisplayMode, ParadigmLabel
 
+# The test wants an ID that never exists. Never say never; I have no idea if we'll
+# have over two billion wordforms, however, we'll most likely run into problems once
+# we exceed certain storage requirements. For example, the maximum for a signed,
+# 32-bit int is a possible boundary condition that may cause issues elsewhere:
+ID_THAT_SHOULD_BE_TOO_BIG = str(2 ** 31 - 1)
+
 
 class TestLemmaDetailsInternal4xx:
     @pytest.mark.django_db
@@ -25,11 +31,7 @@ class TestLemmaDetailsInternal4xx:
             ["10", None, HttpResponseBadRequest.status_code],
             ["5.2", "LINGUISTIC", HttpResponseBadRequest.status_code],
             ["123", "LINUST", HttpResponseBadRequest.status_code],
-            [
-                "99999999",
-                "FULL",
-                HttpResponseNotFound.status_code,
-            ],  # we'll never have as many as 99999999 entries in the database so it's a non-existent id
+            [ID_THAT_SHOULD_BE_TOO_BIG, "FULL", HttpResponseNotFound.status_code],
         ],
     )
     def test_paradigm_details_internal_400_404(

--- a/src/CreeDictionary/CreeDictionary/test_views.py
+++ b/src/CreeDictionary/CreeDictionary/test_views.py
@@ -112,9 +112,7 @@ def test_retrieve_paradigm(client: Client, lexeme: str, query, example_forms: st
         assertInHTML(wordform, body)
 
 
-# transaction=True is required so that Django does not close the database
-# after the first HTTP response has been returned by the client.
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.skip(reason="Django does not like this test case :(")
 def test_paradigm_from_full_page_and_api(client: Client):
     """
     The paradigm returned from the full details page and the API endpoint should

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -176,13 +176,21 @@ def paradigm_internal(request):
         return HttpResponseNotFound("specified lemma-id is not found in the database")
     # end guards
 
+    paradigm = paradigm_for(lemma, paradigm_size)
+    if isinstance(paradigm, Paradigm):
+        template_name = "CreeDictionary/components/paradigm-with-panes.html"
+    else:
+        template_name = "CreeDictionary/components/paradigm.html"
+
     return render(
         request,
-        "CreeDictionary/components/paradigm.html",
+        template_name,
         {
             "lemma": lemma,
             "paradigm_size": paradigm_size.value,
-            "paradigm_tables": generate_paradigm(lemma, paradigm_size),
+            # TODO: use the name "paradigm" in both templates
+            "paradigm": paradigm,
+            "paradigm_tables": paradigm,
         },
     )
 

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -79,7 +79,7 @@ def entry_details(request, lemma_text: str):
         # ...this parameter
         wordform=presentation.serialize_wordform(lemma),
         paradigm_size=paradigm_size,
-        paradigm_tables=paradigm,
+        paradigm=paradigm,
     )
     return HttpResponse(render(request, "CreeDictionary/index.html", context))
 
@@ -188,9 +188,7 @@ def paradigm_internal(request):
         {
             "lemma": lemma,
             "paradigm_size": paradigm_size.value,
-            # TODO: use the name "paradigm" in both templates
             "paradigm": paradigm,
-            "paradigm_tables": paradigm,
         },
     )
 

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -81,7 +81,7 @@ def entry_details(request, lemma_text: str):
         paradigm_size=paradigm_size,
         paradigm=paradigm,
     )
-    return HttpResponse(render(request, "CreeDictionary/index.html", context))
+    return render(request, "CreeDictionary/index.html", context)
 
 
 def index(request):  # pragma: no cover
@@ -118,7 +118,7 @@ def index(request):  # pragma: no cover
         search_results=search_results,
         did_search=did_search,
     )
-    return HttpResponse(render(request, "CreeDictionary/index.html", context))
+    return render(request, "CreeDictionary/index.html", context)
 
 
 def search_results(request, query_string: str):  # pragma: no cover


### PR DESCRIPTION
# What is in this PR?

The code when using an AJAX call to get a different paradigm size (e.g., the _+ show more_ button) would use a different paradigm generation method than the standalone view. This makes sure they render the same content.

~~# Why is this PR a draft?~~

~~Although the implementation is simple, **the test is difficult to get right**. I wanted a regression test that would check if the AJAX call would create the same HTML that is included in the standalone HTML. However, the Django test client closes the SQLite3 connection **when returning from the first view**. So I can't visit multiple URLs within one test case. I'm not sure how to fix it or how to write a better test case ¯\\\_(ツ)\_/¯~~

The tests pass. It turns out that passing an `HttpRequest()` to another `HttpRequest()` is a bad idea in test cases!