### PR TITLE
feat: "toast" notification to indicate auto-save success

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -6,6 +6,7 @@
 @import "./_tooltip.css";
 @import "./utilities.css";
 @import "./settings-page.css";
+@import "./toast.css";
 
 /**
  * Preliminary styles for the application.

--- a/frontend/css/toast.css
+++ b/frontend/css/toast.css
@@ -1,0 +1,34 @@
+/**
+ *
+ */
+.toast {
+    --position-away-from-screen: 2rem;
+
+    position: fixed;
+    left: 2rem;
+    bottom: var(--position-away-from-screen);
+    margin: 0;
+
+    border: #CCC solid 1px;
+    border-radius: 4px;
+
+    font-size: 1.5em;
+
+    box-shadow: 1px 1px 16px rgba(0, 0, 0, 0.8);
+    background-color: rgba(255, 255, 255, 95%);
+
+    transition: all 200ms ease-in-out;
+}
+
+.toast--hidden {
+  opacity: 0;
+  transform: translateY(calc(var(--position-away-from-screen) + 4em));
+}
+
+.toast__message {
+  margin-block: 0;
+}
+
+.toast--success .toast__message {
+  color: #17B003;
+}

--- a/frontend/css/toast.css
+++ b/frontend/css/toast.css
@@ -1,7 +1,7 @@
 /**
  * BLOCK toast
  *
- * A minimally intrusive notifaction pop-up that indicates some state change.
+ * A minimally intrusive notification pop-up that indicates some state change.
  *
  * Expected to be a <dialog> element.
  */

--- a/frontend/css/toast.css
+++ b/frontend/css/toast.css
@@ -1,39 +1,68 @@
 /**
+ * BLOCK toast
  *
+ * A minimally intrusive notifaction pop-up that indicates some state change.
+ *
+ * Expected to be a <dialog> element.
  */
 .toast {
+  --toast-height: 4em;
   --position-away-from-screen: 2rem;
 
   position: fixed;
-  left: 2rem;
-  right: 2rem;
+
+  left: var(--position-away-from-screen);
+  right: var(--position-away-from-screen);;
   bottom: var(--position-away-from-screen);
   width: calc(100vw - 2 * var(--position-away-from-screen));
+  max-height: var(--toast-height);
   margin: 0;
 
   border: 0;
   border-radius: 4px;
 
-  box-shadow: 1px 1px 16px rgba(0, 0, 0, 0.8);
   color: white;
   background-color: black;
+  box-shadow: 1px 1px 16px rgba(0, 0, 0, 0.8);
 
-  transition: all 200ms ease-in-out;
+  transition-property: opacity transform;
+  transition-duration: 200ms;
+  transition-timing-function: ease-in-out;
 }
 
+/**
+ * MODIFIER off-screen
+ *
+ * Places the toast off-screen.
+ */
+.toast--off-screen {
+  opacity: 0;
+  transform: translateY(calc(var(--position-away-from-screen) + var(--toast-height)));
+}
+
+/**
+ * MODIFIER success
+ *
+ * The message indicates that something succeeded.
+ */
 .toast--success {
   background-color: #178A4D;
 }
 
+/**
+ * MODIFIER failure
+ *
+ * The message indicates that something failed.
+ */
 .toast--failure {
   background-color: #C42411;
 }
 
-.toast--hidden {
-  opacity: 0;
-  transform: translateY(calc(var(--position-away-from-screen) + 4em));
-}
-
+/**
+ * ELEMENT message
+ *
+ * The actual text shown as part of the toast.
+ */
 .toast__message {
   margin-block: 0;
   text-align: start;

--- a/frontend/css/toast.css
+++ b/frontend/css/toast.css
@@ -25,6 +25,10 @@
   background-color: #178A4D;
 }
 
