### PR TITLE
refactor: change preference

### DIFF
--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -102,7 +102,7 @@
       <h2 class="footer__option-header"> View search results in: </h2>
       <ul class="unbullet">
         <li>
-          <form method="POST" action={% url 'preferences:change' 'display_mode' %}>
+          <form method="POST" action={% url 'preference:change' 'display_mode' %}>
             <button class="unbutton link footer__link" type="submit" name="mode" value="community" data-cy="enable-community-mode">
               Community mode
             </button>
@@ -110,7 +110,7 @@
           </form>
         </li>
         <li>
-          <form method="POST" action={% url 'preferences:change' 'display_mode' %}>
+          <form method="POST" action={% url 'preference:change' 'display_mode' %}>
             <button class="unbutton link footer__link" type="submit" name="mode" value="linguistic" data-cy="enable-linguistic-mode">
               Linguist mode
             </button>

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/base.html
@@ -102,7 +102,7 @@
       <h2 class="footer__option-header"> View search results in: </h2>
       <ul class="unbullet">
         <li>
-          <form method="POST" action={% url 'cree-dictionary-change-display-mode' %}>
+          <form method="POST" action={% url 'preferences:change' 'display_mode' %}>
             <button class="unbutton link footer__link" type="submit" name="mode" value="community" data-cy="enable-community-mode">
               Community mode
             </button>
@@ -110,7 +110,7 @@
           </form>
         </li>
         <li>
-          <form method="POST" action={% url 'cree-dictionary-change-display-mode' %}>
+          <form method="POST" action={% url 'preferences:change' 'display_mode' %}>
             <button class="unbutton link footer__link" type="submit" name="mode" value="linguistic" data-cy="enable-linguistic-mode">
               Linguist mode
             </button>

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-label-switcher.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-label-switcher.html
@@ -25,7 +25,7 @@
         <ul class="unbullet">
           {% for value, label in preferences.paradigm_label.choices_with_labels %}
           <li class="menu-choice{% if value == preferences.paradigm_label.current_choice %} menu-choice--selected{% endif %}">
-            <form method="POST" action="{% url "cree-dictionary-change-paradigm-label" %}">
+            <form method="POST" action="{% url "preferences:change" "paradigm_label" %}">
               <button type="submit" class="unbutton fill-width"
                       name="paradigmlabel" value="{{ value }}">
                 <span class="menu-choice__label">{{ label|capfirst }}</span>

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-label-switcher.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/components/paradigm-label-switcher.html
@@ -25,7 +25,7 @@
         <ul class="unbullet">
           {% for value, label in preferences.paradigm_label.choices_with_labels %}
           <li class="menu-choice{% if value == preferences.paradigm_label.current_choice %} menu-choice--selected{% endif %}">
-            <form method="POST" action="{% url "preferences:change" "paradigm_label" %}">
+            <form method="POST" action="{% url "preference:change" "paradigm_label" %}">
               <button type="submit" class="unbutton fill-width"
                       name="paradigmlabel" value="{{ value }}">
                 <span class="menu-choice__label">{{ label|capfirst }}</span>

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
@@ -13,7 +13,7 @@
     <p class="setting__note"> These are the labels that appear on the <strong>paradigm
         table</strong> to label features like person, tense, plurals, etc.</p>
 
-    <form method="POST" action="{% url "cree-dictionary-change-paradigm-label" %}" data-save-preference="paradigmlabel">
+    <form method="POST" action="{% url "preferences:change" "paradigm_label" %}" data-save-preference="paradigmlabel">
       <ul class="unbullet">
       {% for value, label in preferences.paradigm_label.choices_with_labels %}
         <li class="option">

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
@@ -13,7 +13,7 @@
     <p class="setting__note"> These are the labels that appear on the <strong>paradigm
         table</strong> to label features like person, tense, plurals, etc.</p>
 
-    <form method="POST" action="{% url "preferences:change" "paradigm_label" %}" data-save-preference="paradigmlabel">
+    <form method="POST" action="{% url "preference:change" "paradigm_label" %}" data-save-preference="paradigmlabel">
       <ul class="unbullet">
       {% for value, label in preferences.paradigm_label.choices_with_labels %}
         <li class="option">

