### PR TITLE
feat: reimplements highlighting for corpus frequency in pane-based paradigms

### DIFF
--- a/src/CreeDictionary/CreeDictionary/paradigm/crkeng_corpus_frequency.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/crkeng_corpus_frequency.py
@@ -1,4 +1,5 @@
 import logging
+from functools import cache
 
 from CreeDictionary.utils import shared_res_dir
 from CreeDictionary.utils.types import ConcatAnalysis
@@ -37,8 +38,17 @@ def import_tuples() -> list[tuple[str, ConcatAnalysis, int]]:
             continue
 
         for analysis in analyses:
-            result.append(
-                (wordform, ConcatAnalysis(analysis), int(freq))
-            )
+            result.append((wordform, ConcatAnalysis(analysis), int(freq)))
 
     return result
+
+
+@cache
+def observed_wordforms() -> set[str]:
+    """
+    Return a set of wordforms that have been observed in some corpus.
+
+    As of 2021-06-11, for itwêwina, this information is derived from the
+    corpus_frequency.txt file that is checked-in to the repo.
+    """
+    return {wordform for wordform, _analysis, freq in import_tuples() if freq > 0}

--- a/src/CreeDictionary/CreeDictionary/paradigm/crkeng_corpus_frequency.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/crkeng_corpus_frequency.py
@@ -1,0 +1,36 @@
+import logging
+
+from CreeDictionary.utils import shared_res_dir
+from CreeDictionary.utils.types import ConcatAnalysis
+
+CORPUS_FREQUENCY_FILE = shared_res_dir / "corpus_frequency.txt"
+
+logger = logging.getLogger(__name__)
+
+
+def import_frequency() -> dict[ConcatAnalysis, int]:
+    """
+    Corpus frequency is stored in a bespoke file format. This parses that file and
+    returns a dictionary.
+    """
+    # TODO: store this in the database, rather than as a source file
+    # TODO: make a management command that updates wordform frequencies
+
+    res: dict[ConcatAnalysis, int] = {}
+    lines = CORPUS_FREQUENCY_FILE.read_text(encoding="UTF-8").splitlines()
+    for line in lines:
+        line = line.strip()
+        if not line:
+            # Skip empty lines
+            continue
+
+        try:
+            freq, _, *analyses = line.split()
+        except ValueError:
+            # not enough value to unpack, which means the line has less than 3 values
+            logger.warning(f'line "{line}" is broken in {CORPUS_FREQUENCY_FILE}')
+        else:
+            for analysis in analyses:
+                res[ConcatAnalysis(analysis)] = int(freq)
+
+    return res

--- a/src/CreeDictionary/CreeDictionary/paradigm/crkeng_corpus_frequency.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/crkeng_corpus_frequency.py
@@ -11,12 +11,17 @@ logger = logging.getLogger(__name__)
 def import_frequency() -> dict[ConcatAnalysis, int]:
     """
     Corpus frequency is stored in a bespoke file format. This parses that file and
-    returns a dictionary.
+    returns a dictionary mapping the ANALYSIS to the amount of times it has appeard
+    in the corpus.
     """
+    return {analysis: frequency for _, analysis, frequency in import_tuples()}
+
+
+def import_tuples() -> list[tuple[str, ConcatAnalysis, int]]:
     # TODO: store this in the database, rather than as a source file
     # TODO: make a management command that updates wordform frequencies
 
-    res: dict[ConcatAnalysis, int] = {}
+    result = []
     lines = CORPUS_FREQUENCY_FILE.read_text(encoding="UTF-8").splitlines()
     for line in lines:
         line = line.strip()
@@ -25,12 +30,15 @@ def import_frequency() -> dict[ConcatAnalysis, int]:
             continue
 
         try:
-            freq, _, *analyses = line.split()
+            freq, wordform, *analyses = line.split()
         except ValueError:
             # not enough value to unpack, which means the line has less than 3 values
             logger.warning(f'line "{line}" is broken in {CORPUS_FREQUENCY_FILE}')
-        else:
-            for analysis in analyses:
-                res[ConcatAnalysis(analysis)] = int(freq)
+            continue
 
-    return res
+        for analysis in analyses:
+            result.append(
+                (wordform, ConcatAnalysis(analysis), int(freq))
+            )
+
+    return result

