### PR TITLE
change: ParadigmManager API no longer makes a distinction between static and dynamic layouts

### DIFF
--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -23,12 +23,9 @@ class ParadigmManager:
 
     # Mappings of paradigm name => sizes available => the layout/paradigm
     _name_to_layout: dict[str, dict[str, ParadigmLayout]]
-    # TODO: delete
-    _wc_to_layout: dict[str, dict[str, ParadigmLayout]]
 
     def __init__(self, layout_directory: Path, generation_fst: Transducer):
         self._generator = generation_fst
-        self._wc_to_layout = defaultdict(dict)
         self._name_to_layout = defaultdict(dict)
 
         self._load_static_from(layout_directory / "static")
@@ -73,7 +70,7 @@ class ParadigmManager:
         Returns a dynamic paradigm for the given lemma and word class.
         Returns None if no such paradigm can be generated.
         """
-        size_options = self._wc_to_layout.get(word_class)
+        size_options = self._name_to_layout.get(word_class)
         if size_options is None:
             # No matching name means no paradigm:
             return None
@@ -89,8 +86,6 @@ class ParadigmManager:
 
         if paradigm_name in self._name_to_layout:
             collection = self._name_to_layout
-        elif paradigm_name in self._wc_to_layout:
-            collection = self._wc_to_layout
         else:
             raise KeyError(f"Paradigm does not exist: {paradigm_name}")
 
@@ -116,7 +111,7 @@ class ParadigmManager:
             return
 
         for paradigm_name, size, layout in _load_all_layouts_in_directory(path):
-            self._wc_to_layout[paradigm_name][size] = layout
+            self._name_to_layout[paradigm_name][size] = layout
 
     def _inflect(self, layout: ParadigmLayout, lemma: str) -> Paradigm:
         """
@@ -166,7 +161,7 @@ class ParadigmManagerWithExplicitSizes(ParadigmManager):
         explicit order given in the constructor.
         """
         valid_sizes = {ONLY_SIZE} | self._size_to_order.keys()
-        all_paradigms = self._name_to_layout.keys() | self._wc_to_layout.keys()
+        all_paradigms = self._name_to_layout.keys()
 
         for paradigm in all_paradigms:
             # use super() to avoid any ordering stuff.

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -43,19 +43,13 @@ class ParadigmManager:
         Returns a paradigm for the given paradigm name. If a lemma is given, this is
         substituted into the dynamic paradigm.
         """
+        layout_sizes = self._sizes_or_error_of(paradigm_name)
+        layout = layout_sizes[size]
 
         if lemma is not None:
-            size_options = self._name_to_layout.get(paradigm_name)
-            if size_options is None:
-                # No matching name means no paradigm:
-                raise ParadigmDoesNotExistError(paradigm_name)
-
-            layout = size_options[size]
             return self._inflect(layout, lemma)
         else:
-            if size_options := self._name_to_layout.get(paradigm_name):
-                return size_options[size].as_static_paradigm()
-            raise NotImplementedError("cannot find paradigm?")
+            return layout.as_static_paradigm()
 
     def sizes_of(self, paradigm_name: str) -> Collection[str]:
         """

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -28,8 +28,8 @@ class ParadigmManager:
         self._generator = generation_fst
         self._name_to_layout = defaultdict(dict)
 
-        self._load_static_from(layout_directory / "static")
-        self._load_dynamic_from(layout_directory / "dynamic")
+        self._load_layouts_from(layout_directory / "static")
+        self._load_layouts_from(layout_directory / "dynamic")
 
     def paradigm_for(
         self, paradigm_name: str, lemma: Optional[str] = None, size: str = ONLY_SIZE
@@ -91,23 +91,14 @@ class ParadigmManager:
 
         return collection[paradigm_name].keys()
 
-    def _load_static_from(self, path: Path):
+    def _load_layouts_from(self, path: Path):
         """