--- a/src/CreeDictionary/CreeDictionary/test_views.py
+++ b/src/CreeDictionary/CreeDictionary/test_views.py
@@ -164,7 +164,7 @@ def test_change_display_mode_sets_cookie(mode, whence, client: Client):
     Changing the display mode should set some cookies and MAYBE do a redirect.
     """
 
-    url = reverse("preferences:change", args=[DisplayMode.name])
+    url = reverse("preference:change", args=[DisplayMode.name])
     headers = {}
     if whence:
         # referer (sic) is the correct spelling in HTTP
@@ -192,7 +192,7 @@ def test_change_paradigm_label_preference(option, whence, client: Client):
     Changing the display mode should set some cookies and MAYBE do a redirect.
     """
 
-    url = reverse("preferences:change", args=[ParadigmLabel.name])
+    url = reverse("preference:change", args=[ParadigmLabel.name])
     headers = {}
     if whence:
         # referer (sic) is the correct spelling in HTTP

--- a/src/CreeDictionary/CreeDictionary/test_views.py
+++ b/src/CreeDictionary/CreeDictionary/test_views.py
@@ -164,7 +164,7 @@ def test_change_display_mode_sets_cookie(mode, whence, client: Client):
     Changing the display mode should set some cookies and MAYBE do a redirect.
     """
 
-    url = reverse("cree-dictionary-change-display-mode")
+    url = reverse("preferences:change", args=[DisplayMode.name])
     headers = {}
     if whence:
         # referer (sic) is the correct spelling in HTTP

--- a/src/CreeDictionary/CreeDictionary/test_views.py
+++ b/src/CreeDictionary/CreeDictionary/test_views.py
@@ -192,7 +192,7 @@ def test_change_paradigm_label_preference(option, whence, client: Client):
     Changing the display mode should set some cookies and MAYBE do a redirect.
     """
 
-    url = reverse("cree-dictionary-change-paradigm-label")
+    url = reverse("preferences:change", args=[ParadigmLabel.name])
     headers = {}
     if whence:
         # referer (sic) is the correct spelling in HTTP

--- a/src/CreeDictionary/CreeDictionary/urls.py
+++ b/src/CreeDictionary/CreeDictionary/urls.py
@@ -46,19 +46,8 @@ urlpatterns = [
         views.paradigm_internal,
         name="cree-dictionary-paradigm-detail",
     ),
-    # POST to this URL to change the display mode:
-    path(
-        "_change_display_mode",
-        views.ChangeDisplayMode.as_view(),
-        name="cree-dictionary-change-display-mode",
-    ),
-    # POST to this URL to change the display mode:
-    path(
-        "_change_paradigm_label",
-        views.ChangeParadigmLabelPreference.as_view(),
-        name="cree-dictionary-change-paradigm-label",
-    ),
-    # See morphodict.preference.urls for available views for interacting with prefs
+    # See morphodict.preference.urls for all available views
+    # Hint: You will probably use preferences:change the most!
     path(
         "_preference/", include("morphodict.preference.urls", namespace="preferences")
     ),

--- a/src/CreeDictionary/CreeDictionary/urls.py
+++ b/src/CreeDictionary/CreeDictionary/urls.py
@@ -58,6 +58,10 @@ urlpatterns = [
         views.ChangeParadigmLabelPreference.as_view(),
         name="cree-dictionary-change-paradigm-label",
     ),