--- a/src/CreeDictionary/CreeDictionary/paradigm/filler.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/filler.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import morphodict.analysis
+from CreeDictionary.CreeDictionary.paradigm.crkeng_corpus_frequency import (
+    import_frequency,
+)
 
 """
 Fill a paradigm table with the inflections of a lemma.
@@ -14,6 +17,7 @@ from typing import Iterable, Literal, Optional, Sequence, Union, cast
 
 from attr import attrib, attrs
 from hfst_optimized_lookup import TransducerFile
+
 from CreeDictionary.utils import ParadigmSize, WordClass, shared_res_dir
 from CreeDictionary.utils.types import ConcatAnalysis
 
@@ -29,9 +33,6 @@ PARADIGM_NAME_TO_WC = {
     "verb-ta": WordClass.VTA,
     "verb-ti": WordClass.VTI,
 }
-
-CORPUS_FREQUENCY_FILE = shared_res_dir / "corpus_frequency.txt"
-
 
 ##################################### Simple types #####################################
 
@@ -349,30 +350,6 @@ Layout = list[Row]
 
 
 ################################## Internal functions ##################################
-
-
-def import_frequency() -> dict[ConcatAnalysis, int]:
-    # TODO: store this in the database, rather than as a source file
-    # TODO: make a management command that updates wordform frequencies
-
-    res: dict[ConcatAnalysis, int] = {}
-    lines = CORPUS_FREQUENCY_FILE.read_text(encoding="UTF-8").splitlines()
-    for line in lines:
-        line = line.strip()
-        if not line:
-            # Skip empty lines
-            continue
-
-        try:
-            freq, _, *analyses = line.split()
-        except ValueError:
-            # not enough value to unpack, which means the line has less than 3 values
-            logger.warning(f'line "{line}" is broken in {CORPUS_FREQUENCY_FILE}')
-        else:
-            for analysis in analyses:
-                res[ConcatAnalysis(analysis)] = int(freq)
-
-    return res
 
 
 def import_layouts(layout_file_dir: Path) -> Layouts:

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
@@ -20,6 +20,7 @@
   {% endcomment %}
 
   {% load morphodict_orth %}
+  {% load creedictionary_extras %}
   {% load relabelling %}
 
   <section class="definition__paradigm paradigm js-replaceable-paradigm" data-cy="paradigm">
@@ -45,7 +46,7 @@
                     {% elif cell.is_empty %}
                       <td class="paradigm-cell paradigm-cell--empty"></td>
                     {% else %}
-                      <td class="paradigm-cell paradigm-cell--unobserved">
+                      <td class="paradigm-cell paradigm-cell--{% observed_or_unobserved cell.inflection %}">
                         {% orth cell.inflection %}
                       </td>
                     {% endif %}

--- a/src/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
+++ b/src/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
@@ -7,6 +7,9 @@ from django import template
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
 
+from CreeDictionary.CreeDictionary.paradigm.crkeng_corpus_frequency import (
+    observed_wordforms,
+)
 from CreeDictionary.CreeDictionary.utils import url_for_query
 from CreeDictionary.morphodict.templatetags.morphodict_orth import orth_tag
 
@@ -70,23 +73,16 @@ def kbd_text_query_link(text):
     )
 
 
-@register.simple_tag(takes_context=True)
-def observed_or_unobserved(context, wordform: str):
+@register.simple_tag()
+def observed_or_unobserved(wordform: str):
     """
     Outputs the appropriate name depending on whether the word has been observed or not.
     This is intended to make the paradigm template a bit neater.
-
-    REQUIRES observed_wordforms BE A SET IN THE TEMPLATE CONTEXT!
 
     Intended usage:
 
         <td "wordform wordform--{% observed_or_unobserved inflection.text %}">
     """
-    try:
-        observed_wordforms = context["observed_wordforms"]
-    except KeyError:
-        raise AssertionError("Did not find `observed_wordforms` set in the context")
-
-    if wordform in observed_wordforms:
+    if wordform in observed_wordforms():
         return "observed"
     return "unobserved"

--- a/src/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
+++ b/src/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
@@ -68,3 +68,25 @@ def kbd_text_query_link(text):
     return mark_safe(
         f"<a href='?text={escape(quote(text))}'><kbd>{escape(text)}</kbd></a>"
     )
+
+
+@register.simple_tag(takes_context=True)
+def observed_or_unobserved(context, wordform: str):
+    """
+    Outputs the appropriate name depending on whether the word has been observed or not.
+    This is intended to make the paradigm template a bit neater.
+
+    REQUIRES observed_wordforms BE A SET IN THE TEMPLATE CONTEXT!
+
+    Intended usage:
+
+        <td "wordform wordform--{% observed_or_unobserved inflection.text %}">
+    """
+    try:
+        observed_wordforms = context["observed_wordforms"]
+    except KeyError:
+        raise AssertionError("Did not find `observed_wordforms` set in the context")
+
+    if wordform in observed_wordforms:
+        return "observed"
+    return "unobserved"

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -1,5 +1,4 @@
 import logging
-from functools import cache
 from typing import Any, Dict, Literal, Union
 
 from django.conf import settings
@@ -27,7 +26,7 @@ from CreeDictionary.utils import ParadigmSize
 from crkeng.app.preferences import DisplayMode, ParadigmLabel
 from morphodict.preference.views import ChangePreferenceView
 
-from .paradigm.crkeng_corpus_frequency import import_tuples
+from .paradigm.crkeng_corpus_frequency import observed_wordforms
 from .utils import url_for_query
 
 # The index template expects to be rendered in the following "modes";
@@ -395,14 +394,3 @@ def paradigm_for(
 
     # try returning an old-style paradigm: may return []
     return generate_paradigm(wordform, paradigm_size)
-
-
-@cache
-def observed_wordforms() -> set[str]:
-    """
-    Return a set of wordforms that have been observed in some corpus.
-
-    As of 2021-06-11, for itwêwina, this information is derived from the
-    corpus_frequency.txt file that is checked-in to the repo.
-    """
-    return {wordform for wordform, _analysis, freq in import_tuples() if freq > 0}

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -26,7 +26,6 @@ from CreeDictionary.utils import ParadigmSize
 from crkeng.app.preferences import DisplayMode, ParadigmLabel
 from morphodict.preference.views import ChangePreferenceView
 
-from .paradigm.crkeng_corpus_frequency import observed_wordforms
 from .utils import url_for_query
 
 # The index template expects to be rendered in the following "modes";
@@ -83,7 +82,6 @@ def entry_details(request, lemma_text: str):
         wordform=presentation.serialize_wordform(lemma),
         paradigm_size=paradigm_size,
         paradigm=paradigm,
-        observed_wordforms=observed_wordforms(),
     )
     return render(request, "CreeDictionary/index.html", context)
 
@@ -193,7 +191,6 @@ def paradigm_internal(request):
             "lemma": lemma,
             "paradigm_size": paradigm_size.value,
             "paradigm": paradigm,
-            "observed_wordforms": observed_wordforms(),
         },
     )
 

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -405,4 +405,4 @@ def observed_wordforms() -> set[str]:
     As of 2021-06-11, for itwêwina, this information is derived from the
     corpus_frequency.txt file that is checked-in to the repo.
     """
