### PR TITLE
tests: move some crkeng integration tests to the right place

### DIFF
--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -97,6 +97,8 @@ to:
         │   ├── __init__.py
         │   ├── app/                # Django application (optional)
         │   │   ├── __init__.py
+        │   │   ├── integration_tests/
+        │   │   │   └── …           # tests that use resources/ of current language pair
         │   │   ├── templates/      # Django templates (overrides other apps)
         │   │   └── static/         # Static assets (Django staticfiles app)
         │   ├── cypress/
@@ -126,6 +128,8 @@ to:
         │   ├── __init__.py
         │   ├── app/                # Django application (optional)
         │   │   ├── __init__.py
+        │   │   ├── integration_tests/
+        │   │   │   └── …           # tests that use resources/ of current language pair
         │   │   ├── templates/      # Django templates (overrides other apps)
         │   │   └── static/         # Static assets (Django staticfiles app)
         │   ├── cypress/

--- a/src/crkeng/app/integration_tests/test_paradigm_manager.py
+++ b/src/crkeng/app/integration_tests/test_paradigm_manager.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 import pytest
-from hfst_optimized_lookup import TransducerFile
 from more_itertools import first, ilen
 
+from CreeDictionary.CreeDictionary.paradigm.generation import default_paradigm_manager
 from morphodict.paradigm.manager import ParadigmManager
 
 
@@ -43,15 +43,5 @@ def test_generates_na_paradigm(paradigm_manager) -> None:
 
 
 @pytest.fixture
-def paradigm_manager(testdata_dir: Path) -> ParadigmManager:
-    layout_dir = testdata_dir / "paradigm-layouts"
-    assert layout_dir.is_dir()
-    assert (layout_dir / "static").is_dir()
-    assert (layout_dir / "dynamic").is_dir()
-
-    fst_dir = testdata_dir / "fst"
-    generator_path = fst_dir / "crk-strict-generator.hfstol"
-    assert generator_path.exists()
-    strict_generator = TransducerFile(generator_path)
-
-    return ParadigmManager(layout_dir, strict_generator)
+def paradigm_manager() -> ParadigmManager:
+    return default_paradigm_manager()

--- a/src/crkeng/app/integration_tests/test_paradigm_manager.py
+++ b/src/crkeng/app/integration_tests/test_paradigm_manager.py
@@ -1,4 +1,6 @@
-from pathlib import Path
+"""
+Integration tests for the itwêwina's paradigm generation.
+"""
 
 import pytest
 from more_itertools import first, ilen

--- a/src/morphodict/paradigm/test_panes.py
+++ b/src/morphodict/paradigm/test_panes.py
@@ -243,7 +243,7 @@ def na_layout(na_layout_path: Path) -> ParadigmLayout:
 def pronoun_paradigm_path(testdata_dir: Path) -> Path:
     """
     Return the path to the NA layout in the test fixture dir.
-    NOTE: this is **NOT** the NA paradigm used in production!
+    NOTE: this is **NOT** the pronoun paradigm used in production!
     """
     p = testdata_dir / "paradigm-layouts" / "static" / "demonstrative-pronouns.tsv"
     assert p.exists()

--- a/src/morphodict/paradigm/testdata/fst/.gitattributes
+++ b/src/morphodict/paradigm/testdata/fst/.gitattributes
@@ -1,1 +1,0 @@
-*.hfstol filter=lfs diff=lfs merge=lfs -text

--- a/src/morphodict/paradigm/testdata/fst/crk-strict-generator.hfstol
+++ b/src/morphodict/paradigm/testdata/fst/crk-strict-generator.hfstol
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f544fdef97f35e127840bb178a31f9c0d721d8f9c59bf7bfa4d1a04e0d1cadaf
-size 2381267

--- a/src/morphodict/paradigm/testdata/paradigm-layouts/static/personal-pronouns.tsv
+++ b/src/morphodict/paradigm/testdata/paradigm-layouts/static/personal-pronouns.tsv
@@ -1,9 +1,0 @@
-	| Sg
-_ 1Sg	niya
-_ 2Sg	kiya
-_ 3Sg	wiya
-	| Pl
-_ 1Pl	niyanân
-_ 12Pl	kiyânaw
-_ 2Pl	kiyawâw
-_ 3Pl	wiyawâw


### PR DESCRIPTION
**NOTE**: this is a **stacked PR**. Please see #836 before this.

This moves some integration tests that rely on the Plains Cree FST to `crkeng/app/integration_tests` 👍🏼 