### PR TITLE
feat: choose your animate emoji

### DIFF
--- a/cypress/integration/settings.spec.js
+++ b/cypress/integration/settings.spec.js
@@ -67,6 +67,10 @@ context("The settings page", () => {
     const PREFERENCE_COOKIE = "animate_emoji";
     const NON_DEFAULT_EMOJI = "🐺";
 
+    const VTA_WORD = "mowêw";
+    const NA_WORD = "minôs";
+    const VAI_WORD = "nipâw";
+
     it("should be accessible from the settings page", () => {
       cy.getCookie(PREFERENCE_COOKIE).then((cookie) => {
         expect(cookie).to.be.null;
@@ -84,9 +88,6 @@ context("The settings page", () => {
     });
 
     it("should changes the emoji on the search page", () => {
-      const VTA_WORD = "mowêw";
-      const NA_WORD = "minôs";
-
       cy.visit(Cypress.env("settings_url"));
 
       cy.get("[data-cy=animate-emoji-choice]")
@@ -108,6 +109,19 @@ context("The settings page", () => {
         "[data-cy=word-class]",
         NON_DEFAULT_EMOJI
       );
+    });
+
+    it("should changes the emoji on the details page", () => {
+      cy.visit(Cypress.env("settings_url"));
+
+      cy.get("[data-cy=animate-emoji-choice]")
+        .contains("label", NON_DEFAULT_EMOJI)
+        .click();
+
+      waitForSaveConfirmation();
+
+      cy.visitLemma(VAI_WORD);
+      cy.contains("[data-cy=word-class]", `${NON_DEFAULT_EMOJI}➡️`);
     });
   });
 

--- a/cypress/integration/settings.spec.js
+++ b/cypress/integration/settings.spec.js
@@ -26,9 +26,7 @@ context("The settings page", () => {
           checkedValue = input.value;
         });
 
-      cy.get("[data-cy=toast]")
-        .should("be.visible")
-        .and("have.class", "toast--success");
+      waitForSaveConfirmation();
 
       cy.getCookie(PREFERENCE_COOKIE).then((cookie) => {
         expect(cookie.value).to.equal(checkedValue);
@@ -64,4 +62,58 @@ context("The settings page", () => {
       }
     });
   });
+
+  describe("Choosing an animate emoji", () => {
+    const PREFERENCE_COOKIE = "animate_emoji";
+    const NON_DEFAULT_EMOJI = "🐺";
+
+    it("should be accessible from the settings page", () => {
+      cy.getCookie(PREFERENCE_COOKIE).then((cookie) => {
+        expect(cookie).to.be.null;
+      });
+
+      cy.visit(Cypress.env("settings_url"));
+
+      cy.get("[data-cy=animate-emoji-choice]")
+        .contains("label", NON_DEFAULT_EMOJI)
+        .click();
+
+      cy.getCookie(PREFERENCE_COOKIE).then((cookie) => {
+        expect(cookie.value).to.be.exist;
+      });
+    });
+
+    it("should changes the emoji on the search page", () => {
+      const VTA_WORD = "mowêw";
+      const NA_WORD = "minôs";
+
+      cy.visit(Cypress.env("settings_url"));
+
+      cy.get("[data-cy=animate-emoji-choice]")
+        .contains("label", NON_DEFAULT_EMOJI)
+        .click();
+
+      waitForSaveConfirmation();
+
+      // Visit the search page directly
+      cy.visitSearch(VTA_WORD);
+      cy.get("[data-cy=search-result]:first").contains(
+        "[data-cy=word-class]",
+        `${NON_DEFAULT_EMOJI}➡️${NON_DEFAULT_EMOJI}`
+      );
+
+      // On the same page, search for something else entirely
+      cy.clearSearchBar().search(NA_WORD);
+      cy.get("[data-cy=search-result]:first").contains(
+        "[data-cy=word-class]",
+        NON_DEFAULT_EMOJI
+      );
+    });
+  });
+
+  function waitForSaveConfirmation() {
+    cy.get("[data-cy=toast]")
+      .should("be.visible")
+      .and("have.class", "toast--success");
+  }
 });

--- a/src/CreeDictionary/API/search/core.py
+++ b/src/CreeDictionary/API/search/core.py
@@ -2,7 +2,7 @@ from typing import Any, Iterable
 
 from django.db.models import prefetch_related_objects
 
-from crkeng.app.preferences import DisplayMode
+from crkeng.app.preferences import DisplayMode, AnimateEmoji
 from . import types, presentation
 from .query import Query
 from .util import first_non_none_value
@@ -57,7 +57,9 @@ class SearchRun:
         return results
 
     def presentation_results(
-        self, display_mode=DisplayMode.default
+        self,
+        display_mode=DisplayMode.default,
+        animate_emoji=AnimateEmoji.default,
     ) -> list[presentation.PresentationResult]:
         results = self.sorted_results()
         prefetch_related_objects(
@@ -67,13 +69,20 @@ class SearchRun:
         )
         return [
             presentation.PresentationResult(
-                r, search_run=self, display_mode=display_mode
+                r,
+                search_run=self,
+                display_mode=display_mode,
+                animate_emoji=animate_emoji,
             )
             for r in results
         ]
 
-    def serialized_presentation_results(self, display_mode=DisplayMode.default):
-        results = self.presentation_results(display_mode=display_mode)
+    def serialized_presentation_results(
+        self, display_mode=DisplayMode.default, animate_emoji=AnimateEmoji.default
+    ):
+        results = self.presentation_results(
+            display_mode=display_mode, animate_emoji=animate_emoji
+        )
         return [r.serialize() for r in results]
 
     def add_verbose_message(self, message=None, **messages):

--- a/src/CreeDictionary/API/search/presentation.py
+++ b/src/CreeDictionary/API/search/presentation.py
@@ -10,7 +10,7 @@ from CreeDictionary.CreeDictionary.relabelling import read_labels
 from CreeDictionary.utils import get_modified_distance
 from CreeDictionary.utils.fst_analysis_parser import partition_analysis
 from CreeDictionary.utils.types import ConcatAnalysis, FSTTag, Label
-from crkeng.app.preferences import DisplayMode
+from crkeng.app.preferences import DisplayMode, AnimateEmoji
 from morphodict.analysis import RichAnalysis
 from morphodict.lexicon.models import Wordform
 
@@ -95,6 +95,7 @@ class PresentationResult:
         *,
         search_run: core.SearchRun,
         display_mode="community",
+        animate_emoji=AnimateEmoji.default,
     ):
         self._result = result
         self._search_run = search_run
@@ -102,6 +103,7 @@ class PresentationResult:
             "community": read_labels().english,
             "linguistic": read_labels().linguistic_long,
         }.get(display_mode, DisplayMode.default)
