### PR TITLE
feat: multiple paradigm sizes: preliminary implementation

### DIFF
--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -73,8 +73,8 @@ class ParadigmManager:
         """
         Loads all .tsv files in the path as static paradigms.
         """
-        for filename, layout in self._load_all_layouts_in_directory(path):
-            self._name_to_paradigm[filename.stem][
+        for paradigm_name, layout in self._load_all_layouts_in_directory(path):
+            self._name_to_paradigm[paradigm_name][
                 ONLY_SIZE
             ] = layout.as_static_paradigm()
 
@@ -82,8 +82,8 @@ class ParadigmManager:
         """
         Loads all .tsv files as dynamic layouts.
         """
-        for filename, layout in self._load_all_layouts_in_directory(path):
-            self._wc_to_layout[filename.stem][ONLY_SIZE] = layout
+        for paradigm_name, layout in self._load_all_layouts_in_directory(path):
+            self._wc_to_layout[paradigm_name][ONLY_SIZE] = layout
 
     def _inflect(self, layout: ParadigmLayout, lemma: str) -> Paradigm:
         """
@@ -101,7 +101,7 @@ class ParadigmManager:
     def _load_all_layouts_in_directory(path: Path):
         for layout_file in path.glob("*.tsv"):
             layout = ParadigmLayout.loads(layout_file.read_text(encoding="UTF-8"))
-            yield layout_file, layout
+            yield layout_file.stem, layout
 
 
 class Transducer(Protocol):

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -80,7 +80,7 @@ class ParadigmManager:
             logger.info("No static paradigms found in %s", path)
             return
 
-        for paradigm_name, size, layout in self._load_all_layouts_in_directory(path):
+        for paradigm_name, size, layout in _load_all_layouts_in_directory(path):
             self._name_to_paradigm[paradigm_name][size] = layout.as_static_paradigm()
 
     def _load_dynamic_from(self, path: Path):
@@ -91,7 +91,7 @@ class ParadigmManager:
             logger.info("No dynamic paradigms found in %s", path)
             return
 
-        for paradigm_name, size, layout in self._load_all_layouts_in_directory(path):
+        for paradigm_name, size, layout in _load_all_layouts_in_directory(path):
             self._wc_to_layout[paradigm_name][size] = layout
 
     def _inflect(self, layout: ParadigmLayout, lemma: str) -> Paradigm:
@@ -106,29 +106,33 @@ class ParadigmManager:
         }
         return layout.fill(template2forms)
 
-    @staticmethod
-    def _load_all_layouts_in_directory(path: Path):
-        assert path.is_dir()
 
-        for filename in path.iterdir():
-            if filename.is_dir():
-                yield from _load_all_sizes_for_paradigm(filename)
-            elif filename.match("*.tsv"):
-                layout = _load_layout_file(filename)
-                yield filename.stem, ONLY_SIZE, layout
+def _load_all_layouts_in_directory(path: Path):
+    """
+    Yields (paradigm, size, layout) tuples from the given directory. Immediate
+    subdirectories are assumed to be paradigms with multiple size options.
+    """
+    assert path.is_dir()
+
+    for filename in path.iterdir():
+        if filename.is_dir():
+            yield from _load_all_sizes_for_paradigm(filename)
+        elif filename.match("*.tsv"):
+            yield filename.stem, ONLY_SIZE, _load_layout_file(filename)
 
 
 def _load_all_sizes_for_paradigm(directory: Path):
     """
-    Yields (paradigm, size, layout) tuples from the given directory.
+    Yields (paradigm, size, layout) tuples for ONE paradigm name. The paradigm name
+    is inferred from the directory name.
     """
     paradigm_name = directory.name
     assert directory.is_dir()
 
     for layout_file in directory.glob("*.tsv"):
-        layout = _load_layout_file(layout_file)
         size = layout_file.stem
-        yield paradigm_name, size, layout
+        assert size != ONLY_SIZE, f"size name cannot clash with sentinel value: {size}"
+        yield paradigm_name, size, _load_layout_file(layout_file)
 
 
 def _load_layout_file(layout_file: Path):

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -16,7 +16,7 @@ class ParadigmManager:
 
     def __init__(self, layout_directory: Path, generation_fst: TransducerFile):
         self._generator = generation_fst
-        self._name_to_layout: dict[str, Paradigm] = {}
+        self._name_to_paradigm: dict[str, Paradigm] = {}
         self._wc_to_layout: dict[str, ParadigmLayout] = {}
 
         self._load_static_from(layout_directory / "static")
@@ -27,7 +27,7 @@ class ParadigmManager:
         Returns a static paradigm with the given name.
         Returns None if there is no paradigm with such a name.
         """
-        return self._name_to_layout.get(name)
+        return self._name_to_paradigm.get(name)
 
     def dynamic_paradigm_for(
         self, *, lemma: str, word_class: str
@@ -47,7 +47,7 @@ class ParadigmManager:
         Loads all .tsv files in the path as static paradigms.
         """
         for filename, layout in self._load_all_layouts_in_directory(path):
-            self._name_to_layout[filename.stem] = layout.as_static_paradigm()
+            self._name_to_paradigm[filename.stem] = layout.as_static_paradigm()
 
     def _load_dynamic_from(self, path: Path):
         """

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from pathlib import Path
-from typing import Iterable, Optional, Protocol
+from typing import Any, Collection, Iterable, Optional, Protocol
 
 from CreeDictionary.CreeDictionary.paradigm.panes import Paradigm, ParadigmLayout
 
@@ -53,6 +53,21 @@ class ParadigmManager:
 
         layout = size_options[ONLY_SIZE]
         return self._inflect(layout, lemma)
+
+    def sizes_of(self, paradigm_name: str) -> Collection[str]:
+        """
+        Returns the size options of the given paradigm.
+        """
+        collection: dict[str, dict[str, Any]]
+
+        if paradigm_name in self._name_to_paradigm:
+            collection = self._name_to_paradigm
+        elif paradigm_name in self._wc_to_layout:
+            collection = self._wc_to_layout
+        else:
+            raise KeyError(f"Paradigm does not exist: {paradigm_name}")
+
+        return collection[paradigm_name].keys()
 
     def _load_static_from(self, path: Path):
         """

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -33,6 +33,23 @@ class ParadigmManager:
         self._load_static_from(layout_directory / "static")
         self._load_dynamic_from(layout_directory / "dynamic")
 
+    def paradigm_for(self, paradigm_name: str, lemma: Optional[str] = None) -> Paradigm:
+        """
+        Returns a paradigm for the given paradigm name. If a lemma is given, this is
+        substituted into the dynamic paradigm.
+        """
+        if lemma is not None:
+            paradigm = self.dynamic_paradigm_for(lemma=lemma, word_class=paradigm_name)
+        else:
+            paradigm = self.static_paradigm_for(paradigm_name)
+
+        if paradigm is None:
+            raise NotImplementedError(
+                "not sure what should happen if a paradigm cannot be found"
+            )
+
+        return paradigm
+
     def static_paradigm_for(self, name: str) -> Optional[Paradigm]:
         """
         Returns a static paradigm with the given name.

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -33,15 +33,19 @@ class ParadigmManager:
         self._load_static_from(layout_directory / "static")
         self._load_dynamic_from(layout_directory / "dynamic")
 
-    def paradigm_for(self, paradigm_name: str, lemma: Optional[str] = None) -> Paradigm:
+    def paradigm_for(
+        self, paradigm_name: str, lemma: Optional[str] = None, size: str = ONLY_SIZE
+    ) -> Paradigm:
         """
         Returns a paradigm for the given paradigm name. If a lemma is given, this is
         substituted into the dynamic paradigm.
         """
         if lemma is not None:
-            paradigm = self.dynamic_paradigm_for(lemma=lemma, word_class=paradigm_name)
+            paradigm = self.dynamic_paradigm_for(
+                lemma=lemma, word_class=paradigm_name, size=size
+            )
         else:
-            paradigm = self.static_paradigm_for(paradigm_name)
+            paradigm = self.static_paradigm_for(paradigm_name, size=size)
 
         if paradigm is None:
             raise NotImplementedError(
@@ -50,17 +54,19 @@ class ParadigmManager:
 
         return paradigm
 
-    def static_paradigm_for(self, name: str) -> Optional[Paradigm]:
+    def static_paradigm_for(
+        self, name: str, size: str = ONLY_SIZE
+    ) -> Optional[Paradigm]:
         """
         Returns a static paradigm with the given name.
         Returns None if there is no paradigm with such a name.
         """
         if size_options := self._name_to_paradigm.get(name):
-            return size_options[ONLY_SIZE]
+            return size_options[size]
         return None
 
     def dynamic_paradigm_for(
-        self, *, lemma: str, word_class: str
+        self, *, lemma: str, word_class: str, size: str = ONLY_SIZE
     ) -> Optional[Paradigm]:
         """
         Returns a dynamic paradigm for the given lemma and word class.
@@ -71,7 +77,7 @@ class ParadigmManager:
             # No matching name means no paradigm:
             return None
 
-        layout = size_options[ONLY_SIZE]
+        layout = size_options[size]
         return self._inflect(layout, lemma)
 
     def sizes_of(self, paradigm_name: str) -> Collection[str]:

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -73,17 +73,15 @@ class ParadigmManager:
         """
         Loads all .tsv files in the path as static paradigms.
         """
-        for paradigm_name, layout in self._load_all_layouts_in_directory(path):
-            self._name_to_paradigm[paradigm_name][
-                ONLY_SIZE
-            ] = layout.as_static_paradigm()
+        for paradigm_name, size, layout in self._load_all_layouts_in_directory(path):
+            self._name_to_paradigm[paradigm_name][size] = layout.as_static_paradigm()
 
     def _load_dynamic_from(self, path: Path):
         """
         Loads all .tsv files as dynamic layouts.
         """
-        for paradigm_name, layout in self._load_all_layouts_in_directory(path):
-            self._wc_to_layout[paradigm_name][ONLY_SIZE] = layout
+        for paradigm_name, size, layout in self._load_all_layouts_in_directory(path):
+            self._wc_to_layout[paradigm_name][size] = layout
 
     def _inflect(self, layout: ParadigmLayout, lemma: str) -> Paradigm:
         """
@@ -101,7 +99,7 @@ class ParadigmManager:
     def _load_all_layouts_in_directory(path: Path):
         for layout_file in path.glob("*.tsv"):
             layout = ParadigmLayout.loads(layout_file.read_text(encoding="UTF-8"))
-            yield layout_file.stem, layout
+            yield layout_file.stem, ONLY_SIZE, layout
 
 
 class Transducer(Protocol):

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from pathlib import Path
-from typing import Optional
-
-from hfst_optimized_lookup import TransducerFile
+from typing import Iterable, Optional, Protocol
 
 from CreeDictionary.CreeDictionary.paradigm.panes import Paradigm, ParadigmLayout
 
@@ -24,7 +22,7 @@ class ParadigmManager:
     _name_to_paradigm: dict[str, dict[str, Paradigm]]
     _wc_to_layout: dict[str, dict[str, ParadigmLayout]]
 
-    def __init__(self, layout_directory: Path, generation_fst: TransducerFile):
+    def __init__(self, layout_directory: Path, generation_fst: Transducer):
         self._generator = generation_fst
         self._name_to_paradigm = defaultdict(dict)
         self._wc_to_layout = defaultdict(dict)
@@ -89,3 +87,15 @@ class ParadigmManager:
         for layout_file in path.glob("*.tsv"):
             layout = ParadigmLayout.loads(layout_file.read_text(encoding="UTF-8"))
             yield layout_file, layout
+
+
+class Transducer(Protocol):
+    """
+    Interface for something that can lookup forms in bulk.
+
+    This is basically the subset of the hfst_optimized_lookup.TransducerFile API that
+    the paradigm manager actually uses.
+    """
+
+    def bulk_lookup(self, strings: Iterable[str]) -> dict[str, set[str]]:
+        ...

--- a/src/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -8,7 +8,7 @@ import logging
 import re
 import string
 from itertools import zip_longest
-from typing import Collection, Iterable, Optional, TextIO
+from typing import Collection, Iterable, Mapping, Optional, TextIO
 
 from more_itertools import first, ilen
 
@@ -132,7 +132,7 @@ class ParadigmLayout(Paradigm):
             for inflection in self.inflection_cells
         }
 
-    def fill(self, forms: dict[str, Collection[str]]) -> Paradigm:
+    def fill(self, forms: Mapping[str, Collection[str]]) -> Paradigm:
         """
         Given a mapping from analysis to a collection of wordforms, returns a
         paradigm with all its InflectionTemplate cells replaced with WordformCells.
@@ -218,7 +218,7 @@ class Pane:
     def contains_wordform(self, wordform: str) -> bool:
         return any(row.contains_wordform(wordform) for row in self.rows)
 
-    def fill(self, forms: dict[str, Collection[str]]) -> Pane:
+    def fill(self, forms: Mapping[str, Collection[str]]) -> Pane:
         return Pane(row.fill(forms) for row in self.rows)
 
 
@@ -261,7 +261,7 @@ class Row:
     def contains_wordform(self, wordform: str) -> bool:
         raise NotImplementedError
 
-    def fill(self, forms: dict[str, Collection[str]]) -> Row:
+    def fill(self, forms: Mapping[str, Collection[str]]) -> Row:
         if not self.has_content:
             # Just labels; can return ourselves verbatim
             return self
@@ -316,7 +316,7 @@ class ContentRow(Row):
     def contains_wordform(self, wordform: str) -> bool:
         return any(cell.contains_wordform(wordform) for cell in self.cells)
 
-    def fill(self, forms: dict[str, Collection[str]]) -> ContentRow:
+    def fill(self, forms) -> ContentRow:
         return ContentRow(cell.fill_one(forms) for cell in self.cells)
 
     def __eq__(self, other) -> bool:

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
@@ -38,20 +38,12 @@ def test_can_find_wordforms_in_multiple_sizes(paradigm_manager: ParadigmManager)
     # "venti" is the largest size
     # Pedantic note: There's also "short" and "trenti", but let's not.
 
-    tall = paradigm_manager.paradigm_for(
-        "has-multiple-sizes",
-        lemma=lemma,
-        size="tall"
+    tall = paradigm_manager.paradigm_for("has-multiple-sizes", lemma=lemma, size="tall")
+    grande = paradigm_manager.paradigm_for(
+        "has-multiple-sizes", lemma=lemma, size="grande"
     )
     venti = paradigm_manager.paradigm_for(
-        "has-multiple-sizes",
-        lemma=lemma,
-        size="grande"
-    )
-    grande = paradigm_manager.paradigm_for(
-        "has-multiple-sizes",
-        lemma=lemma,
-        size="venti"
+        "has-multiple-sizes", lemma=lemma, size="venti"
     )
 
     present_in_all_sizes = [lemma]
@@ -72,7 +64,6 @@ def test_can_find_wordforms_in_multiple_sizes(paradigm_manager: ParadigmManager)
             assert not size.contains_wordform(form)
 
         assert venti.contains_wordform(form)
-
 
 
 @pytest.fixture

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
@@ -13,7 +13,6 @@ def test_one_size(paradigm_manager: ParadigmManager):
     paradigm = paradigm_manager.paradigm_for(
         "has-only-one-size", lemma="everything bagel"
     )
-    assert paradigm is not None
 
     all_forms = [
         "everything bagel",
@@ -32,12 +31,12 @@ def test_multiple_sizes(paradigm_manager: ParadigmManager):
 
 def test_can_find_wordforms_in_multiple_sizes(paradigm_manager: ParadigmManager):
     lemma = "caramel macchiato"
+
     # For those not familiar with a certain Seattle-based coffee chain:
     # "tall" is the smallest size
     # "grande" is the medium size
     # "venti" is the largest size
     # Pedantic note: There's also "short" and "trenti", but let's not.
-
     tall = paradigm_manager.paradigm_for("has-multiple-sizes", lemma=lemma, size="tall")
     grande = paradigm_manager.paradigm_for(
         "has-multiple-sizes", lemma=lemma, size="grande"
@@ -69,14 +68,18 @@ def test_can_find_wordforms_in_multiple_sizes(paradigm_manager: ParadigmManager)
 @pytest.fixture
 def paradigm_manager():
     testdata = Path(__file__).parent / "testdata"
-    assert testdata.exists()
+    assert testdata.is_dir()
     transducer = IdentityTransducer()
+
     return ParadigmManager(testdata / "layouts", transducer)
 
 
 class IdentityTransducer:
     """
-    For each lookup, returns the query unchanged (.lookup() is the identity function).
+    For each lookup, returns the query unchanged -- .lookup() is the identity function.
+
+    Note: ${lemma} is substituted BEFORE calling .bulk_lookup(), so the "analysis" will
+    just be whatever is in the paradigm cell, with all the substitutions finished.
     """
 
     def bulk_lookup(self, analyses: Iterable[str]) -> dict[str, set[str]]:

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
@@ -30,6 +30,51 @@ def test_multiple_sizes(paradigm_manager: ParadigmManager):
     assert set(paradigm_manager.sizes_of("has-multiple-sizes")) == expected_sizes
 
 
+def test_can_find_wordforms_in_multiple_sizes(paradigm_manager: ParadigmManager):
+    lemma = "caramel macchiato"
+    # For those not familiar with a certain Seattle-based coffee chain:
+    # "tall" is the smallest size
+    # "grande" is the medium size
+    # "venti" is the largest size
+    # Pedantic note: There's also "short" and "trenti", but let's not.
+
+    tall = paradigm_manager.paradigm_for(
+        "has-multiple-sizes",
+        lemma=lemma,
+        size="tall"
+    )
+    venti = paradigm_manager.paradigm_for(
+        "has-multiple-sizes",
+        lemma=lemma,
+        size="grande"
+    )
+    grande = paradigm_manager.paradigm_for(
+        "has-multiple-sizes",
+        lemma=lemma,
+        size="venti"
+    )
+
+    present_in_all_sizes = [lemma]
+    exclusively_in_grande_and_up = [f"iced {lemma}"]
+    exclusively_in_venti = [f"iced almond {lemma}, no whip"]
+
+    for form in present_in_all_sizes:
+        for size in (tall, grande, venti):
+            assert size.contains_wordform(form)
+
+    for form in exclusively_in_grande_and_up:
+        assert not tall.contains_wordform(form)
+        for size in (grande, venti):
+            assert size.contains_wordform(form)
+
+    for form in exclusively_in_venti:
+        for size in (tall, grande):
+            assert not size.contains_wordform(form)
+
+        assert venti.contains_wordform(form)
+
+
+
 @pytest.fixture
 def paradigm_manager():
     testdata = Path(__file__).parent / "testdata"

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
@@ -3,17 +3,18 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from CreeDictionary.CreeDictionary.paradigm.manager import ParadigmManager, ONLY_SIZE
+from CreeDictionary.CreeDictionary.paradigm.manager import ONLY_SIZE, ParadigmManager
 
 
 def test_one_size(paradigm_manager: ParadigmManager):
     assert set(paradigm_manager.sizes_of("has-only-one-size")) == {ONLY_SIZE}
 
 
-@pytest.mark.xfail
 def test_multiple_sizes(paradigm_manager: ParadigmManager):
     assert set(paradigm_manager.sizes_of("has-multiple-sizes")) == {
-        "tall", "grande", "venti"
+        "tall",
+        "grande",
+        "venti",
     }
 
 

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
@@ -1,5 +1,6 @@
+import re
 from pathlib import Path
-from unittest.mock import MagicMock
+from typing import Iterable
 
 import pytest
 
@@ -9,19 +10,45 @@ from CreeDictionary.CreeDictionary.paradigm.manager import ONLY_SIZE, ParadigmMa
 def test_one_size(paradigm_manager: ParadigmManager):
     assert set(paradigm_manager.sizes_of("has-only-one-size")) == {ONLY_SIZE}
 
+    paradigm = paradigm_manager.paradigm_for(
+        "has-only-one-size", lemma="everything bagel"
+    )
+    assert paradigm is not None
+
+    all_forms = [
+        "everything bagel",
+        "buttered everything bagel",
+        "cream cheese everything bagel",
+    ]
+
+    for form in all_forms:
+        assert paradigm.contains_wordform(form), f"{form} not found in {paradigm}"
+
 
 def test_multiple_sizes(paradigm_manager: ParadigmManager):
-    assert set(paradigm_manager.sizes_of("has-multiple-sizes")) == {
-        "tall",
-        "grande",
-        "venti",
-    }
+    expected_sizes = {"tall", "grande", "venti"}
+    assert set(paradigm_manager.sizes_of("has-multiple-sizes")) == expected_sizes
 
 
 @pytest.fixture
 def paradigm_manager():
     testdata = Path(__file__).parent / "testdata"
     assert testdata.exists()
-    transducer = MagicMock()
-    transducer.bulk_lookup = MagicMock(side_effect=NotImplementedError)
+    transducer = IdentityTransducer()
     return ParadigmManager(testdata / "layouts", transducer)
+
+
+class IdentityTransducer:
+    """
+    For each lookup, returns the query unchanged (.lookup() is the identity function).
+    """
+
+    def bulk_lookup(self, analyses: Iterable[str]) -> dict[str, set[str]]:
+        result = {}
+        for analysis in analyses:
+            result[analysis] = {self.lookup(analysis)}
+        return result
+
+    @staticmethod
+    def lookup(analysis: str) -> str:
+        return analysis

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from CreeDictionary.CreeDictionary.paradigm.manager import ParadigmManager, ONLY_SIZE
+
+
+def test_one_size(paradigm_manager: ParadigmManager):
+    assert set(paradigm_manager.sizes_of("has-only-one-size")) == {ONLY_SIZE}
+
+
+@pytest.mark.xfail
+def test_multiple_sizes(paradigm_manager: ParadigmManager):
+    assert set(paradigm_manager.sizes_of("has-multiple-sizes")) == {
+        "tall", "grande", "venti"
+    }
+
+
+@pytest.fixture
+def paradigm_manager():
+    testdata = Path(__file__).parent / "testdata"
+    assert testdata.exists()
+    transducer = MagicMock()
+    transducer.bulk_lookup = MagicMock(side_effect=NotImplementedError)
+    return ParadigmManager(testdata / "layouts", transducer)

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/grande.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/grande.tsv
@@ -1,4 +1,4 @@
 _ 2Pct	${lemma}
-
+	
 # Iced	
 _ 2Pct	iced ${lemma}

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/grande.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/grande.tsv
@@ -1,4 +1,4 @@
-_ 2Pct	grande ${lemma}
+_ 2Pct	${lemma}
 
 # Iced	
-_ 2Pct	iced grande ${lemma}
+_ 2Pct	iced ${lemma}

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/grande.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/grande.tsv
@@ -1,0 +1,4 @@
+	| Regular	| Decaf
+_ 2Pct	${lemma}	${lemma}
+_ NonFat	${lemma}	${lemma}
+_ Soy	${lemma}	${lemma}

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/grande.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/grande.tsv
@@ -1,4 +1,4 @@
-	| Regular	| Decaf
-_ 2Pct	${lemma}	${lemma}
-_ NonFat	${lemma}	${lemma}
-_ Soy	${lemma}	${lemma}
+_ 2Pct	grande ${lemma}
+
+# Iced	
+_ 2Pct	iced grande ${lemma}

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/tall.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/tall.tsv
@@ -1,0 +1,3 @@
+	| Regular
+_ 2Pct	${lemma}
+_ Soy	${lemma}

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/tall.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/tall.tsv
@@ -1,3 +1,2 @@
 	| Regular
-_ 2Pct	${lemma}
-_ Soy	${lemma}
+_ 2Pct	tall ${lemma}

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/tall.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/tall.tsv
@@ -1,2 +1,2 @@
 	| Regular
-_ 2Pct	tall ${lemma}
+_ 2Pct	${lemma}

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/venti.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/venti.tsv
@@ -1,7 +1,7 @@
 	| Whip	| NoWhip
-_ 2Pct	venti ${lemma}	venti ${lemma}, no whip
-_ Almond	venti almond ${lemma}	venti ${lemma}, no whip
+_ 2Pct	${lemma}	${lemma}, no whip
+_ Almond	almond ${lemma}	${lemma}, no whip
 
 # Iced
-_ 2Pct	iced venti ${lemma}	iced venti ${lemma}, no whip
-_ Almond	iced venti almond ${lemma}	iced venti ${lemma}, no whip
+_ 2Pct	iced ${lemma}	iced ${lemma}, no whip
+_ Almond	iced almond ${lemma}	iced almond ${lemma}, no whip

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/venti.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/venti.tsv
@@ -1,7 +1,7 @@
 	| Whip	| NoWhip
 _ 2Pct	${lemma}	${lemma}, no whip
 _ Almond	almond ${lemma}	${lemma}, no whip
-
-# Iced
+		
+# Iced	
 _ 2Pct	iced ${lemma}	iced ${lemma}, no whip
 _ Almond	iced almond ${lemma}	iced almond ${lemma}, no whip

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/venti.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/venti.tsv
@@ -1,6 +1,7 @@
-	| Regular	| Decaf
-_ 2Pct	${lemma}	${lemma}
-_ NonFat	${lemma}	${lemma}
-_ Soy	${lemma}	${lemma}
-_ Oat	${lemma}	${lemma}
-_ Almond	${lemma}	${lemma}
+	| Whip	| NoWhip
+_ 2Pct	venti ${lemma}	venti ${lemma}, no whip
+_ Almond	venti almond ${lemma}	venti ${lemma}, no whip
+
+# Iced
+_ 2Pct	iced venti ${lemma}	iced venti ${lemma}, no whip
+_ Almond	iced venti almond ${lemma}	iced venti ${lemma}, no whip

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/venti.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-multiple-sizes/venti.tsv
@@ -1,0 +1,6 @@
+	| Regular	| Decaf
+_ 2Pct	${lemma}	${lemma}
+_ NonFat	${lemma}	${lemma}
+_ Soy	${lemma}	${lemma}
+_ Oat	${lemma}	${lemma}
+_ Almond	${lemma}	${lemma}

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-only-one-size.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-only-one-size.tsv
@@ -1,0 +1,4 @@
+	| Col | 1	| Col | 2
+_ Row _ 1	[Px1Sg]${lemma}[Noun][Sg]	[Px1Sg]${lemma}[Noun][Pl]
+_ Row _ 2	[Px2Sg]${lemma}[Noun][Sg]	[Px2Sg]${lemma}[Noun][Pl]
+_ Row _ 3	[Px3Sg]${lemma}[Noun][Sg]	[Px3Sg]${lemma}[Noun][Pl]

--- a/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-only-one-size.tsv
+++ b/src/CreeDictionary/CreeDictionary/paradigm/testdata/layouts/dynamic/has-only-one-size.tsv
@@ -1,4 +1,3 @@
-	| Col | 1	| Col | 2
-_ Row _ 1	[Px1Sg]${lemma}[Noun][Sg]	[Px1Sg]${lemma}[Noun][Pl]
-_ Row _ 2	[Px2Sg]${lemma}[Noun][Sg]	[Px2Sg]${lemma}[Noun][Pl]
-_ Row _ 3	[Px3Sg]${lemma}[Noun][Sg]	[Px3Sg]${lemma}[Noun][Pl]
+_ Plain	${lemma}
+_ Butter	buttered ${lemma}
+_ CreamCheese	cream cheese ${lemma}


### PR DESCRIPTION
# What's in this PR?

 - **added**: support to load either a single size or multiple sizes of paradigm layouts from the filesystem
 - **added**: `ParadigmManager.sizes_of(name)` — returns all sizes for a given paradigm name
 - **added**: `ParadigmManager.paradigm_for(name, [size,] [lemma])` — uniform access to get a paradigm, based on its name
 - **changed**: the `ParadigmManager` now takes in a `Transducer` instead of a concrete `hfst_optimized_lookup.TransducerFile` instance.
 - **added**: a bunch of wacky, coffee-inspired test cases. Please let me know if I'm way off the rails with this.

# What is NOT in this PR?

This will not add anything useful to itwêwina as of yet — I would need to edit the existing full paradigms to basic paradigms before. I'd just like feedback on how paradigms are loaded and the test cases before do the work on implementing them in the production site.