### PR TITLE
ci: run actions on Ubuntu 20.04

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   # Skips deploy if [skip deploy] is present in the commit message
   should-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     outputs:
       should-run: ${{ steps.ci-skip.outputs.ci-skip-not }}
@@ -82,7 +82,7 @@ jobs:
 
   # Runs Cypress acceptance tests
   integration-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -143,7 +143,7 @@ jobs:
         npm run test:ci
 
   build-docker-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     # Only build the Docker Image when we're deploying!
     needs:
@@ -175,7 +175,7 @@ jobs:
           ghcr.io/ualbertaaltlab/itwewina.altlab.app:${{ github.sha }}
 
   trigger-deployment:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     needs:
     - should-deploy

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -6,13 +6,6 @@ env:
   ACTIONS_PYTHON_VERSION: 3.9
   # Version required to run npm build:
   ACTIONS_NODE_VERSION: 12
-  # Version running on Sapir:
-  ACTIONS_OS_VERSION: ubuntu-16.04
-  # N.B.: Currently available versions (2021-01-04) are:
-  #   - ubuntu-16.04
-  #   - ubuntu-18.04 (@ubuntu-latest)
-  #   - ubuntu-20.04 (soon-to-be @ubuntu-latest)
-  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
 jobs:
   # Skips deploy if [skip deploy] is present in the commit message
@@ -35,7 +28,7 @@ jobs:
 
   # Run Pytest unit tests
   unit-test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -89,7 +82,7 @@ jobs:
 
   # Runs Cypress acceptance tests
   integration-test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub is deprecating Ubuntu 16.04 from its Actions runners. I believe it was hard-coded to use 16.04 because Sapir was running 16.04.

Note: `${ACTIONS_OS_VERSION}` variable substitution was not being used, and I think it never worked, so I just deleted that variable!