### PR TITLE
refactor(cypress): cy.login() is available to all specs

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,5 +5,9 @@
   "projectId": "8r2xra",
   "defaultCommandTimeout": 10000,
   "supportFile": "cypress/support/commands.js",
-  "pluginsFile": false
+  "pluginsFile": false,
+  "env": {
+    "admin_url": "/admin/",
+    "admin_login_url": "/admin/login/"
+  }
 }

--- a/cypress/integration/admin.spec.js
+++ b/cypress/integration/admin.spec.js
@@ -1,35 +1,3 @@
-Cypress.Commands.add('login', () => {
-  cy.visit('/admin/login/')
-  cy.get('[name=csrfmiddlewaretoken]')
-    .should('exist')
-    .should('have.attr', 'value')
-    .as('csrfToken')
-
-  cy.readCypressUserJSON()
-    .then(({username, password}) => {
-      cy.get('@csrfToken').then(function (token) {
-        cy.request({
-          method: 'POST',
-          url: Cypress.env('admin_login_url'),
-          form: true,
-          body: {
-            username,
-            password,
-            next: Cypress.env('admin_url')
-          },
-          headers: {
-            'X-CSRFTOKEN': token,
-          },
-          followRedirect: false
-        }).then(response => {
-          expect(response.status).to.eql(302)
-          expect(response.headers).to.have.property('location')
-          expect(response.headers.location).to.not.contain('login')
-        })
-      })
-    })
-})
-
 context('Admin interface', () => {
   it('should redirect anonymous users to the login page', function() {
     cy.visit('/admin')

--- a/cypress/integration/admin.spec.js
+++ b/cypress/integration/admin.spec.js
@@ -1,6 +1,3 @@
-const ADMIN_LOGIN_URL = '/admin/login/'
-const ADMIN_URL = '/admin/'
-
 Cypress.Commands.add('login', () => {
   cy.visit('/admin/login/')
   cy.get('[name=csrfmiddlewaretoken]')
@@ -13,12 +10,12 @@ Cypress.Commands.add('login', () => {
       cy.get('@csrfToken').then(function (token) {
         cy.request({
           method: 'POST',
-          url: ADMIN_LOGIN_URL,
+          url: Cypress.env('admin_login_url'),
           form: true,
           body: {
             username,
             password,
-            next: '/admin'
+            next: Cypress.env('admin_url')
           },
           headers: {
             'X-CSRFTOKEN': token,
@@ -37,7 +34,7 @@ context('Admin interface', () => {
   it('should redirect anonymous users to the login page', function() {
     cy.visit('/admin')
     cy.location().then(({pathname}) =>
-      expect(pathname).to.contain(ADMIN_LOGIN_URL))
+      expect(pathname).to.contain(Cypress.env('admin_login_url')))
   })
 
   it('should allow login', function() {
@@ -51,7 +48,7 @@ context('Admin interface', () => {
         cy.get('#id_password').type(cypressUser.password)
         cy.get('.submit-row > input').click()
       })
-    cy.location('pathname').should('eq', ADMIN_URL)
+    cy.location('pathname').should('eq', Cypress.env('admin_url'))
   })
 
   it('should show auto-translations to logged-in users', function() {
@@ -91,6 +88,6 @@ context('Admin interface', () => {
   it('should not show the FST tool to non-admin users', function() {
     cy.visit('/admin/fst-tool')
     cy.location().then(({pathname}) =>
-      expect(pathname).to.contain(ADMIN_LOGIN_URL))
+      expect(pathname).to.contain(Cypress.env('admin_login_url')))
   })
 })

--- a/cypress/integration/admin.spec.js
+++ b/cypress/integration/admin.spec.js
@@ -1,13 +1,5 @@
-const { join: joinPath } = require('path')
-
 const ADMIN_LOGIN_URL = '/admin/login/'
 const ADMIN_URL = '/admin/'
-
-const CYPRESS_USER_JSON = joinPath(__dirname, '..', '..', 'cypress', '.cypress-user.json')
-
-Cypress.Commands.add('readCypressUserJSON', () => {
-  cy.readFile(CYPRESS_USER_JSON)
-})
 
 Cypress.Commands.add('login', () => {
   cy.visit('/admin/login/')

--- a/cypress/integration/admin.spec.js
+++ b/cypress/integration/admin.spec.js
@@ -5,6 +5,10 @@ const ADMIN_URL = '/admin/'
 
 const CYPRESS_USER_JSON = joinPath(__dirname, '..', '..', 'cypress', '.cypress-user.json')
 
+Cypress.Commands.add('readCypressUserJSON', () => {
+  cy.readFile(CYPRESS_USER_JSON)
+})
+
 Cypress.Commands.add('login', () => {
   cy.visit('/admin/login/')
   cy.get('[name=csrfmiddlewaretoken]')
@@ -12,7 +16,7 @@ Cypress.Commands.add('login', () => {
     .should('have.attr', 'value')
     .as('csrfToken')
 
-  cy.readFile(CYPRESS_USER_JSON)
+  cy.readCypressUserJSON()
     .then(({username, password}) => {
       cy.get('@csrfToken').then(function (token) {
         cy.request({
@@ -49,7 +53,7 @@ context('Admin interface', () => {
     // USE_TEST_DB=True, because the `cypress` user only gets created in the
     // test database.
     cy.visit('/admin')
-    cy.readFile(CYPRESS_USER_JSON)
+    cy.readCypressUserJSON()
       .then(cypressUser => {
         cy.get('#id_username').type(cypressUser.username)
         cy.get('#id_password').type(cypressUser.password)

--- a/cypress/integration/paradigm.spec.js
+++ b/cypress/integration/paradigm.spec.js
@@ -147,11 +147,18 @@ describe('paradigms can be toggled by the show more/less button', () => {
 })
 
 // Can lift skip off this once admin can be tested.
-describe.skip('Paradigm labels', () => {
+describe('Paradigm labels', () => {
   let lemma = 'nipâw'
   let englishLabel = 'they'
   let nehiyawewinLabel = 'wiyanaw'
   let linguisticLabel = '3s'
+
+  beforeEach(() => {
+    // As of 2021-06-02: paradigm label switching is only available to
+    // logged-in users. If you are reading this, and paradigm label switching
+    // is enabled for all users, please delete this entire beforeEach() block.
+    cy.login()
+  })
 
   it('should appear in plain English by default', () => {
     cy.visitLemma(lemma, { 'paradigm-size': 'FULL'})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,8 @@
+const { join: joinPath } = require('path')
+
+// Why does this path traverse OUTSIDE of the cypress/ directory only to traverse back into it?
+const CYPRESS_USER_JSON = joinPath(__dirname, '..', '..', 'cypress', '.cypress-user.json')
+
 /**
  * Fixes a bug (feature?) in Cypress: it should call encodeURIComponent() for
  * /path/components/ in visit(). This way paths with non-ASCII stuff is
@@ -69,6 +74,21 @@ Cypress.Commands.add('visitLemma', {prevSubject: false}, (lemmaText, queryParams
       expect(loc.pathname, 'lemmaText and queryParams should be enough to disambiguate the lemma').to.eq(`/word/${encodeURIComponent(lemmaText)}/`)
     }
   )
+})
+
+/**
+ * Reads the .cypress-user.json file. This file should contains log-in credentials for an admin user.
+ *
+ * Promises an object with {username, password} properties, i.e.,
+ *
+ *    cy.readCypressUserJSON()
+ *      .then(({username, password}) => {
+ *        // use username and password
+ *      })
+ *
+ */
+Cypress.Commands.add('readCypressUserJSON', () => {
+  cy.readFile(CYPRESS_USER_JSON)
 })
 
 /**

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,29 +1,3 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add("login", (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This is will overwrite an existing command --
-// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
-
 /**
  * Fixes a bug (feature?) in Cypress: it should call encodeURIComponent() for
  * /path/components/ in visit(). This way paths with non-ASCII stuff is
@@ -115,7 +89,7 @@ function findColHeader(tdElement){
   3. the cell does not have column header nor a title row
    */
 
-  
+
   let idx = tdElement.cellIndex
   let upperRow = tdElement.parentElement.previousElementSibling
   while (upperRow != null) {
@@ -204,7 +178,7 @@ Cypress.Commands.add('getParadigmCell', {prevSubject: false}, (rowLabel, {colLab
 
       for (const thElement of $thCollection) {
         // const startTH = Cypress.dom.unwrap($th)[0]
-  
+
         // iterate over all tds in the row
 
         let colLabelMatched = false
@@ -224,7 +198,7 @@ Cypress.Commands.add('getParadigmCell', {prevSubject: false}, (rowLabel, {colLab
 
           if (titleLabel){
             const titleRowTH = findTitleRow(tdElement)
-            
+
             if (titleRowTH && titleRowTH.innerText === titleLabel){
               titleLabelMatched = true
             }


### PR DESCRIPTION
# What's in this PR?

 - **moves** command definition of `cy.login()` from `admin.spec.js` to Cypress's support file, making it available to **all spec files**.
 - Uses `Cypress.env()` to declare URLs in `cypress.json`, [similar to the speech-db](https://github.com/UAlbertaALTLab/recording-validation-interface/blob/38b15f74be325898bcefce58b6d4834c5e279ae4/cypress.json#L3-L11)
 - Creates a new command: `cy.readCypressUserJSON()` to do exactly that!
 - **enables** a test that was skipped in the last PR — the paradigm labels require a logged-in user (for now)