-        Loads all .tsv files in the path as static paradigms.
+        Loads all .tsv files in the path as paradigm layouts.
+
+        Does nothing if the directory does not exist.
         """
         if not path.exists():
-            logger.info("No static paradigms found in %s", path)
-            return
-
-        for paradigm_name, size, layout in _load_all_layouts_in_directory(path):
-            self._name_to_layout[paradigm_name][size] = layout
-
-    def _load_dynamic_from(self, path: Path):
-        """
-        Loads all .tsv files as dynamic layouts.
-        """
-        if not path.exists():
-            logger.info("No dynamic paradigms found in %s", path)
+            logger.debug("No layouts found in %s", path)
             return
 
         for paradigm_name, size, layout in _load_all_layouts_in_directory(path):

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -42,8 +42,10 @@ class ParadigmManager:
         """
         Returns a paradigm for the given paradigm name. If a lemma is given, this is
         substituted into the dynamic paradigm.
+
+        :raises ParadigmDoesNotExistError: when the paradigm name cannot be found.
         """
-        layout_sizes = self._sizes_or_error_of(paradigm_name)
+        layout_sizes = self._layout_sizes_or_raise(paradigm_name)
         layout = layout_sizes[size]
 
         if lemma is not None:
@@ -54,13 +56,16 @@ class ParadigmManager:
     def sizes_of(self, paradigm_name: str) -> Collection[str]:
         """
         Returns the size options of the given paradigm.
-        """
-        return self._sizes_or_error_of(paradigm_name).keys()
 
-    def _sizes_or_error_of(self, paradigm_name) -> dict[str, ParadigmLayout]:
+        :raises ParadigmDoesNotExistError: when the paradigm name cannot be found.
         """
-        Returns the sizes the given paradigm name. Errors if the paradigm cannot be
-        found.
+        return self._layout_sizes_or_raise(paradigm_name).keys()
+
+    def _layout_sizes_or_raise(self, paradigm_name) -> dict[str, ParadigmLayout]:
+        """
+        Returns the sizes the given paradigm name.
+
+        :raises ParadigmDoesNotExistError: when the paradigm name cannot be found.
         """
         try:
             return self._name_to_layout[paradigm_name]

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -82,14 +82,18 @@ class ParadigmManager:
         """
         Returns the size options of the given paradigm.
         """
-        collection: dict[str, dict[str, Any]]
+        return self._sizes_or_error_of(paradigm_name).keys()
 
-        if paradigm_name in self._name_to_layout:
-            collection = self._name_to_layout
-        else:
-            raise KeyError(f"Paradigm does not exist: {paradigm_name}")
-
-        return collection[paradigm_name].keys()
+    def _sizes_or_error_of(self, paradigm_name) -> dict[str, ParadigmLayout]:
+        """
+        Returns the sizes the given paradigm name. Errors if the paradigm cannot be
+        found.
+        """
+        try:
+            return self._name_to_layout[paradigm_name]
+        except KeyError:
+            # XXX: kinda weird; probably want our own error for this:
+            raise KeyError(f"Paradigm does not exist: {paradigm_name}") from None
 
     def _load_layouts_from(self, path: Path):
         """

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -43,45 +43,19 @@ class ParadigmManager:
         Returns a paradigm for the given paradigm name. If a lemma is given, this is
         substituted into the dynamic paradigm.
         """
+
         if lemma is not None:
-            paradigm = self.dynamic_paradigm_for(
-                lemma=lemma, word_class=paradigm_name, size=size
-            )
+            size_options = self._name_to_layout.get(paradigm_name)
+            if size_options is None:
+                # No matching name means no paradigm:
+                raise ParadigmDoesNotExistError(paradigm_name)
+
+            layout = size_options[size]
+            return self._inflect(layout, lemma)
         else:
