### PR TITLE
fix: do not run CVD if query looks like Cree

### DIFF
--- a/src/CreeDictionary/API/search/core.py
+++ b/src/CreeDictionary/API/search/core.py
@@ -69,10 +69,27 @@ class SearchRun:
         return [r.serialize() for r in results]
 
     def add_verbose_message(self, message=None, **messages):
-        assert message is not None or messages
+        """
+        Add any arbitrary JSON-serializable data to be displayed to the user at the
+        top of the search page, if a search is run with verbose:1.
+
+        Protip! Use keyword arguments as syntactic sugar for adding a dictionary, e.g.,
+
+            search_run.add_verbose_message(foo="bar")
+
+        Will appear as:
+
+        [
+            {"foo": "bar"}
+        ]
+        """
+        if message is None and not messages:
+            raise TypeError("must provide a message or messages")
+
         if message is not None:
             self._verbose_messages.append(message)
-        self._verbose_messages.append(messages)
+        if messages:
+            self._verbose_messages.append(messages)
 
     @property
     def verbose_messages(self):

--- a/src/CreeDictionary/API/search/cvd_search.py
+++ b/src/CreeDictionary/API/search/cvd_search.py
@@ -29,6 +29,7 @@ def do_cvd_search(search_run: SearchRun):
     if not keys:
         return
 
+    search_run.add_verbose_message(cvd_extracted_keys=keys)
     query_vector = vector_for_keys(google_news_vectors(), keys)
 
     try:

--- a/src/CreeDictionary/API/search/runner.py
+++ b/src/CreeDictionary/API/search/runner.py
@@ -1,3 +1,5 @@
+import re
+
 from CreeDictionary.API.search.affix import (
     do_source_language_affix_search,
     do_target_language_affix_search,
@@ -10,6 +12,8 @@ from CreeDictionary.API.search.lookup import fetch_results
 from CreeDictionary.API.search.query import CvdSearchType
 from CreeDictionary.API.search.util import first_non_none_value
 from CreeDictionary.utils.types import cast_away_optional
+
+CREE_LONG_VOWEL = re.compile("[êîôâēīōā]")
 
 
 def search(
@@ -33,6 +37,7 @@ def search(
         first_non_none_value(search_run.query.cvd, default=CvdSearchType.DEFAULT)
     )
 
+    # For when you type 'cvd:exclusive' in a query to debug ONLY CVD results!
     if cvd_search_type == CvdSearchType.EXCLUSIVE:
         do_cvd_search(search_run)
         return search_run
@@ -45,10 +50,30 @@ def search(
         do_source_language_affix_search(search_run)
         do_target_language_affix_search(search_run)
 
-    if cvd_search_type.should_do_search():
+    if cvd_search_type.should_do_search() and not is_almost_certainly_cree(search_run):
         do_cvd_search(search_run)
 
     if search_run.query.espt:
         espt_search.inflect_search_results()
 
     return search_run
+
+
+def is_almost_certainly_cree(search_run: SearchRun) -> bool:
+    """
+    Heuristics intended to AVOID doing an English search.
+    """
+    query = search_run.query
+
+    # If there is a word with two or more dashes in it, it's probably Cree:
+    if any(term.count("-") >= 2 for term in query.query_terms):
+        search_run.add_verbose_message(
+            "Skipping CVD because query has too many hyphens"
+        )
+        return True
+
+    if CREE_LONG_VOWEL.search(query.query_string):
+        search_run.add_verbose_message("Skipping CVD because query has Cree diacritics")
+        return True
+
+    return False

--- a/src/CreeDictionary/cvd/cvd_test.py
+++ b/src/CreeDictionary/cvd/cvd_test.py
@@ -20,12 +20,15 @@ FAKE_WORD_SET = {"loose", "leaf", "paper", "news_paper", "you're", "that"}
             ["paper"],
         ),
         ("  PAPER!", ["paper"]),
+        # Square brackets come from parenthetical parts of Arok's definitions,
+        # so we want to ignore them when extracting keys to do the cosine vector search.
         (" paper, (loose!) [yes]", ["paper", "loose"]),
         (
             "loose-leaf paper",
             ["loose", "leaf", "paper"],
         ),
         ("news-paper", ["news_paper"]),
+        # not in FAKE_WORD_SET:
         ("cheese", []),
         ("Cheese-Paper", ["paper"]),
         ("that's", ["that"]),

--- a/src/CreeDictionary/tests/API_tests/model_test.py
+++ b/src/CreeDictionary/tests/API_tests/model_test.py
@@ -310,6 +310,24 @@ def test_logs_error_on_analyzable_result_without_generated_string(caplog):
     assert any("bod" in log.message for log in errors)
 
 
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "query",
+    [
+        # typo in pîmi-:
+        "ê-pim-nêhiyawêyahk",
+        # non-word with plausible Cree phonotactics:
+        "pêp-kôniw",  # (see: https://www.youtube.com/watch?v=3fG8rNHUspU)
+    ],
+)
+def test_avoids_cvd_search_if_query_looks_like_cree(query: str) -> None:
+    """
+    Some searches should not even **TOUCH** CVD, yielding zero results.
+    """
+    results = search(query=query).presentation_results()
+    assert len(results) == 0
+
+
 ####################################### Helpers ########################################
 
 


### PR DESCRIPTION
# What's in this PR?

The Google vectors have surprising things that may match strangely with Cree queries. So just don't do a CVD search!

Fixes #897
See also: https://github.com/giellalt/lang-crk/issues/31