### PR TITLE
fix: bad comment syntax

### DIFF
--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/word-detail.html
@@ -63,8 +63,10 @@
     <section id="paradigm">
       {% if paradigm %}
         {% if user.is_authenticated %}
-          {# As of 2021-06-02, this feature is not ready for the general
-             public, so make it only visible to logged-in users #}
+          {% comment %}
+            As of 2021-06-02, this feature is not ready for the general
+            public, so make it only visible to logged-in users.
+          {% endcomment %}
           {% include './components/paradigm-label-switcher.html' %}
         {% endif %}
         {% if paradigm.uses_pane_based_layout %}


### PR DESCRIPTION
I thought I could use jinja2 comment syntax in a Django template file and the mistake made it to production 😫 (for logged-in users only)