-    return {wordform for wordform, _analysis, freq in import_tuples() if freq > 1}
+    return {wordform for wordform, _analysis, freq in import_tuples() if freq > 0}

--- a/src/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
+++ b/src/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: UTF-8 -*-
-
 import pytest
 from django.http import HttpRequest
 from django.template import Context, RequestContext, Template
@@ -180,35 +177,17 @@ def test_url_for_query_tag():
 
 
 @pytest.mark.parametrize(
-    "observed,classname",
+    "wordform,classname",
     [
-        (True, "wordform--observed"),
-        (False, "wordform--unobserved"),
+        ("ôma", "wordform--observed"),
+        ("Fhqwhgads", "wordform--unobserved"),
     ],
 )
-def test_observed_or_unobserved(observed: bool, classname: str):
-    wordform = "ê-wâpamikot"
-    database = set()
-    if observed:
-        database.add(wordform)
-
-    context = Context({"wordform": wordform, "observed_wordforms": database})
+def test_observed_or_unobserved(wordform: str, classname: str):
+    context = Context({"wordform": wordform})
     template = Template(
         "{% load creedictionary_extras %}"
         "<span class='wordform--{% observed_or_unobserved wordform %}'>"
     )
 
     assert classname in template.render(context)
-
-
-def test_observed_or_unobserved_raises_on_missing_database():
-    """
-    The template must throw an error when the required context variable is missing.
-    """
-    context = Context({"wordform": "anything"})
-    template = Template(
-        "{% load creedictionary_extras %}" "{% observed_or_unobserved wordform %}'>"
-    )
-
-    with pytest.raises(AssertionError):
-        template.render(context)

--- a/src/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
+++ b/src/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
@@ -177,3 +177,38 @@ def test_url_for_query_tag():
     rendered = template.render(context)
     assert "search" in rendered
     assert "wapamew" in rendered
+
+
+@pytest.mark.parametrize(
+    "observed,classname",
+    [
+        (True, "wordform--observed"),
+        (False, "wordform--unobserved"),
+    ],
+)
+def test_observed_or_unobserved(observed: bool, classname: str):
+    wordform = "ê-wâpamikot"
+    database = set()
+    if observed:
+        database.add(wordform)
+
+    context = Context({"wordform": wordform, "observed_wordforms": database})
+    template = Template(
+        "{% load creedictionary_extras %}"
+        "<span class='wordform--{% observed_or_unobserved wordform %}'>"
+    )
+
+    assert classname in template.render(context)
+
+
+def test_observed_or_unobserved_raises_on_missing_database():
+    """
+    The template must throw an error when the required context variable is missing.
+    """
+    context = Context({"wordform": "anything"})
+    template = Template(
+        "{% load creedictionary_extras %}" "{% observed_or_unobserved wordform %}'>"
+    )
+
+    with pytest.raises(AssertionError):
+        template.render(context)


### PR DESCRIPTION
# What's in this PR?

 - **refactor**: move that code to parse `corpus_frequency.txt` to its own file
 - **added**: `{% observed_or_unobserved %}` template tag, because Django's template system makes this kind of thing really ugly 🙃 
 - **added**: `observed_wordform` template context variable to views that render a paradigm