+    # See morphodict.preference.urls for available views for interacting with prefs
+    path(
+        "_preference/", include("morphodict.preference.urls", namespace="preferences")
+    ),
     ################################ Click in text #################################
     # cree word translation for click-in-text
     path(

--- a/src/CreeDictionary/CreeDictionary/urls.py
+++ b/src/CreeDictionary/CreeDictionary/urls.py
@@ -47,10 +47,8 @@ urlpatterns = [
         name="cree-dictionary-paradigm-detail",
     ),
     # See morphodict.preference.urls for all available views
-    # Hint: You will probably use preferences:change the most!
-    path(
-        "_preference/", include("morphodict.preference.urls", namespace="preferences")
-    ),
+    # Hint: You will probably use preference:change the most!
+    path("_preference/", include("morphodict.preference.urls", namespace="preference")),
     ################################ Click in text #################################
     # cree word translation for click-in-text
     path(

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -19,9 +19,7 @@ from CreeDictionary.phrase_translate.translate import (
     eng_phrase_to_crk_features_fst,
     eng_verb_entry_to_inflected_phrase_fst,
 )
-from crkeng.app.preferences import DisplayMode, ParadigmLabel
 from morphodict.lexicon.models import Wordform
-from morphodict.preference.views import ChangePreferenceView
 from .paradigm.manager import ParadigmDoesNotExistError
 from .paradigm.panes import Paradigm
 from .utils import url_for_query
@@ -318,23 +316,6 @@ def google_site_verification(request):
         f"google-site-verification: google{code}.html",
         content_type="text/html; charset=UTF-8",
     )
-
-
-class ChangeDisplayMode(ChangePreferenceView):
-    """
-    Sets the mode= cookie, which affects how search results are rendered.
-    """
-
-    preference = DisplayMode  # type: ignore  # mypy can't deal with the decorator :/
-
-
-class ChangeParadigmLabelPreference(ChangePreferenceView):
-    """
-    Sets the paradigmlabel= cookie, which affects the type of labels ONLY IN THE
-    PARADIGMS!
-    """
-
-    preference = ParadigmLabel  # type: ignore  # mypy can't deal with the decorator :/
 
 
 ## Helper functions

--- a/src/crkeng/app/preferences.py
+++ b/src/crkeng/app/preferences.py
@@ -2,7 +2,7 @@
 Preferences used in itwêwina, the Cree Intelligent Dictionary.
 """
 
-from morphodict.preference import register_preference
+from morphodict.preference import register_preference, Preference
 
 
 @register_preference
@@ -23,7 +23,7 @@ class DisplayMode:
 
 
 @register_preference
-class ParadigmLabel:
+class ParadigmLabel(Preference):
     """
     What style labels should be used in the paradigm?
     """

--- a/src/crkeng/app/preferences.py
+++ b/src/crkeng/app/preferences.py
@@ -6,7 +6,7 @@ from morphodict.preference import register_preference, Preference
 
 
 @register_preference
-class DisplayMode:
+class DisplayMode(Preference):
     """
     As of 2021-04-14, "mode" is a coarse mechanism for affecting the display; there are
     plans for more fine-grained control over the display of, e.g., search results.

--- a/src/morphodict/preference/__init__.py
+++ b/src/morphodict/preference/__init__.py
@@ -56,7 +56,7 @@ def all_preferences():
     """
     Return all preferences registered in this site.
     """
-    return _registry().items()
+    return registry().items()
 
 
 def register_preference(declaration) -> Preference:
@@ -106,13 +106,13 @@ def register_preference(declaration) -> Preference:
         name=name, choices=choices, default=default, cookie_name=cookie_name
     )
 
-    _registry()[name] = pref
+    registry()[name] = pref
 
     return pref
 
 
 @cache
-def _registry() -> dict[str, Preference]:
+def registry() -> dict[str, Preference]:
     """
     Contains all registered preferences.
     """

--- a/src/morphodict/preference/test_views.py
+++ b/src/morphodict/preference/test_views.py
@@ -23,7 +23,7 @@ def test_post_preference(rf: RequestFactory, pet_preference: Preference):
 
 def test_bad_choice(rf: RequestFactory, pet_preference: Preference):
     """
-    Tests the happy path for setting a preference.
+    Test that setting an unknown choice should fail.
     """
     name = pet_preference.cookie_name
     choice = arbitrary_string()
@@ -39,6 +39,9 @@ def test_bad_choice(rf: RequestFactory, pet_preference: Preference):
 
 
 def test_preference_unknown(rf: RequestFactory):
+    """
+    Test that accessing an unknown preference 404s.
+    """
     unknown_name = arbitrary_string()
     choice = arbitrary_string()
 

