### PR TITLE
fix: crash when best_lemma_matches() has zero analyses

### DIFF
--- a/src/CreeDictionary/API/search/lookup.py
+++ b/src/CreeDictionary/API/search/lookup.py
@@ -118,10 +118,14 @@ def best_lemma_matches(analysis, possible_lemmas) -> list[Wordform]:
     if len(possible_lemmas) < 2:
         return possible_lemmas
 
+    lemmas_with_analyses = [wf for wf in possible_lemmas if wf.analysis]
+
+    if len(lemmas_with_analyses) == 0:
+        # Cannot figure out the intersection if we have no analyses!
+        return possible_lemmas
+
     max_tag_intersection_count = max(
-        analysis.tag_intersection_count(lwf.analysis)
-        for lwf in possible_lemmas
-        if lwf.analysis
+        analysis.tag_intersection_count(lwf.analysis) for lwf in lemmas_with_analyses
     )
     return [
         lwf


### PR DESCRIPTION
Fixes #930

Note: I'm not sure if this is a true fix, as I wonder why the imported items do not have analyses. They absolutely should!