### PR TITLE
Drop old API_* database tables

### DIFF
--- a/src/CreeDictionary/API/migrations/0006_drop_api_tables.py
+++ b/src/CreeDictionary/API/migrations/0006_drop_api_tables.py
@@ -1,0 +1,31 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("API", "0005_wordform_paradigm"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="englishkeyword",
+            name="lemma",
+        ),
+        migrations.RemoveField(
+            model_name="wordform",
+            name="lemma",
+        ),
+        migrations.DeleteModel(
+            name="Definition",
+        ),
+        migrations.DeleteModel(
+            name="DictionarySource",
+        ),
+        migrations.DeleteModel(
+            name="EnglishKeyword",
+        ),
+        migrations.DeleteModel(
+            name="Wordform",
+        ),
+    ]

--- a/src/CreeDictionary/CreeDictionary/migrations/0001_insert_bibliographic_data.py
+++ b/src/CreeDictionary/CreeDictionary/migrations/0001_insert_bibliographic_data.py
@@ -9,4 +9,4 @@ class Migration(migrations.Migration):
         ("API", "0001_initial"),
     ]
 
-    operations = []
+    operations: list[migrations.RunPython] = []

--- a/src/CreeDictionary/CreeDictionary/migrations/0001_insert_bibliographic_data.py
+++ b/src/CreeDictionary/CreeDictionary/migrations/0001_insert_bibliographic_data.py
@@ -1,50 +1,7 @@
 """
-Inserts bibliographic information for three Plains Cree dictionary sources:
-    - [CW] Cree : Words - edited by Arok Wolvengrey
-    - [MD] Maskwacîs Dictionary
-    - [AE] Alberta Elders' Cree Dictionary
+Stub for data migration that used to add data to a table that no longer exists.
 """
 from django.db import migrations
-
-BIBLIOGRAPHY = {
-    "MD": {
-        "title": "Maskwacîs Dictionary of Cree Words / Nehiyaw Pîkiskweninisa",
-        "editor": "Maskwaschees Cultural College",
-        "publisher": "Maskwachees Cultural College",
-        "year": 2009,
-        "city": "Maskwacîs, Alberta",
-    },
-    "CW": {
-        "title": "nêhiyawêwin : itwêwina / Cree : Words",
-        "editor": "Arok Wolvengrey",
-        "year": 2001,
-        "publisher": "Canadian Plains Research Center",
-        "city": "Regina, Saskatchewan",
-    },
-    "AE": {
-        "title": "Alberta Elders' Cree Dictionary/"
-        "alperta ohci kehtehayak nehiyaw otwestamâkewasinahikan",
-        "author": "Nancy LeClaire, George Cardinal",
-        "editor": "Earle H. Waugh",
-        "year": 2002,
-        "publisher": "The University of Alberta Press",
-        "city": "Edmonton, Alberta",
-    },
-}
-
-
-def insert_bibliographic_information(apps, schema_editor):
-    DictionarySource = apps.get_model("API", "DictionarySource")
-
-    for abbrv, fields in BIBLIOGRAPHY.items():
-        source, created = DictionarySource.objects.get_or_create(abbrv=abbrv)
-        if source.title or source.author or source.editor:
-            # Already has data -- Skip!
-            continue
-
-        for attr, data in fields.items():
-            setattr(source, attr, data)
-        source.save()
 
 
 class Migration(migrations.Migration):
@@ -52,6 +9,4 @@ class Migration(migrations.Migration):
         ("API", "0001_initial"),
     ]
 
-    operations = [
-        migrations.RunPython(insert_bibliographic_information),
-    ]
+    operations = []

--- a/src/CreeDictionary/CreeDictionary/migrations/0003_add_wordform_paradigms.py
+++ b/src/CreeDictionary/CreeDictionary/migrations/0003_add_wordform_paradigms.py
@@ -11,4 +11,4 @@ class Migration(migrations.Migration):
         ("CreeDictionary", "0002_change_example_site_to_cree_dictionary_site"),
     ]
 
-    operations = []
+    operations: list[migrations.RunPython] = []

--- a/src/CreeDictionary/CreeDictionary/migrations/0003_add_wordform_paradigms.py
+++ b/src/CreeDictionary/CreeDictionary/migrations/0003_add_wordform_paradigms.py
@@ -1,28 +1,14 @@
+"""
+Stub for data migration that used to add data to a table that no longer exists.
+"""
 from django.db import migrations
-
-from CreeDictionary.CreeDictionary.ensure_data import (
-    set_paradigm_for_demonstrative_and_personal_pronouns,
-)
-
-
-def add_explicit_paradigm_field(apps, schema_editor):
-    """
-    For the current (2021-05-07) paradigms, explicitly adds the paradigm filed.
-    """
-    Wordform = apps.get_model("API", "Wordform")
-    to_update = set_paradigm_for_demonstrative_and_personal_pronouns(
-        Wordform.objects.all()
-    )
-    Wordform.objects.bulk_update(to_update, ["paradigm"])
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        # Absolutely required by this migration:
         ("API", "0005_wordform_paradigm"),
-        # Run this migration **after** this one:
         ("CreeDictionary", "0002_change_example_site_to_cree_dictionary_site"),
     ]
 
-    operations = [migrations.RunPython(add_explicit_paradigm_field)]
+    operations = []


### PR DESCRIPTION
The equivalent data is now in new lexicon_* tables instead.