--- a/src/morphodict/preference/test_views.py
+++ b/src/morphodict/preference/test_views.py
@@ -1,0 +1,68 @@
+import secrets
+
+import pytest
+from django.http import Http404
+from django.test import RequestFactory
+
+from morphodict.preference import register_preference, Preference, registry
+from morphodict.preference.views import change_preference
+
+
+def test_post_preference(rf: RequestFactory, pet_preference: Preference):
+    """
+    Tests the happy path for setting a preference.
+    """
+    name = pet_preference.cookie_name
+    choice = "dogs"
+
+    request = rf.post(f"/change-preference/{name}", data={name: choice})
+    response = change_preference(request, name)
+
+    assert response.cookies[name].value == choice
+
+
+def test_bad_choice(rf: RequestFactory, pet_preference: Preference):
+    """
+    Tests the happy path for setting a preference.
+    """
+    name = pet_preference.cookie_name
+    choice = arbitrary_string()
+
+    assert choice not in pet_preference.choices
+
+    request = rf.post(f"/change-preference/{name}", data={name: choice})
+    response = change_preference(request, name)
+
+    # It should be a bad request of some sort:
+    assert response.status_code in range(400, 500)
+    assert name not in response.cookies
+
+
+def test_preference_unknown(rf: RequestFactory):
+    unknown_name = arbitrary_string()
+    choice = arbitrary_string()
+
+    assert unknown_name not in registry()
+
+    request = rf.post(f"/change-preference/{unknown_name}", data={unknown_name: choice})
+
+    with pytest.raises(Http404):
+        change_preference(request, unknown_name)
+
+
+@pytest.fixture(scope="session")
+def pet_preference() -> Preference:
+    @register_preference
+    class Pet(Preference):
+        default = "cats"
+        cookie_name = "pet"
+        choices = {"cats": "Cats", "dogs": "Dogs"}
+
+    return registry()[Pet.name]
+
+
+def arbitrary_string() -> str:
+    """
+    :return: an arbitrary, URL-safe string.
+    """
+    return secrets.token_urlsafe()

--- a/src/morphodict/preference/urls.py
+++ b/src/morphodict/preference/urls.py
@@ -1,0 +1,20 @@
+"""
+URLs defined for interacting with morphodict preferences.
+
+Usage:
+In your site URLConf, include() these URLs:
+
+    # site/urls.py
+    urlpatterns = [
+        # ...
+        path("preferences", include("morphodict.preference.urls")),
+    ]
+"""
+from django.urls import path
+
+from . import views
+
+app_name = "morphodict-preference"
+urlpatterns = [
+    path("change/<name>", views.change_preference, name="change"),
+]

--- a/src/morphodict/preference/views.py
+++ b/src/morphodict/preference/views.py
@@ -39,14 +39,6 @@ class ChangePreferenceView(View):
 
     preference: Preference
 
-    @property
-    def cookie_name(self):
-        return self.preference.cookie_name
-
-    @property
-    def choices(self):
-        return self.preference.choices
-
     def post(self, request) -> HttpResponse:
         preference = self.preference
 

--- a/src/morphodict/preference/views.py
+++ b/src/morphodict/preference/views.py
@@ -48,11 +48,13 @@ class ChangePreferenceView(View):
         return self.preference.choices
 
     def post(self, request) -> HttpResponse:
+        preference = self.preference
+
         # TODO: let preferences share ONE cookie
-        value = request.POST.get(self.cookie_name)
+        value = request.POST.get(preference.cookie_name)
 
         # Tried to set to an unknown display mode
-        if value not in self.preference.choices:
+        if value not in preference.choices:
             return HttpResponse(status=HTTPStatus.BAD_REQUEST)
 
         if who_asked_us := request.headers.get("Referer"):
@@ -68,5 +70,5 @@ class ChangePreferenceView(View):
         # When left to default, the cookie should last "only as long as the client’s
         # browser session", though... I'm not sure how long that generally is :/
         # See: https://docs.djangoproject.com/en/3.2/ref/request-response/#django.http.HttpResponse.set_cookie
-        response.set_cookie(self.cookie_name, value)
+        response.set_cookie(preference.cookie_name, value)
         return response

--- a/src/morphodict/preference/views.py
+++ b/src/morphodict/preference/views.py
@@ -1,7 +1,6 @@
 from http import HTTPStatus
 
 from django.http import HttpResponse, HttpRequest, Http404
-from django.views import View
 from django.views.decorators.http import require_POST
 
 from morphodict.preference import Preference, registry
