### PR TITLE
feat: compound rows in paradigms

### DIFF
--- a/cypress/integration/paradigm.spec.js
+++ b/cypress/integration/paradigm.spec.js
@@ -82,7 +82,6 @@ describe('I want to search for a Cree word and see its inflectional paradigm', (
   })
 })
 
-
 describe('I want to know if a form is observed inside a paradigm table', () => {
   // TODO: this test should be re-enabled in linguist mode!
   it.skip('shows inflection frequency as digits in brackets', ()=>{
@@ -212,5 +211,32 @@ describe('Paradigm labels', () => {
 
     cy.get('[data-cy=paradigm]')
       .contains('th[scope=row]', linguisticLabel)
+  })
+})
+
+describe('I want to see multiple variants of the same inflection on multiple rows', () => {
+  // See: https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/issues/507
+  it('should display two rows for nipâw+V+AI+Ind+12Pl', () => {
+    const forms = ['kinipânaw', 'kinipânânaw']
+    let rowA = null
+    let rowB = null
+    cy.visitLemma('nipâw')
+
+    // get the first row
+    cy.get('[data-cy=paradigm]')
+      .contains('tr', forms[0])
+      .then($form => { rowA = $form.get(0) })
+
+    // get the second row
+    cy.get('[data-cy=paradigm]')
+      .contains('tr', forms[1])
+      .then($form => { rowB = $form.get(0) })
+      .then(() => {
+        expect(rowA).not.to.be.null
+        expect(rowB).not.to.be.null
+
+        // they should not be the same row!
+        expect(rowA).not.to.equal(rowB)
+      })
   })
 })

--- a/src/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -322,7 +322,7 @@ class ContentRow(Row):
         of ContentRows.
         """
 
-        # fill each COLUMN, then figure out if we need to make a compond row
+        # Fill each **column**, then figure out if we need to make a compound row
         columns = n_empty_lists(self.num_cells)
         for index, cell in enumerate(self.cells):
             columns[index].extend(cell.fill(forms))
@@ -424,6 +424,10 @@ class CompoundRow(Row):
     @property
     def num_cells(self):
         return max(row.num_cells for row in self._rows)
+
+    @property
+    def num_subrows(self) -> int:
+        return len(self._rows)
 
     @property
     def subrows(self) -> Iterable[ContentRow]:

--- a/src/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -348,7 +348,8 @@ class ContentRow(Row):
         # Create compound rows
         rows = []
         for row_num in range(num_rows_needed):
-            cells = [wordform_if_exists_or_no_output(col, row_num) for col in columns]
+            cells = [cell_if_exists_or_no_output(col, row_num) for col in columns]
+            cells = [adjust_row_span(cell, num_rows_needed) for cell in cells]
             rows.append(ContentRow(cells))
         return CompoundRow(rows)
 
@@ -775,7 +776,7 @@ def n_empty_lists(n: int) -> list[list[Cell]]:
     return [[] for _ in range(n)]
 
 
-def wordform_if_exists_or_no_output(col: Sequence[Cell], row_num: int):
+def cell_if_exists_or_no_output(col: Sequence[Cell], row_num: int):
     """
     Extracts the content cell from the column if it exists, else returns an EmptyCell if
     nothing is found.
@@ -784,3 +785,13 @@ def wordform_if_exists_or_no_output(col: Sequence[Cell], row_num: int):
         return col[row_num]
     except IndexError:
         return SuppressOutputCell()
+
+
+def adjust_row_span(cell: Cell, span: int) -> Cell:
+    """
+    Fixes RowLabels such that they span the amount given. Only affects RowLabels.
+    Other cells are returned as is.
+    """
+    if isinstance(cell, RowLabel):
+        return cell.with_row_span(span)
+    return cell

--- a/src/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -323,7 +323,7 @@ class ContentRow(Row):
         """
 
         # fill each COLUMN, then figure out if we need to make a compond row
-        columns: tuple[list[Cell], ...] = tuple([] for n in range(self.num_cells))
+        columns = n_empty_lists(self.num_cells)
         for index, cell in enumerate(self.cells):
             columns[index].extend(cell.fill(forms))
 
@@ -732,3 +732,10 @@ def pairs(seq):
     [(1, 2), (3, 4), (5, 6)]
     """
     return zip(seq[::2], seq[1::2])
+
+
+def n_empty_lists(n: int) -> list[list[Cell]]:
+    """
+    Returns the given number of distinct, empty lists.
+    """
+    return [[] for _ in range(n)]

--- a/src/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -185,6 +185,18 @@ class Pane:
     def rows(self) -> Iterable[Row]:
         yield from self._rows
 
+    @property
+    def tr_rows(self) -> Iterable[Row]:
+        """
+        Yields rows needed in the HTML model. All rows of a compound row are yielded
+        individually.
+        """
+        for row in self._rows:
+            if isinstance(row, CompoundRow):
+                yield from row.subrows
+            else:
+                yield row
+
     def dumps(self, require_num_columns: Optional[int] = None) -> str:
         """
         Returns a string representation that can be parsed again.

--- a/src/CreeDictionary/CreeDictionary/paradigm/panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/panes.py
@@ -10,7 +10,7 @@ import string
 from itertools import zip_longest
 from typing import Collection, Iterable, Mapping, Optional, TextIO
 
-from more_itertools import first, ilen, one
+from more_itertools import ilen, one
 
 logger = logging.getLogger(__name__)
 
@@ -484,16 +484,6 @@ class Cell:
         # Namely, InflectionTemplate should override this.
         raise NotImplementedError
 
-    def fill_one(self, forms: dict[str, Collection[str]]) -> Cell:
-        """
-        Returns exactly ONE cell by filling the paradigm.
-        """
-        if not self.is_inflection:
-            return self
-        # This should be overridden by subclasses.
-        # Namely, InflectionTemplate should override this.
-        raise NotImplementedError
-
 
 class WordformCell(Cell):
     """
@@ -637,11 +627,11 @@ class MissingForm(Cell, SingletonMixin):
         """
         return False
 
-    def fill_one(self, forms: dict[str, Collection[str]]) -> Cell:
+    def fill(self, forms: Mapping[str, Collection[str]]) -> tuple[Cell, ...]:
         """
-        A missing form is already "filled".
+        A missing form is already "filled" -- return one entry
         """
-        return self
+        return (self,)
 
 
 class EmptyCell(Cell, SingletonMixin):

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
@@ -1,10 +1,14 @@
 """
 Unit tests for the paradigm pane module.
 """
-from more_itertools import one
+from more_itertools import first, ilen, last, one
 
-from CreeDictionary.CreeDictionary.paradigm.panes import Pane, \
-    CompoundRow
+from CreeDictionary.CreeDictionary.paradigm.panes import (
+    CompoundRow,
+    EmptyCell,
+    Pane,
+    WordformCell,
+)
 
 
 def test_compound_rows():
@@ -12,9 +16,27 @@ def test_compound_rows():
     row = one(pane.rows)
 
     multiple_forms = ("form", "longer-form")
-
     filled_row = row.fill({"${lemma}": multiple_forms})
     assert isinstance(filled_row, CompoundRow)
 
+    # Ensure all generated forms are in there:
     for form in multiple_forms:
         assert filled_row.contains_wordform(form)
+
+    assert ilen(filled_row.subrows) == len(
+        multiple_forms
+    ), "expected as many subrows as there are forms"
+
+    first_row_cells = tuple(first(filled_row.subrows).cells)
+    assert first(row.cells) == first_row_cells[0], "expected the label to be the same"
+
+    first_form = first_row_cells[-1]
+    assert isinstance(first_form, WordformCell)
+    assert first_form.inflection == multiple_forms[0]
+
+    last_row_cells = tuple(last(filled_row.subrows).cells)
+    assert isinstance(last_row_cells[0], EmptyCell)
+
+    last_form = last_row_cells[-1]
+    assert isinstance(last_form, WordformCell)
+    assert last_form.inflection == multiple_forms[-1]

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
@@ -9,7 +9,9 @@ from CreeDictionary.CreeDictionary.paradigm.panes import (
     EmptyCell,
     MissingForm,
     Pane,
-    WordformCell, RowLabel, SuppressOutputCell,
+    RowLabel,
+    SuppressOutputCell,
+    WordformCell,
 )
 
 
@@ -30,7 +32,8 @@ def test_compound_rows():
     ), "expected as many subrows as there are forms"
 
     first_row_cells = tuple(first(filled_row.subrows).cells)
-    assert first(row.cells) == first_row_cells[0], "expected the label to be the same"
+    assert first(row.cells).fst_tags == first_row_cells[0].fst_tags
+    assert first_row_cells[0].row_span == len(multiple_forms)
 
     first_form = first_row_cells[-1]
     assert isinstance(first_form, WordformCell)

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
@@ -1,11 +1,13 @@
 """
 Unit tests for the paradigm pane module.
 """
+import pytest
 from more_itertools import first, ilen, last, one
 
 from CreeDictionary.CreeDictionary.paradigm.panes import (
     CompoundRow,
     EmptyCell,
+    MissingForm,
     Pane,
     WordformCell,
 )
@@ -40,3 +42,11 @@ def test_compound_rows():
     last_form = last_row_cells[-1]
     assert isinstance(last_form, WordformCell)
     assert last_form.inflection == multiple_forms[-1]
+
+
+@pytest.mark.parametrize("cell", [MissingForm(), EmptyCell()])
+def test_filling_singleton_cells(cell):
+    """
+    Filling certain cells should only return the cell itself.
+    """
+    assert cell == one(cell.fill({}))

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
@@ -25,8 +25,8 @@ def test_compound_rows():
     for form in multiple_forms:
         assert filled_row.contains_wordform(form)
 
-    assert filled_row.num_subrows == ilen(filled_row.subrows) == len(
-        multiple_forms
+    assert (
+        filled_row.num_subrows == ilen(filled_row.subrows) == len(multiple_forms)
     ), "expected as many subrows as there are forms"
 
     first_row_cells = tuple(first(filled_row.subrows).cells)
@@ -42,6 +42,15 @@ def test_compound_rows():
     last_form = last_row_cells[-1]
     assert isinstance(last_form, WordformCell)
     assert last_form.inflection == multiple_forms[-1]
+
+
+def test_pane_iterate_tr_rows():
+    pane = Pane.parse("_ Tag\t${lemma}\n")
+    multiple_forms = ("form", "longer-form")
+    filled_pane = pane.fill({"${lemma}": multiple_forms})
+
+    assert ilen(filled_pane.rows) == ilen(pane.rows)
+    assert ilen(filled_pane.tr_rows) == len(multiple_forms)
 
 
 @pytest.mark.parametrize("cell", [MissingForm(), EmptyCell()])

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
@@ -1,0 +1,20 @@
+"""
+Unit tests for the paradigm pane module.
+"""
+from more_itertools import one
+
+from CreeDictionary.CreeDictionary.paradigm.panes import Pane, \
+    CompoundRow
+
+
+def test_compound_rows():
+    pane = Pane.parse("_ Tag\t${lemma}\n")
+    row = one(pane.rows)
+
+    multiple_forms = ("form", "longer-form")
+
+    filled_row = row.fill({"${lemma}": multiple_forms})
+    assert isinstance(filled_row, CompoundRow)
+
+    for form in multiple_forms:
+        assert filled_row.contains_wordform(form)

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
@@ -9,7 +9,7 @@ from CreeDictionary.CreeDictionary.paradigm.panes import (
     EmptyCell,
     MissingForm,
     Pane,
-    WordformCell,
+    WordformCell, RowLabel, SuppressOutputCell,
 )
 
 
@@ -37,7 +37,7 @@ def test_compound_rows():
     assert first_form.inflection == multiple_forms[0]
 
     last_row_cells = tuple(last(filled_row.subrows).cells)
-    assert isinstance(last_row_cells[0], EmptyCell)
+    assert isinstance(last_row_cells[0], SuppressOutputCell)
 
     last_form = last_row_cells[-1]
     assert isinstance(last_form, WordformCell)
@@ -53,7 +53,17 @@ def test_pane_iterate_tr_rows():
     assert ilen(filled_pane.tr_rows) == len(multiple_forms)
 
 
-@pytest.mark.parametrize("cell", [MissingForm(), EmptyCell()])
+def test_row_label_with_row_span():
+    label = RowLabel(("Ebb", "Flow"))
+    assert label.row_span == 1
+
+    n = 3  # or any small integer above 1
+    new_label = label.with_row_span(n)
+    assert new_label.fst_tags == label.fst_tags
+    assert new_label.row_span == n
+
+
+@pytest.mark.parametrize("cell", [MissingForm(), EmptyCell(), SuppressOutputCell()])
 def test_filling_singleton_cells(cell):
     """
     Filling certain cells should only return the cell itself.

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_panes.py
@@ -25,7 +25,7 @@ def test_compound_rows():
     for form in multiple_forms:
         assert filled_row.contains_wordform(form)
 
-    assert ilen(filled_row.subrows) == len(
+    assert filled_row.num_subrows == ilen(filled_row.subrows) == len(
         multiple_forms
     ), "expected as many subrows as there are forms"
 

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
@@ -29,7 +29,7 @@
       <table class="paradigm__table">
         {% for pane in paradigm.panes %}
           <tbody>
-            {% for row in pane.rows %}
+            {% for row in pane.tr_rows %}
               {% if row.is_header %}
                 <th class="paradigm-header" colspan="{{ paradigm.max_num_columns }}"
                 >{% relabel row.fst_tags %}</th>

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-with-panes.html
@@ -36,8 +36,10 @@
               {% else %}
                 <tr class="paradigm-row">
                   {% for cell in row.cells %}
-                    {% if cell.is_label %}
-                      <th scope="{{ cell.label_for }}"
+                    {% if cell.should_suppress_output %}
+                        {% comment %} Produce NO output! {% endcomment %}
+                    {% elif cell.is_label %}
+                      <th scope="{{ cell.label_for }}" rowspan="{{ cell.row_span }}"
                           class="paradigm-label paradigm-label--{{ cell.label_for }}">
                           {% relabel cell.fst_tags %}
                       </th>

--- a/src/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
+++ b/src/CreeDictionary/tests/CreeDictionary_tests/test_panes.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from more_itertools import first
 from more_itertools import ilen as count
+from more_itertools import one
 
 from CreeDictionary.CreeDictionary.paradigm.panes import (
     ColumnLabel,
@@ -139,7 +140,7 @@ def test_wordform_cell():
     assert cell.contains_wordform(wordform)
 
     # Trying to fill a cell returns the same cell back:
-    assert cell == cell.fill_one({})
+    assert cell == one(cell.fill({}))
 
 
 def sample_pane():

--- a/src/crkeng/app/integration_tests/test_render_paradigm.py
+++ b/src/crkeng/app/integration_tests/test_render_paradigm.py
@@ -1,0 +1,64 @@
+"""
+Test paradigm generation for the itwêwina (crkeng) dictionary.
+"""
+from more_itertools import first
+
+from CreeDictionary.CreeDictionary.paradigm.generation import default_paradigm_manager
+
+# mîcisow - s/he eats (basic vocabulary)
+from CreeDictionary.CreeDictionary.paradigm.panes import CompoundRow, RowLabel
+
+VAI_LEMMA = "mîcisow"
+
+MULTIPLE_12PL_FORMS = [
+    "kimîcisonaw",  # dialectal
+    "kimîcisonânaw",  # more common
+]
+
+# These are the forms that are typically taught in a 1st year/2nd year class:
+EXPECTED_BASIC_VAI_FORMS = [
+    # I eat
+    "nimîcison",
+    # You (sg) eat
+    "kimîcison",
+    # They (sg) eats (lemma)
+    VAI_LEMMA,
+    # We (excl.) eat
+    "nimîcisonân",
+    # We (incl.) eat
+    *MULTIPLE_12PL_FORMS,
+    # You (pl) eat
+    "kimîcisonâwâw",
+    # They (pl) eat:
+    "mîcisowak",
+    # They (obviative) eat
+    "mîcisoyiwa",
+]
+
+
+def test_vai_paradigm() -> None:
+    """
+    Tests the generation of a VAI paradigm. This tests that elementary verb forms
+    exist in the paradigm and that multiple forms are produced for the +12Pl
+    independent form.
+    """
+    manager = default_paradigm_manager()
+
+    name = "VAI"
+    size = first(manager.sizes_of(name))
+    paradigm = manager.paradigm_for(name, lemma=VAI_LEMMA, size=size)
+    first_pane = first(paradigm.panes)
+
+    for form in EXPECTED_BASIC_VAI_FORMS:
+        assert first_pane.contains_wordform(form)
+
+    # The +12PL form should contain **at least** two wordforms.
+    compound_row = first(row for row in first_pane.rows if isinstance(row, CompoundRow))
+    n_rows = compound_row.num_subrows
+    for form in MULTIPLE_12PL_FORMS:
+        assert compound_row.contains_wordform(form)
+    assert n_rows >= 2
+    label = first(first(compound_row.subrows).cells)
+    assert isinstance(label, RowLabel)
+    assert "12Pl" in label.fst_tags
+    assert label.row_span == n_rows


### PR DESCRIPTION
# What's in this PR?

Adds compound rows! Do you have inflections that have **multiple valid** realizations? What's the plural of cactus? This PR will place each wordform on its own row instead of concactenating all the results together on the same line!

Before:
![kinipânânaw on the same line](https://user-images.githubusercontent.com/2294397/121964954-8691fe00-cd29-11eb-9a6c-bb2805e8e2a4.png)

After:
![kinipânânaw on its own line](https://user-images.githubusercontent.com/2294397/121965016-a32e3600-cd29-11eb-8274-ddfa0b0dfa13.png)

- **added**: `CompoundRow` class — contains multiple `ContentRow`
- **added**: `RowLabel` has a `row_span` attribute, which allows it to label multiple rows!
- **added**: `Pane.tr_rows` — iterates rows that should create `<tr>` in the HTML output
- **added**: `SuppressOutputCell` — indicates that a `<td>` should NOT be created in the HTML output
- **added**:  a bevy of unit tests, integration tests, and end-to-end tests


Fixes #507 