### PR TITLE
Update crk FSTs

### DIFF
--- a/src/CreeDictionary/CreeDictionary/hfstol.py
+++ b/src/CreeDictionary/CreeDictionary/hfstol.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """
 Run finite-state transducer analyzer and generator
 """

--- a/src/CreeDictionary/tests/CreeDictionary_tests/test_hfstol.py
+++ b/src/CreeDictionary/tests/CreeDictionary_tests/test_hfstol.py
@@ -14,9 +14,10 @@ from CreeDictionary.CreeDictionary.hfstol import analyze, generate
     ],
 )
 def test_analyze_wordform(wordform, lemma, suffix):
-    analysis, *_more_analyses = analyze(wordform)
-    assert analysis.lemma == lemma
-    assert suffix in analysis.raw_suffixes
+    assert any(
+        analysis.lemma == lemma and suffix in analysis.raw_suffixes
+        for analysis in analyze(wordform)
+    )
 
 
 @pytest.mark.parametrize(

--- a/src/crkeng/resources/fst/crk-relaxed-analyzer-for-dictionary.hfstol
+++ b/src/crkeng/resources/fst/crk-relaxed-analyzer-for-dictionary.hfstol
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0800a57898c37dafcd24514a970aba5d1e17fe0e58591b6f86c25c4a9e2e2f5e
-size 11189655
+oid sha256:4a5e21789d0375368bae1cef50ec8017136efb96ba2b12871858d0a33ec130e2
+size 12990925

--- a/src/crkeng/resources/fst/crk-strict-analyzer-for-dictionary.hfstol
+++ b/src/crkeng/resources/fst/crk-strict-analyzer-for-dictionary.hfstol
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:489ae191edb03c76ecd7a3260a33eb331ebf2701dae18842009ac45efe27a54e
-size 2342803
+oid sha256:733fb987e553fc120bdaeff1a9d65b9dea62472537a0c0c2ee7d564ca9173851
+size 2343452

--- a/src/crkeng/resources/fst/crk-strict-generator.hfstol
+++ b/src/crkeng/resources/fst/crk-strict-generator.hfstol
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f544fdef97f35e127840bb178a31f9c0d721d8f9c59bf7bfa4d1a04e0d1cadaf
-size 2381267
+oid sha256:f4bb0fe27e2dd069be7925ed8688537367fb94acc8b5e51584717b76d2549759
+size 2382398


### PR DESCRIPTION
FSTs come from [lang-crk v2021.6.10](https://github.com/giellalt/lang-crk/releases/tag/fst-v2021.6.10).

The unit test change is because the relaxed analysis of `niskak` went from
only

    niska+N+A+Pl

to

    sikâk+N+A+Px1Sg+Sg
    niska+N+A+Pl
    nîsiwak+V+AI+Imp+Del+12Pl