@@ -11,6 +10,8 @@ from morphodict.preference import Preference, registry
 def change_preference(request: HttpRequest, name: str):
     """
     A view that sets the cookie for the preference named in the URL path:
+
+    Uses the cookie name, and choices from the given preference.
 
         > POST /change-preference/mode HTTP/1.1
         > Referer: /search?q=miciw
@@ -28,44 +29,6 @@ def change_preference(request: HttpRequest, name: str):
         raise Http404(f"Preference does not exist: {name}")
 
     return _change_preference_cookie(request, preference)
-
-
-class ChangePreferenceView(View):
-    """
-    A generic view (class-based view) that sets the cookie for a preference.
-
-    Usage:
-
-        # views.py
-        class ChangeMyPreference(ChangePreferenceView):
-            preference = MyPreferenceSubclass
-
-        # urls.py
-        urlpatterns = [
-            ...,
-            path("change-my-preference, ChangeMyPreference.as_view()),
-        ]
-
-    Uses cookie name, and options from the given preference.
-
-        > POST /change-preference HTTP/1.1
-        > Referer: /search?q=miciw
-        > Cookie: preference=old-value
-        >
-        > preference=new-value
-
-        < HTTP/1.1 302 See Other
-        < Set-Cookie: mode=linguistic
-        < Location: /search?q=miciw
-
-    See also: https://docs.djangoproject.com/en/3.2/topics/class-based-views/
-    """
-
-    preference: Preference
-
-    def post(self, request) -> HttpResponse:
-        preference = self.preference
-        return _change_preference_cookie(request, preference)
 
 
 def _change_preference_cookie(request: HttpRequest, preference: Preference):

--- a/src/morphodict/preference/views.py
+++ b/src/morphodict/preference/views.py
@@ -8,7 +8,7 @@ from morphodict.preference import Preference, registry
 
 
 @require_POST
-def change_preference(request: HttpRequest, preference_name: str):
+def change_preference(request: HttpRequest, name: str):
     """
     A view that sets the cookie for the preference named in the URL path:
 
@@ -23,9 +23,9 @@ def change_preference(request: HttpRequest, preference_name: str):
         < Location: /search?q=miciw
     """
     try:
-        preference = registry()[preference_name]
+        preference = registry()[name]
     except KeyError:
-        raise Http404(f"Preference does not exist: {preference_name}")
+        raise Http404(f"Preference does not exist: {name}")
 
     return _change_preference_cookie(request, preference)
 

--- a/src/morphodict/preference/views.py
+++ b/src/morphodict/preference/views.py
@@ -3,17 +3,18 @@ from http import HTTPStatus
 from django.http import HttpResponse, HttpRequest, Http404
 from django.views.decorators.http import require_POST
 
-from morphodict.preference import Preference, registry
+from morphodict.preference import registry
 
 
 @require_POST
 def change_preference(request: HttpRequest, name: str):
     """
-    A view that sets the cookie for the preference named in the URL path:
+    A view that sets the cookie for the preference named in the URL path.
 
-    Uses the cookie name, and choices from the given preference.
+    NOTE: the path is expected to be the Preference.name, while the parameter is
+    expected to be the Preference.cookie_name. These may differ!
 
-        > POST /change-preference/mode HTTP/1.1
+        > POST /preference/change/display_mode HTTP/1.1
         > Referer: /search?q=miciw
         > Cookie: mode=old-value
         >
@@ -28,15 +29,6 @@ def change_preference(request: HttpRequest, name: str):
     except KeyError:
         raise Http404(f"Preference does not exist: {name}")
 
-    return _change_preference_cookie(request, preference)
-
-
-def _change_preference_cookie(request: HttpRequest, preference: Preference):
-    """
-    Shared implementation for changing a preference.
-    """
-
-    # TODO: let preferences share ONE cookie
     value = request.POST.get(preference.cookie_name)
 
     # Tried to set to an unknown choice


### PR DESCRIPTION
# What's in this PR?

Preferences are now changed using a simple view function `morphodict.preference.views.change_preference`. This simplifies the prior method, which was to subclass `morphodict.preference.views.ChangePreferenceView` and include a URL for each preference in the URLconf. Now there is only one view, plus, you only have to include one URL in the URLconf to support _all_ preferences.

 - **added**: `change_preference()` view
 - **removed**: `ChangePreferenceView` class-based view (obsoleted by the former)
 - **added**: URLConf for `morphodict.preference` — useful for namespacing views where they're used
 - **changed**: use `change_preference` for all existing preferences

Note: I did this work while working on #879; I intend to add a new `Preference` for animate emojis, and I figured now is a good time to make one view that handles all preferences.