-            paradigm = self.static_paradigm_for(paradigm_name, size=size)
-
-        if paradigm is None:
-            raise NotImplementedError(
-                "not sure what should happen if a paradigm cannot be found"
-            )
-
-        return paradigm
-
-    def static_paradigm_for(
-        self, name: str, size: str = ONLY_SIZE
-    ) -> Optional[Paradigm]:
-        """
-        Returns a static paradigm with the given name.
-        Returns None if there is no paradigm with such a name.
-        """
-        if size_options := self._name_to_layout.get(name):
-            return size_options[size].as_static_paradigm()
-        return None
-
-    def dynamic_paradigm_for(
-        self, *, lemma: str, word_class: str, size: str = ONLY_SIZE
-    ) -> Optional[Paradigm]:
-        """
-        Returns a dynamic paradigm for the given lemma and word class.
-        Returns None if no such paradigm can be generated.
-        """
-        size_options = self._name_to_layout.get(word_class)
-        if size_options is None:
-            # No matching name means no paradigm:
-            return None
-
-        layout = size_options[size]
-        return self._inflect(layout, lemma)
+            if size_options := self._name_to_layout.get(paradigm_name):
+                return size_options[size].as_static_paradigm()
+            raise NotImplementedError("cannot find paradigm?")
 
     def sizes_of(self, paradigm_name: str) -> Collection[str]:
         """

--- a/src/CreeDictionary/CreeDictionary/paradigm/manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/manager.py
@@ -22,13 +22,14 @@ class ParadigmManager:
     """
 
     # Mappings of paradigm name => sizes available => the layout/paradigm
-    _name_to_paradigm: dict[str, dict[str, Paradigm]]
+    _name_to_layout: dict[str, dict[str, ParadigmLayout]]
+    # TODO: delete
     _wc_to_layout: dict[str, dict[str, ParadigmLayout]]
 
     def __init__(self, layout_directory: Path, generation_fst: Transducer):
         self._generator = generation_fst
-        self._name_to_paradigm = defaultdict(dict)
         self._wc_to_layout = defaultdict(dict)
+        self._name_to_layout = defaultdict(dict)
 
         self._load_static_from(layout_directory / "static")
         self._load_dynamic_from(layout_directory / "dynamic")
@@ -61,8 +62,8 @@ class ParadigmManager:
         Returns a static paradigm with the given name.
         Returns None if there is no paradigm with such a name.
         """
-        if size_options := self._name_to_paradigm.get(name):
-            return size_options[size]
+        if size_options := self._name_to_layout.get(name):
+            return size_options[size].as_static_paradigm()
         return None
 
     def dynamic_paradigm_for(
@@ -86,8 +87,8 @@ class ParadigmManager:
         """
         collection: dict[str, dict[str, Any]]
 
-        if paradigm_name in self._name_to_paradigm:
-            collection = self._name_to_paradigm
+        if paradigm_name in self._name_to_layout:
+            collection = self._name_to_layout
         elif paradigm_name in self._wc_to_layout:
             collection = self._wc_to_layout
         else:
@@ -104,7 +105,7 @@ class ParadigmManager:
             return
 
         for paradigm_name, size, layout in _load_all_layouts_in_directory(path):
-            self._name_to_paradigm[paradigm_name][size] = layout.as_static_paradigm()
+            self._name_to_layout[paradigm_name][size] = layout
 
     def _load_dynamic_from(self, path: Path):
         """
@@ -165,7 +166,7 @@ class ParadigmManagerWithExplicitSizes(ParadigmManager):
         explicit order given in the constructor.
         """
         valid_sizes = {ONLY_SIZE} | self._size_to_order.keys()
-        all_paradigms = self._name_to_paradigm.keys() | self._wc_to_layout.keys()
+        all_paradigms = self._name_to_layout.keys() | self._wc_to_layout.keys()
 
         for paradigm in all_paradigms:
             # use super() to avoid any ordering stuff.

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
@@ -9,9 +9,10 @@ from more_itertools import first
 
 from CreeDictionary.CreeDictionary.paradigm.manager import (
     ONLY_SIZE,
+    ParadigmDoesNotExistError,
     ParadigmManager,
     ParadigmManagerWithExplicitSizes,
-    Transducer, ParadigmDoesNotExistError,
+    Transducer,
 )
 
 
