### PR TITLE
Use default orthography if cookie is invalid

### DIFF
--- a/src/CreeDictionary/morphodict/orthography.py
+++ b/src/CreeDictionary/morphodict/orthography.py
@@ -1,12 +1,14 @@
 """
 Handling of the writing system of the language.
 """
-
+import logging
 from importlib import import_module
 from typing import Callable, Set
 
 from django.conf import settings
 from django.http import HttpRequest
+
+logger = logging.getLogger(__name__)
 
 
 class Orthography:
@@ -45,7 +47,24 @@ class Orthography:
         Return the requested orthography code from the HTTP request. If the request
         does not specify an orthography, the default code is returned.
         """
-        return request.COOKIES.get(self.COOKIE_NAME, self.default)
+
+        orthography = request.COOKIES.get(self.COOKIE_NAME, self.default)
+
+        # If the orthography cookie has an invalid value—often encountered when
+        # doing development work that changes what orthographies are
+        # available—then use the default orthography instead.
+        if orthography not in self.available:
+            logger.warning(
+                f"Requested orthography {orthography!r} not found, using default instead"
+            )
+            orthography = ORTHOGRAPHY.default
+            # This doesn’t actually set the cookie, as that would have to happen
+            # on the Response object, which likely hasn’t been created yet, or
+            # in some middleware; but it at least prevents the same warning from
+            # being logged repeatedly for the same request.
+            request.COOKIES[self.COOKIE_NAME] = orthography
+
+        return orthography
 
 
 ORTHOGRAPHY = Orthography()

--- a/src/CreeDictionary/morphodict/templatetags/morphodict_orth.py
+++ b/src/CreeDictionary/morphodict/templatetags/morphodict_orth.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: UTF-8 -*-
-
 from django import template
 from django.conf import settings
 from django.utils.html import format_html


### PR DESCRIPTION
Instead of returning a server error page.