### PR TITLE
Small changes to paradigm styles

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -794,8 +794,7 @@ a.multiple-recordings__action-button {
 .paradigm-title,
 .paradigm-header {
   text-align: center;
-  font-style: italic;
-  font-weight: var(--body-font-weight);
+  font-weight: var(--strong-font-weight);
 }
 
 .paradigm-label {
@@ -804,7 +803,7 @@ a.multiple-recordings__action-button {
 }
 
 .paradigm-label--row {
-  font-style: italic;
+  font-weight: var(--strong-font-weight);
 }
 
 .paradigm-label--col {
@@ -820,14 +819,16 @@ a.multiple-recordings__action-button {
 }
 
 .paradigm-cell--observed{
-  font-weight: var(--strong-font-weight);
+  font-weight: var(--body-font-weight);
+}
+
+.paradigm-cell--unobserved{
+  font-style: italic;
 }
 
 .paradigm-cell--no-analysis{
   background-color: lightgray;
 }
-
-
 
 .paradigm-label--row, .paradigm-cell {
   vertical-align: top; /* When a label applies to multiple wordforms */


### PR DESCRIPTION
## What's in this PR:
* changed which elements are bold vs. italic

It looks like this now:
<img width="859" alt="Screen Shot 2021-06-17 at 10 03 26 AM" src="https://user-images.githubusercontent.com/28357720/122433334-5d54b600-cf53-11eb-9b71-86981f595894.png">