+.toast--failure {
+  background-color: #C42411;
+}
+
 .toast--hidden {
   opacity: 0;
   transform: translateY(calc(var(--position-away-from-screen) + 4em));

--- a/frontend/css/toast.css
+++ b/frontend/css/toast.css
@@ -2,22 +2,27 @@
  *
  */
 .toast {
-    --position-away-from-screen: 2rem;
+  --position-away-from-screen: 2rem;
 
-    position: fixed;
-    left: 2rem;
-    bottom: var(--position-away-from-screen);
-    margin: 0;
+  position: fixed;
+  left: 2rem;
+  right: 2rem;
+  bottom: var(--position-away-from-screen);
+  width: calc(100vw - 2 * var(--position-away-from-screen));
+  margin: 0;
 
-    border: #CCC solid 1px;
-    border-radius: 4px;
+  border: 0;
+  border-radius: 4px;
 
-    font-size: 1.5em;
+  box-shadow: 1px 1px 16px rgba(0, 0, 0, 0.8);
+  color: white;
+  background-color: black;
 
-    box-shadow: 1px 1px 16px rgba(0, 0, 0, 0.8);
-    background-color: rgba(255, 255, 255, 95%);
+  transition: all 200ms ease-in-out;
+}
 
-    transition: all 200ms ease-in-out;
+.toast--success {
+  background-color: #178A4D;
 }
 
 .toast--hidden {
@@ -27,8 +32,5 @@
 
 .toast__message {
   margin-block: 0;
-}
-
-.toast--success .toast__message {
-  color: #17B003;
+  text-align: start;
 }

--- a/frontend/css/toast.css
+++ b/frontend/css/toast.css
@@ -12,11 +12,12 @@
   position: fixed;
 
   left: var(--position-away-from-screen);
-  right: var(--position-away-from-screen);;
+  right: var(--position-away-from-screen);
   bottom: var(--position-away-from-screen);
   width: calc(100vw - 2 * var(--position-away-from-screen));
   max-height: var(--toast-height);
   margin: 0;
+  padding: 1rem;
 
   border: 0;
   border-radius: 4px;
@@ -25,7 +26,7 @@
   background-color: black;
   box-shadow: 1px 1px 16px rgba(0, 0, 0, 0.8);
 
-  transition-property: opacity transform;
+  transition-property: opacity, transform;
   transition-duration: 200ms;
   transition-timing-function: ease-in-out;
 }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -49,7 +49,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   setupSearchBar();
   settings.setupAutoSubmitForEntirePage();
-  toast.setGlobalElement(document.querySelector("#toast"));
+  toast.setGlobalElement(document.getElementById("toast"));
 
   let route = makeRouteRelativeToSlash(window.location.pathname);
   // Tiny router.

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -25,6 +25,7 @@ import {
 import { debounce } from "./js/debounce.js";
 import { setupParadigm } from "./js/paradigm.js";
 import * as settings from "./js/settings-page.js";
+import * as toast from "./js/toast.js";
 
 ///////////////////////////////// Constants //////////////////////////////////
 
@@ -48,6 +49,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   setupSearchBar();
   settings.setupAutoSubmitForEntirePage();
+  toast.setGlobalElement(document.querySelector("#toast"));
 
   let route = makeRouteRelativeToSlash(window.location.pathname);
   // Tiny router.

--- a/frontend/js/settings-page.js
+++ b/frontend/js/settings-page.js
@@ -34,7 +34,7 @@ function setupFormAutoSubmit(form) {
   form.addEventListener("change", async () => {
     try {
       await changePreference();
-    } catch (_anyError) {
+    } catch {
       toast.showFailure("😕  Could not save preference");
       return;
     }

--- a/frontend/js/settings-page.js
+++ b/frontend/js/settings-page.js
@@ -1,3 +1,5 @@
+import * as toast from "./toast.js";
+
 /**
  * Sets up all <form data-save-preference> elements on the page to be submitted upon
  * change. This means there is no need for a submit <button> in the form as
@@ -29,7 +31,16 @@ function setupFormAutoSubmit(form) {
   const endpoint = form.action;
   const submitButton = form.querySelector("button[type=submit]");
 
-  form.addEventListener("change", () => void changePreference());
+  form.addEventListener("change", async () => {
+    try {
+      await changePreference();
+    } catch (_anyError) {
+      toast.showFailure("😕  Could not save preference");
+      return;
+    }
+
+    toast.showSuccess("✅ Saved!");
+  });
 
   if (submitButton) {
     submitButton.remove();

--- a/frontend/js/toast.js
+++ b/frontend/js/toast.js
@@ -50,7 +50,7 @@ class Toast {
     this._timer = null;
 
     this._el.close();
-    this._classList.add("toast--hidden");
+    this._classList.add("toast--off-screen");
   }
 
   /**
@@ -103,11 +103,11 @@ class Toast {
 
     this._timer = setTimeout(() => void this._hide(), TOAST_DURATION);
     this._el.show();
-    this._classList.remove("toast--hidden");
+    this._classList.remove("toast--off-screen");
   }
 
   _hide() {
-    this._classList.add("toast--hidden");
+    this._classList.add("toast--off-screen");
     this._timer = null;
 
     const closeDialog = () => {

--- a/frontend/js/toast.js
+++ b/frontend/js/toast.js
@@ -51,6 +51,9 @@ class Toast {
 
     this._el.close();
     this._classList.add("toast--off-screen");
+    /* Makes screen readers speak the message, only after they're done
+     * speaking what they are currently reading: */
+    this._el.setAttribute("aria-live", "polite");
   }
 
   /**
@@ -81,14 +84,10 @@ class Toast {
 
   _setMessage(message) {
     this._textNode.textContent = message;
-    /* Makes screen readers speak the message, only after they're done
-     * speaking what they are currently reading: */
-    this._el.setAttribute("aria-live", "polite");
   }
 
   _clearMessage() {
     this._textNode.textContent = "";
-    this._el.setAttribute("aria-live", "off");
   }
 
   _setCSSModifier(modifier) {

--- a/frontend/js/toast.js
+++ b/frontend/js/toast.js
@@ -1,0 +1,120 @@
+/**
+ * How long the toast should stay on the screen by default.
+ */
+const TOAST_DURATION = 1000;
+
+/**
+ * Initialize the global toast element.
+ *
+ * @param {HTMLDialogElement} element
+ */
+export function setGlobalElement(el) {
+  return (_toast = new Toast(el));
+}
+
+/**
+ * Show a message that something succeeded.
+ */
+export function showSuccess(message) {
+  return globalToastOrThrow().showSuccess(message);
+}
+
+/**
+ * Show a message that something failed.
+ */
+export function showFailure(message) {
+  return globalToastOrThrow().showFailure(message);
+}
+
+/**
+ * Toast component.
+ *
+ * A toast is a small, minimally intrusive notifcation.
+ *
+ * See: https://cultureamp.design/components/toast-notification/
+ *
+ * (At what point do you consider using a frontend UI framework? :S)
+ */
+class Toast {
+  constructor(element) {
+    /* == null matches **both** null and undefined. */
+    if (element == null || !(element instanceof HTMLDialogElement)) {
+      throw new TypeError("must provide a valid <dialog> element");
+    }
+
+    this._el = element;
+    this._timer = null;
+
+    this._el.close();
+    this._classList.add("toast--hidden");
+  }
+
+  get _classList() {
+    return this._el.classList;
+  }
+
+  get _textNode() {
+    return this._el.querySelector(".toast__message");
+  }
+
+  showSuccess(message) {
+    this._setMessage(message);
+    this._setCSSModifier("toast--success");
+    this._show();
+  }
+
+  showFailure(message) {
+    this._setMessage(message);
+    this._setCSSModifier("toast--failure");
+    this._show();
+  }
+
+  _setMessage(message) {
+    this._textNode.textContent = message;
+    /* Makes screen readers speak the message, only after they're done
+     * speaking what they are currently reading: */
+    this._el.setAttribute("aria-live", "polite");
+  }
+
+  _clearMessage() {
+    this._textNode.textContent = "";
+    this._el.setAttribute("aria-live", "off");
+  }
+
+  _setCSSModifier(newClass) {
+    this._classList.remove("toast--success", "toast--failure");
+    this._classList.add(newClass);
+  }
+
+  _show() {
+    if (this._timer) {
+      clearTimeout(this._timer);
+    }
+
+    this._timer = setTimeout(() => void this._hide(), TOAST_DURATION);
+    this._el.show();
+    this._classList.remove("toast--hidden");
+  }
+
+  _hide() {
+    this._classList.add("toast--hidden");
+
+    const closeDialog = () => {
+      this._el.close();
+      this._clearMessage();
+    };
+
+    this._el.addEventListener("transitionend", closeDialog, { once: true });
+  }
+}
+
+let _toast = null;
+
+function globalToastOrThrow() {
+  if (_toast === null) {
+    throw new Error(
+      "The toast has not been configured! Did you call toast.setGlobalElement()?"
+    );
+  }
+  return _toast;
+}

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -50,6 +50,11 @@
       </svg>
     </button>
   </template>
+
+  {# The toast or little message that pops-up to notifiy you of small state changes. #}
+   <dialog id="toast" class="toast" aria-live="polite" data-cy="toast">
+    <p class="toast__message"></p>
+  </dialog>
 {% endspaceless %}
 
 {% comment %}

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -52,7 +52,7 @@
   </template>
 
   {# The toast or little message that pops-up to notifiy you of small state changes. #}
-   <dialog id="toast" class="toast" aria-live="polite" data-cy="toast">
+   <dialog id="toast" class="toast" data-cy="toast">
     <p class="toast__message"></p>
   </dialog>
 {% endspaceless %}

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
@@ -43,7 +43,7 @@
   </section>
 </section>
 
-<dialog class="toast toast--success" open>
+<dialog class="toast toast--success" open aria-live="polite">
   <p class="toast__message"> ✅ Saved! </p>
 </dialog>
 {% endblock %}

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
@@ -42,4 +42,8 @@
     </form>
   </section>
 </section>
+
+<dialog class="toast toast--success" open>
+  <p class="toast__message"> ✅ Saved! </p>
+</dialog>
 {% endblock %}

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
@@ -42,8 +42,4 @@
     </form>
   </section>
 </section>
-
-<dialog class="toast toast--success" open aria-live="polite">
-  <p class="toast__message"> ✅ Saved! </p>
-</dialog>
 {% endblock %}


### PR DESCRIPTION
# What's in this PR?

Adds a new widget component: a ["toast"](https://uxdesign.cc/toasts-or-snack-bars-design-organic-system-notifications-1236f2883023) that shows a small message and disappears automatically.

- **added**: saving a preference shows a toast reading "Saved!"
- **added**: toast JS and CSS. Unfortunately `<dialog>`'s JS API is [not well-supported](https://caniuse.com/dialog) so there are a few hacks to make it work universally.

https://user-images.githubusercontent.com/2294397/125134166-36a61d00-e0c4-11eb-8ff4-a907267ece8f.mov


Fixes #895.