+        self._animate_emoji = animate_emoji
 
         self.wordform = result.wordform
         self.lemma_wordform = result.lemma_wordform
@@ -114,7 +116,7 @@ class PresentationResult:
             self.linguistic_breakdown_tail,
         ) = result.wordform.analysis or [[], None, []]
 
-        self.lexical_info = get_lexical_info(result.wordform.analysis)
+        self.lexical_info = get_lexical_info(result.wordform.analysis, animate_emoji)
 
         self.preverbs = [
             lexical_entry["entry"]
@@ -136,7 +138,9 @@ class PresentationResult:
 
     def serialize(self) -> SerializedPresentationResult:
         ret: SerializedPresentationResult = {
-            "lemma_wordform": serialize_wordform(self.lemma_wordform),
+            "lemma_wordform": serialize_wordform(
+                self.lemma_wordform, self._animate_emoji
+            ),
             "wordform_text": self.wordform.text,
             "is_lemma": self.is_lemma,
             "definitions": serialize_definitions(
@@ -186,7 +190,7 @@ class PresentationResult:
         return f"PresentationResult<{self.wordform}:{self.wordform.id}>"
 
 
-def serialize_wordform(wordform) -> SerializedWordform:
+def serialize_wordform(wordform: Wordform, animate_emoji: str) -> SerializedWordform:
     """
     Intended to be passed in a JSON API or into templates.
 
@@ -211,7 +215,9 @@ def serialize_wordform(wordform) -> SerializedWordform:
                 }
             )
         if wordclass := wordform.linguist_info.get("wordclass"):
-            result["wordclass_emoji"] = get_emoji_for_cree_wordclass(wordclass)
+            result["wordclass_emoji"] = get_emoji_for_cree_wordclass(
+                wordclass, animate_emoji
+            )
 
     for key in wordform.linguist_info or []:
         if key not in result:
@@ -255,7 +261,9 @@ def replace_user_friendly_tags(fst_tags: List[FSTTag]) -> List[Label]:
     return read_labels().english.get_full_relabelling(fst_tags)
 
 
-def get_emoji_for_cree_wordclass(word_class: Optional[str]) -> Optional[str]:
+def get_emoji_for_cree_wordclass(
+    word_class: Optional[str], animate_emoji: str = AnimateEmoji.default
+) -> Optional[str]:
     """
     Attempts to get an emoji description of the full wordclass.
     e.g., "👤👵🏽" for "nôhkom"
@@ -272,10 +280,24 @@ def get_emoji_for_cree_wordclass(word_class: Optional[str]) -> Optional[str]:
             return [value.title()]
 
     tags = to_fst_output_style(word_class)
-    return read_labels().emoji.get_longest(tags)
+    original = read_labels().emoji.get_longest(tags)
+
+    return use_preferred_animate_emoji(original, animate_emoji)
 
 
-def get_lexical_info(result_analysis: RichAnalysis) -> List[Dict]:
+def use_preferred_animate_emoji(original: str, animate_emoji: str) -> str:
+    return original.replace(
+        emoji_for_value(AnimateEmoji.default), emoji_for_value(animate_emoji)
+    )
+
+
+def emoji_for_value(choice: str) -> str:
+    if emoji := AnimateEmoji.choices.get(choice):
+        return emoji
+    return AnimateEmoji.choices[AnimateEmoji.default]
+
+
+def get_lexical_info(result_analysis: RichAnalysis, animate_emoji: str) -> List[Dict]:
     if not result_analysis:
         return []
 
@@ -349,7 +371,7 @@ def get_lexical_info(result_analysis: RichAnalysis) -> List[Dict]:
             _type = "Reduplication"
 
         if preverb_result is not None:
-            entry = serialize_wordform(preverb_result)
+            entry = serialize_wordform(preverb_result, animate_emoji)
             _type = "Preverb"
 
         if entry and _type:

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
@@ -41,5 +41,30 @@
       </div>
     </form>
   </section>
+
+  <section>
+    <h3 id="animate-emoji" class="setting__title">Emoji for animate nouns (awa words)</h3>
+
+    <p class="setting__note">The emoji that will represent all</p>
+
+    <form method="POST" action=" {% url "cree-dictionary-change-preference" %}" data-save-preference="awaemoji">
+      <ul class="unbullet">
+        {% for value, label in preferences.animate_emoji.choices_with_labels %}
+        <li class="option">
+          <label class="option__label">
+            <input type="radio" name="awaemoji" value="{{ value }}" class="option__control"
+               {% if preferences.animate_emoji.current_choice == value %}checked{% endif %}>
+            <span class="option__label-text">{{ label|capfirst }}</span>
+          </label>
+        </li>
+        {% endfor %}
+      </ul>
+
+      <div class="action-bar">
+        {% csrf_token %}
+        <button type="submit"> Save settings </button>
+      </div>
+    </form>
+  </section>
 </section>
 {% endblock %}

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
@@ -45,14 +45,16 @@
   <section>
     <h3 id="animate-emoji" class="setting__title">Emoji for animate nouns (awa words)</h3>
 
-    <p class="setting__note">The emoji that will represent all</p>
+    <p class="setting__note">The emoji that will represent all animate words wors</p>
 
-    <form method="POST" action=" {% url "cree-dictionary-change-preference" %}" data-save-preference="awaemoji">
+    <form method="POST" action="{% url "preference:change" "animate_emoji" %}"
+          data-save-preference="animate_emoji">
       <ul class="unbullet">
         {% for value, label in preferences.animate_emoji.choices_with_labels %}
         <li class="option">
           <label class="option__label">
-            <input type="radio" name="awaemoji" value="{{ value }}" class="option__control"
+            <input type="radio" class="option__control"
+                   name="animate_emoji" value="{{ value }}"
                {% if preferences.animate_emoji.current_choice == value %}checked{% endif %}>
             <span class="option__label-text">{{ label|capfirst }}</span>
           </label>

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
@@ -43,9 +43,9 @@
   </section>
 
   <section>
-    <h3 id="animate-emoji" class="setting__title">Emoji for animate nouns (awa words)</h3>
+    <h3 id="animate-emoji" class="setting__title">Emoji for animate nouns ({% orth 'awa' %} words)</h3>
 
-    <p class="setting__note">The emoji that will represent all animate words wors</p>
+    <p class="setting__note">Choose the emoji that will represent all {% orth 'awa' %} words. </p>
 
     <form method="POST" action="{% url "preference:change" "animate_emoji" %}"
           data-save-preference="animate_emoji" data-cy="animate-emoji-choice">

--- a/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
+++ b/src/CreeDictionary/CreeDictionary/templates/CreeDictionary/settings.html
@@ -48,7 +48,7 @@
     <p class="setting__note">The emoji that will represent all animate words wors</p>
 
     <form method="POST" action="{% url "preference:change" "animate_emoji" %}"
-          data-save-preference="animate_emoji">
+          data-save-preference="animate_emoji" data-cy="animate-emoji-choice">
       <ul class="unbullet">
         {% for value, label in preferences.animate_emoji.choices_with_labels %}
         <li class="option">

--- a/src/CreeDictionary/CreeDictionary/views.py
+++ b/src/CreeDictionary/CreeDictionary/views.py
@@ -19,7 +19,7 @@ from CreeDictionary.phrase_translate.translate import (
     eng_phrase_to_crk_features_fst,
     eng_verb_entry_to_inflected_phrase_fst,
 )
-from crkeng.app.preferences import DisplayMode
+from crkeng.app.preferences import DisplayMode, AnimateEmoji
 from morphodict.lexicon.models import Wordform
 
 from .paradigm.manager import ParadigmDoesNotExistError
@@ -75,6 +75,7 @@ def entry_details(request, slug: str):
             paradigm=paradigm, paradigm_size=size, paradigm_sizes=sizes
         )
 
+    animate_emoji = AnimateEmoji.current_value_from_request(request)  # type: ignore
     context = create_context_for_index_template(
         "word-detail",
         # TODO: rename this to wordform ID
@@ -82,7 +83,7 @@ def entry_details(request, slug: str):
         # TODO: remove this parameter in favour of...
         lemma=lemma,
         # ...this parameter
-        wordform=presentation.serialize_wordform(lemma),
+        wordform=presentation.serialize_wordform(lemma, animate_emoji=animate_emoji),
         **paradigm_context,
     )
     return render(request, "CreeDictionary/index.html", context)
@@ -106,7 +107,8 @@ def index(request):  # pragma: no cover
             include_auto_definitions=should_include_auto_definitions(request),
         )
         search_results = search_run.serialized_presentation_results(
-            display_mode=DisplayMode.current_value_from_request(request)
+            display_mode=DisplayMode.current_value_from_request(request),
+            animate_emoji=AnimateEmoji.current_value_from_request(request),
         )
         did_search = True
     else:
@@ -141,7 +143,8 @@ def search_results(request, query_string: str):  # pragma: no cover
         query_string, include_auto_definitions=should_include_auto_definitions(request)
     ).serialized_presentation_results(
         # mypy cannot infer this property, but it exists!
-        display_mode=DisplayMode.current_value_from_request(request)  # type: ignore
+        display_mode=DisplayMode.current_value_from_request(request),  # type: ignore
+        animate_emoji=AnimateEmoji.current_value_from_request(request),  # type: ignore
     )
     return render(
         request,

--- a/src/crkeng/app/preferences.py
+++ b/src/crkeng/app/preferences.py
@@ -38,3 +38,31 @@ class ParadigmLabel(Preference):
         "nehiyawewin": "nêhiyawêwin labels",
     }
     default = "english"
