### PR TITLE
feat: “Legend of abbreviations” page

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -8,6 +8,7 @@
   "pluginsFile": false,
   "env": {
     "admin_url": "/admin/",
-    "admin_login_url": "/admin/login/"
+    "admin_login_url": "/admin/login/",
+    "legend_url": "/legend"
   }
 }

--- a/cypress/integration/legend.spec.js
+++ b/cypress/integration/legend.spec.js
@@ -1,0 +1,33 @@
+context('The Legend page', function () {
+  describe('Visiting any page', () => {
+    it('should have a link to the about page in the footer', () => {
+      cy.visit('/')
+      cy.get('footer')
+        .contains('a', 'Legend')
+        .click()
+
+      cy.url()
+        .should('contain', Cypress.env('legend_url'))
+    })
+  })
+
+  describe('Visiting the legend page', () => {
+    beforeEach(function () {
+      cy.visit(Cypress.env('legend_url'))
+    })
+
+    it('should have a title', () => {
+      cy.get('main').contains('h2', /\bLegend/i)
+    })
+
+    const AROKS_ABBREVIATIONS = ['s.t.', 's.o.', 's/he']
+    for (const abbrv of AROKS_ABBREVIATIONS) {
+      it(`should define ${abbrv}`, () => {
+        cy.get('main')
+          .contains('dt', abbrv)
+          .next()
+          .should('match', 'dd')
+      })
+    }
+  })
+})

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -83,6 +83,7 @@
     <ul class="footer__links footer__basic-links ">
       <li><a href="http://altlab.artsrn.ualberta.ca/itwewina#help" class="footer-links__link" target="_blank"
              rel="noopener">Help</a></li>
+      <li><a href="{% url 'cree-dictionary-legend' %}" class="footer-links__link">Legend of abbreviations</a></li>
       <li><a href="{% url 'cree-dictionary-about' %}" class="footer-links__link">About</a></li>
       <li><a href="{% url 'cree-dictionary-contact-us' %}" class="footer-links__link">Contact us</a></li>
     </ul>

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/legend.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/legend.html
@@ -1,0 +1,33 @@
+{% extends 'CreeDictionary/base.html' %}
+
+{% load creedictionary_extras %}
+{% load morphodict_orth %}
+
+{% block prose %}
+  <section id="legend" class="prose box box--spaced">
+    <h2 class="proce__section-title">Legend of abbreviations</h2>
+
+    <dl>
+      <dt>s/he</dt>
+      <dd><strong>s</strong>he, <strong>h</strong>e, or (singular)
+        th<strong>e</strong>y. Used in definitions to stand for the
+        <strong>animate actor</strong>. The equivalent to the Cree pronoun
+        {% definition_link "wiya" %}.</dd>
+
+      <dt>s.t.</dt>
+      <dd><strong>s</strong>ome<strong>t</strong>hing. Used in definitions to
+        stand for the <strong>inanimate goal</strong>.</dd>
+
+      <dt>s.o.</dt>
+      <dd><strong>s</strong>ome<strong>o</strong>ne, but can also mean
+        “something animate” like {% definition_link "pahkwêsikan" %} or
+        {% definition_link "asikan" %}.  Used in definitions to stand for the
+        <strong>animate goal</strong>. </dd>
+
+      <dt>it</dt>
+      <dd>Used in definitions to stand for the <strong>inanimate
+          actor</strong> or <strong>expletive subject</strong> (the “it” in
+        “it's raining”).</dd>
+    </dl>
+  </section>
+{% endblock %}

--- a/src/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
+++ b/src/CreeDictionary/CreeDictionary/templatetags/creedictionary_extras.py
@@ -4,6 +4,7 @@ Template tags related to the Cree Dictionary specifically.
 from urllib.parse import quote
 
 from django import template
+from django.urls import reverse
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
 
@@ -55,6 +56,18 @@ def url_for_query_tag(user_query: str) -> str:
         /search?q=w%C3%A2pam%C3%AAw
     """
     return url_for_query(user_query)
+
+
+@register.simple_tag(takes_context=True)
+def definition_link(context, wordform: str) -> str:
+    """
+    Links to the definition of the wordform. Outputs wordform with current orthography.
+    """
+    return format_html(
+        '<a href="{}">{}</a>',
+        reverse("cree-dictionary-index-with-lemma", kwargs=dict(lemma_text=wordform)),
+        orth_tag(context, wordform),
+    )
 
 
 @register.filter()

--- a/src/CreeDictionary/CreeDictionary/urls.py
+++ b/src/CreeDictionary/CreeDictionary/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     path("about", views.about, name="cree-dictionary-about"),
     path("contact-us", views.contact_us, name="cree-dictionary-contact-us"),
     path("query-help", views.query_help, name="cree-dictionary-query-help"),
+    path("legend", views.legend, name="cree-dictionary-legend"),
     path("admin/fst-tool", views.fst_tool, name="cree-dictionary-fst-tool"),
     ################################# Internal API #################################
     # internal use to render boxes of search results

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -217,6 +217,18 @@ def contact_us(request):  # pragma: no cover
     )
 
 
+def legend(request):  # pragma: no cover
+    """
+    Legend of abbreviations page.
+    """
+    context = create_context_for_index_template("info-page")
+    return render(
+        request,
+        "CreeDictionary/legend.html",
+        context,
+    )
+
+
 def query_help(request):  # pragma: no cover
     """
     Query help page. Not yet linked from any public parts of site.

--- a/src/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
+++ b/src/CreeDictionary/tests/CreeDictionary_tests/test_creedictionary_extras.py
@@ -177,6 +177,30 @@ def test_url_for_query_tag():
 
 
 @pytest.mark.parametrize(
+    ("orthography", "wordform"),
+    [
+        ("Latn", "wâpamêw"),
+        ("Latn-x-macron", "wāpamēw"),
+        ("Cans", "ᐚᐸᒣᐤ"),
+    ],
+)
+def test_definition_link(orthography: str, wordform: str):
+    """
+    Test that it's in a link and the orthography is correct.
+    """
+    request = HttpRequest()
+    request.COOKIES["orth"] = orthography
+    context = RequestContext(request, {})
+    template = Template(
+        "{% load creedictionary_extras %}" '{% definition_link "wâpamêw" %}'
+    )
+    rendered = template.render(context)
+    assert rendered.startswith("<a")
+    assert rendered.endswith("</a>")
+    assertInHTML(wordform, rendered)
+
+
+@pytest.mark.parametrize(
     "wordform,classname",
     [
         ("ôma", "wordform--observed"),


### PR DESCRIPTION
# What's in this PR?

A separate help page that defines the abbreviations. I'm trying to define them as accessibly as possible first, and then drop in jargon near the end.

<img width="859" alt="A preview of the legend of abbreviations" src="https://user-images.githubusercontent.com/2294397/123681597-3f1a7000-d807-11eb-8634-b749ab96a45a.png">


I've also added the `{% definition_link wordform %}` tag that links to a wordform definition page (with text in the current orthography).

Resolves #405.