@@ -122,7 +123,9 @@ def test_paradigm_for_raises_does_not_exist_error(paradigm_manager: ParadigmMana
     bad_paradigm_name = create_arbitrary_string()
 
     with pytest.raises(ParadigmDoesNotExistError) as error:
-        paradigm_manager.paradigm_for(bad_paradigm_name, lemma=create_arbitrary_string())
+        paradigm_manager.paradigm_for(
+            bad_paradigm_name, lemma=create_arbitrary_string()
+        )
 
     assert bad_paradigm_name in str(error)
 

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
@@ -110,12 +110,22 @@ def test_can_find_wordforms_in_multiple_sizes(paradigm_manager: ParadigmManager)
         assert venti.contains_wordform(form)
 
 
-def test_paradigm_does_not_exist_error(paradigm_manager: ParadigmManager):
+def test_sizes_of_raises_does_not_exist_error(paradigm_manager: ParadigmManager):
     bad_paradigm_name = create_arbitrary_string()
     with pytest.raises(ParadigmDoesNotExistError) as error:
         paradigm_manager.sizes_of(bad_paradigm_name)
 
     assert bad_paradigm_name in str(error)
+
+
+def test_paradigm_for_raises_does_not_exist_error(paradigm_manager: ParadigmManager):
+    bad_paradigm_name = create_arbitrary_string()
+
+    with pytest.raises(ParadigmDoesNotExistError) as error:
+        paradigm_manager.paradigm_for(bad_paradigm_name, lemma=create_arbitrary_string())
+
+    assert bad_paradigm_name in str(error)
+
 
 @pytest.fixture
 def paradigm_manager(coffee_layout_dir: Path, identity_transducer):

--- a/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
+++ b/src/CreeDictionary/CreeDictionary/paradigm/test_manager.py
@@ -1,6 +1,6 @@
 import logging
 import random
-import re
+import secrets
 from pathlib import Path
 from typing import Iterable
 
@@ -11,7 +11,7 @@ from CreeDictionary.CreeDictionary.paradigm.manager import (
     ONLY_SIZE,
     ParadigmManager,
     ParadigmManagerWithExplicitSizes,
-    Transducer,
+    Transducer, ParadigmDoesNotExistError,
 )
 
 
@@ -110,6 +110,13 @@ def test_can_find_wordforms_in_multiple_sizes(paradigm_manager: ParadigmManager)
         assert venti.contains_wordform(form)
 
 
+def test_paradigm_does_not_exist_error(paradigm_manager: ParadigmManager):
+    bad_paradigm_name = create_arbitrary_string()
+    with pytest.raises(ParadigmDoesNotExistError) as error:
+        paradigm_manager.sizes_of(bad_paradigm_name)
+
+    assert bad_paradigm_name in str(error)
+
 @pytest.fixture
 def paradigm_manager(coffee_layout_dir: Path, identity_transducer):
     return ParadigmManager(coffee_layout_dir, identity_transducer)
@@ -168,3 +175,10 @@ def distinct_permutation(sequence):
     while result == original:
         random.shuffle(result)
     return result
+
+
+def create_arbitrary_string():
+    """
+    Returns a random string, unlikely to collide with a human-generated name.
+    """
+    return secrets.token_hex()

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -366,7 +366,7 @@ def paradigm_for(
     manager = default_paradigm_manager()
 
     if name := wordform.paradigm:
-        if static_paradigm := manager.static_paradigm_for(name):
+        if static_paradigm := manager.paradigm_for(name):
             return static_paradigm
         logger.warning(
             "Could not retrieve static paradigm %r " "associated with wordform %r",

--- a/src/crkeng/app/integration_tests/test_paradigm_manager.py
+++ b/src/crkeng/app/integration_tests/test_paradigm_manager.py
@@ -22,7 +22,7 @@ def test_paradigm_sizes_are_ordered(paradigm_manager):
 
 
 def test_generates_personal_pronoun_paradigm(paradigm_manager) -> None:
-    paradigm = paradigm_manager.static_paradigm_for("personal-pronouns")
+    paradigm = paradigm_manager.paradigm_for("personal-pronouns")
     assert paradigm is not None
 
     # I don't know how many panes there will be, but the first should DEFINITELY have


### PR DESCRIPTION
# What's in this PR?

We decided that the `ParadigmManager` doesn't really need to care whether a layout is "static" or "dynamic" anymore.

**NOTE**: I did NOT change the directory structure, so the layouts are still being loaded from `layouts/{dynamic,static}`.

 - **removed**: `ParadigmManager.static_paradigm_for()`
 - **removed**: `ParadigmManager.dynamic_paradigm_for()`
 - **changed**: `ParadigmManager.paradigm_for()` just... does the right thing!
 - **added**: `ParadigmDoesNotExistError` for when you to try to generate a paradigm that does not exist!

+ other misc. refactorings!