+
+
+@register_preference
+class AnimateEmoji:
+    """
+    Which emoji to use to substitute all animate emoji (awa words).
+    """
+
+    cookie_name = "awaemoji"
+
+    default = "iyiniw"  # backwards-compatible
+    choices = {
+        "iyiniw": "🧑🏽",  # iyiniw (NA)/tastawiyiniw (NA)
+        "granny": "👵🏽",  # kôhkom/*kokum (NDA)
+        "grandpa": "👴🏽",  # môsom/*moshum (NDA)
+        # Required by requester of this feature:
+        "wolf": "🐺",  # mahihkan (NA)
+        # Required for community partner
+        "bear": "🐻",  # maskwa (NA)
+        # Counter-intuitive awa word:
+        "bread": "🍞",  # pahkwêsikan (NA)
+        # Significant awa word:
+        "star": "🌟",  # atâhk/acâhkos (NA)
+        # I don't want to add too many options to start with, but more can always be
+        # added in the future like:
+        # - 🦬 paskwâwi-mostsos
+        # - 🦫 amisk
+    }

--- a/src/crkeng/app/preferences.py
+++ b/src/crkeng/app/preferences.py
@@ -41,14 +41,16 @@ class ParadigmLabel(Preference):
 
 
 @register_preference
-class AnimateEmoji:
+class AnimateEmoji(Preference):
     """
     Which emoji to use to substitute all animate emoji (awa words).
     """
 
-    cookie_name = "awaemoji"
+    # Ensure the internal name and the cookie name (external name) are the same!
+    name = "animate_emoji"
+    cookie_name = name
 
-    default = "iyiniw"  # backwards-compatible
+    default = "iyiniw"  # the original itwêwina animate emoji
     choices = {
         "iyiniw": "🧑🏽",  # iyiniw (NA)/tastawiyiniw (NA)
         "granny": "👵🏽",  # kôhkom/*kokum (NDA)


### PR DESCRIPTION
# What's in this PR?

Lets you chose your preferred animate emoji from the settings page!

**Note**: I wanted to do a lot more with this PR, but I don't think I'll have time to implement everything. Possible improvements:

 - this PR introduces the [Data Clumps code smell](https://en.wikipedia.org/wiki/Data_clump) because the display mode and animate emoji are buddies travelling on their journey from request to serialized wordform. Suggested refactoring: do an [_Extract Class_ Refactoring](https://refactoring.com/catalog/extractClass.html) that wraps display preferences, something like `DisplayPreference` that can be created from a Django `HttpRequest`, e.g., `display = DisplayPreferences.from_request(request)` and is passed down. It can reformat emoji for you, i.e., `display.emoji_for("🧑🏽") == "🐺")` and give you reformat FST strings for you `display.relabel_fst_analysis(analysis)`.
 - I wanted to display emoji in a big grid with each emoji having its cooresponding nêhiyawêwin word below to describe it

Resolves #879 
Resolves #563