### PR TITLE
VT full layout relabeling

### DIFF
--- a/src/srseng/resources/altlabel.tsv
+++ b/src/srseng/resources/altlabel.tsv
@@ -4,15 +4,15 @@ I	Intransitive	Intransitive	Someone does something	?
 Im	Impersonal	Impersonal	Something happens	?
 T	Transitive	Transitive	Someone acts on someone	?
 D	Ditransitive	Ditransitive	Someone gives someone something	?
-E	Experiential Object	Experiential object	?	?
+E	Experiential Object	Experiential object	Someone experiences something	?
 O	Oblique Object	Oblique object	?	?
-Ipfv	Imperfective	Aspect: imperfective	Unfinished / Non-past	?
-Pfv	Perfective	Aspect: perfective 	Finished / Past	?
-Prog	Progressive	Progressive	On-going	?
-Pot	Potential	Aspect: potential	Possibly	?
-Rep	Repetitive	Superaspect: repetitive	Again and again	?
-Ipfv+Rep	Imperfective Repetitive	Aspect: imperfective repetitive	Non-past + Again and again	?
-Pfv+Rep	Perfective Repetitive	Aspect: perfective repetitive	Past + Again and again	?
+Ipfv	Imperfective	Aspect: imperfective	Unfinished / Non-past	Dú k'àgunììt'a (ák'óo ágùná)
+Pfv	Perfective	Aspect: perfective 	Finished / Past	K'àgunììt'a (dzánádà ágùjàg)
+Prog	Progressive	Progressive	On-going	Ágùdánáł
+Pot	Potential	Aspect: potential	Possibly	Ágùyiná-hí-gulà
+Rep	Repetitive	Superaspect: repetitive	Again and again	Ánágùt'ìsh
+Ipfv+Rep	Imperfective Repetitive	Aspect: imperfective repetitive	Non-past + Again and again	Dú k'àgunììt'a (ánágùt'ìsh)
+Pfv+Rep	Perfective Repetitive	Aspect: perfective repetitive	Past + Again and again	K'àgunììt'a (ánágùyít'ìsh)
 1Sg	1st person singular	Subject: 1st person singular	I	síní
 2Sg	2nd person singular	Subject: 2nd person singular	you (one)	níní
 3Sg	3rd person singular	Subject: 3rd person singular	he/she/it	idíní
@@ -21,10 +21,10 @@ Pfv+Rep	Perfective Repetitive	Aspect: perfective repetitive	Past + Again and aga
 2Pl	2nd person plural	Subject: 2nd person plural	you (all)	nahíní
 3Pl	3rd person plural	Subject: 3rd person plural	they	igidíní
 4Pl	4th person plural	Subject: 4th person plural	some people	?
-1Pl+Distr	Distributive 1st person plural	Subject: distributive 1st person plural	each and every one of us	niihíní
-2Pl+Distr	Distributive 2nd person plural	Subject: distributive 2nd person plural	each and every one of you (all)	nahíní
-3Pl+Distr	Distributive 3rd person plural	Subject: distributive 3rd person plural	each and every one of them	igidíní
-4Sg+Distr	Distributive 4th person singular	Subject: distributive 4th person plural	each and every one of some people	?
+1Pl+Distr	Distributive 1st person plural	Subject: distributive 1st person plural	each and every one of us	niihíní (tłaát'áa)
+2Pl+Distr	Distributive 2nd person plural	Subject: distributive 2nd person plural	each and every one of you (all)	nahíní (tłaát'áa)
+3Pl+Distr	Distributive 3rd person plural	Subject: distributive 3rd person plural	each and every one of them	igidíní (tłaát'áa)
+4Sg+Distr	Distributive 4th person singular	Subject: distributive 4th person plural	each and every one of some people	gúní (tłaát'áa)
 SbjSg1	S: 1st person singular	Subject: 1st person singular	I	síní
 SbjSg2	S: 2nd person singular	Subject: 2nd person singular	you (one)	níní
 SbjSg3	S: 3rd person singular	Subject: 3rd person singular	he/she/it	idíní
@@ -78,3 +78,91 @@ NomzPl	Nominalized plural	Nominalized plural	?	?
 EN/gu	Enclitic: gu	Enclitic: gu	?	?
 EN/la	Enclitic: la	Enclitic: la	?	?
 EN/gula	Enclitic: gula	Enclitic: gula	?	?
+1Pl+1PlO	1st person plural → DO: 1st person plural	Subject: 1st person plural → Direct Object: 1st person plural	we → us	niihíní → niihíní
+1Pl+1SgO	1st person plural → DO: 1st person singular	Subject: 1st person plural → Direct Object: 1st person singular	we → me	niihíní → síní
+1Pl+2PlO	1st person plural → DO: 2nd person plural	Subject: 1st person plural → Direct Object: 2nd person plural	we → you (all)	niihíní → nahíní
+1Pl+2SgO	1st person plural → DO: 2nd person singular	Subject: 1st person plural → Direct Object: 2nd person singular	we → you (one)	niihíní → níní
+1Pl+3PlO	1st person plural → DO: 3rd person plural	Subject: 1st person plural → Direct Object: 3rd person plural	we → them	niihíní → igidíní
+1Pl+3SgO	1st person plural → DO: 3rd person singular	Subject: 1st person plural → Direct Object: 3rd person singular	we → him/her/it	niihíní → idíní
+1Pl+4PlO	1st person plural → DO: 4th person plural	Subject: 1st person plural → Direct Object: 4th person plural	we → some people	niihíní → ?
+1Pl+4SgO	1st person plural → DO: 4th person singular	Subject: 1st person plural → Direct Object: 4th person singular	we → someone	niihíní → gúní
+1Pl+Distr+1PlO	Distributive 1st person plural → DO: 1st person plural	Subject: distributive 1st person plural → Direct Object: 1st person plural	each and every one of us → us	niihíní (tłaát'áa) → niihíní
+1Pl+Distr+1SgO	Distributive 1st person plural → DO: 1st person singular	Subject: distributive 1st person plural → Direct Object: 1st person singular	each and every one of us → me	niihíní (tłaát'áa) → síní
+1Pl+Distr+2PlO	Distributive 1st person plural → DO: 2nd person plural	Subject: distributive 1st person plural → Direct Object: 2nd person plural	each and every one of us → you (all)	niihíní (tłaát'áa) → nahíní
+1Pl+Distr+2SgO	Distributive 1st person plural → DO: 2nd person singular	Subject: distributive 1st person plural → Direct Object: 2nd person singular	each and every one of us → you (one)	niihíní (tłaát'áa) → níní
+1Pl+Distr+3PlO	Distributive 1st person plural → DO: 3rd person plural	Subject: distributive 1st person plural → Direct Object: 3rd person plural	each and every one of us → them	niihíní (tłaát'áa) → igidíní
+1Pl+Distr+3SgO	Distributive 1st person plural → DO: 3rd person singular	Subject: distributive 1st person plural → Direct Object: 3rd person singular	each and every one of us → him/her/it	niihíní (tłaát'áa) → idíní
+1Pl+Distr+4PlO	Distributive 1st person plural → DO: 4th person plural	Subject: distributive 1st person plural → Direct Object: 4th person plural	each and every one of us → some people	niihíní (tłaát'áa) → ?
+1Pl+Distr+4SgO	Distributive 1st person plural → DO: 4th person singular	Subject: distributive 1st person plural → Direct Object: 4th person singular	each and every one of us → someone	niihíní (tłaát'áa) → gúní
+1Sg+1PlO	1st person singular → DO: 1st person plural	Subject: 1st person singular → Direct Object: 1st person plural	I → us	síní → niihíní
+1Sg+1SgO	1st person singular → DO: 1st person singular	Subject: 1st person singular → Direct Object: 1st person singular	I → me	síní → síní
+1Sg+2PlO	1st person singular → DO: 2nd person plural	Subject: 1st person singular → Direct Object: 2nd person plural	I → you (all)	síní → nahíní
+1Sg+2SgO	1st person singular → DO: 2nd person singular	Subject: 1st person singular → Direct Object: 2nd person singular	I → you (one)	síní → níní
+1Sg+3PlO	1st person singular → DO: 3rd person plural	Subject: 1st person singular → Direct Object: 3rd person plural	I → them	síní → igidíní
+1Sg+3SgO	1st person singular → DO: 3rd person singular	Subject: 1st person singular → Direct Object: 3rd person singular	I → him/her/it	síní → idíní
+1Sg+4PlO	1st person singular → DO: 4th person plural	Subject: 1st person singular → Direct Object: 4th person plural	I → some people	síní → ?
+1Sg+4SgO	1st person singular → DO: 4th person singular	Subject: 1st person singular → Direct Object: 4th person singular	I → someone	síní → gúní
+2Pl+1PlO	2nd person plural → DO: 1st person plural	Subject: 2nd person plural → Direct Object: 1st person plural	you (all) → us	nahíní → niihíní
+2Pl+1SgO	2nd person plural → DO: 1st person singular	Subject: 2nd person plural → Direct Object: 1st person singular	you (all) → me	nahíní → síní
+2Pl+2PlO	2nd person plural → DO: 2nd person plural	Subject: 2nd person plural → Direct Object: 2nd person plural	you (all) → you (all)	nahíní → nahíní
+2Pl+2SgO	2nd person plural → DO: 2nd person singular	Subject: 2nd person plural → Direct Object: 2nd person singular	you (all) → you (one)	nahíní → níní
+2Pl+3PlO	2nd person plural → DO: 3rd person plural	Subject: 2nd person plural → Direct Object: 3rd person plural	you (all) → them	nahíní → igidíní
+2Pl+3SgO	2nd person plural → DO: 3rd person singular	Subject: 2nd person plural → Direct Object: 3rd person singular	you (all) → him/her/it	nahíní → idíní
+2Pl+4PlO	2nd person plural → DO: 4th person plural	Subject: 2nd person plural → Direct Object: 4th person plural	you (all) → some people	nahíní → ?
+2Pl+4SgO	2nd person plural → DO: 4th person singular	Subject: 2nd person plural → Direct Object: 4th person singular	you (all) → someone	nahíní → gúní
+2Pl+Distr+1PlO	Distributive 2nd person plural → DO: 1st person plural	Subject: distributive 2nd person plural → Direct Object: 1st person plural	each and every one of you (all) → us	nahíní (tłaát'áa) → niihíní
+2Pl+Distr+1SgO	Distributive 2nd person plural → DO: 1st person singular	Subject: distributive 2nd person plural → Direct Object: 1st person singular	each and every one of you (all) → me	nahíní (tłaát'áa) → síní
+2Pl+Distr+2PlO	Distributive 2nd person plural → DO: 2nd person plural	Subject: distributive 2nd person plural → Direct Object: 2nd person plural	each and every one of you (all) → you (all)	nahíní (tłaát'áa) → nahíní
+2Pl+Distr+2SgO	Distributive 2nd person plural → DO: 2nd person singular	Subject: distributive 2nd person plural → Direct Object: 2nd person singular	each and every one of you (all) → you (one)	nahíní (tłaát'áa) → níní
+2Pl+Distr+3PlO	Distributive 2nd person plural → DO: 3rd person plural	Subject: distributive 2nd person plural → Direct Object: 3rd person plural	each and every one of you (all) → them	nahíní (tłaát'áa) → igidíní
+2Pl+Distr+3SgO	Distributive 2nd person plural → DO: 3rd person singular	Subject: distributive 2nd person plural → Direct Object: 3rd person singular	each and every one of you (all) → him/her/it	nahíní (tłaát'áa) → idíní
+2Pl+Distr+4PlO	Distributive 2nd person plural → DO: 4th person plural	Subject: distributive 2nd person plural → Direct Object: 4th person plural	each and every one of you (all) → some people	nahíní (tłaát'áa) → ?
+2Pl+Distr+4SgO	Distributive 2nd person plural → DO: 4th person singular	Subject: distributive 2nd person plural → Direct Object: 4th person singular	each and every one of you (all) → someone	nahíní (tłaát'áa) → gúní
+2Sg+1PlO	2nd person singular → DO: 1st person plural	Subject: 2nd person singular → Direct Object: 1st person plural	you (one) → us	níní → niihíní
+2Sg+1SgO	2nd person singular → DO: 1st person singular	Subject: 2nd person singular → Direct Object: 1st person singular	you (one) → me	níní → síní
+2Sg+2PlO	2nd person singular → DO: 2nd person plural	Subject: 2nd person singular → Direct Object: 2nd person plural	you (one) → you (all)	níní → nahíní
+2Sg+2SgO	2nd person singular → DO: 2nd person singular	Subject: 2nd person singular → Direct Object: 2nd person singular	you (one) → you (one)	níní → níní
+2Sg+3PlO	2nd person singular → DO: 3rd person plural	Subject: 2nd person singular → Direct Object: 3rd person plural	you (one) → them	níní → igidíní
+2Sg+3SgO	2nd person singular → DO: 3rd person singular	Subject: 2nd person singular → Direct Object: 3rd person singular	you (one) → him/her/it	níní → idíní
+2Sg+4PlO	2nd person singular → DO: 4th person plural	Subject: 2nd person singular → Direct Object: 4th person plural	you (one) → some people	níní → ?
+2Sg+4SgO	2nd person singular → DO: 4th person singular	Subject: 2nd person singular → Direct Object: 4th person singular	you (one) → someone	níní → gúní
+3Pl+1PlO	3rd person plural → DO: 1st person plural	Subject: 3rd person plural → Direct Object: 1st person plural	they → us	igidíní → niihíní
+3Pl+1SgO	3rd person plural → DO: 1st person singular	Subject: 3rd person plural → Direct Object: 1st person singular	they → me	igidíní → síní
+3Pl+2PlO	3rd person plural → DO: 2nd person plural	Subject: 3rd person plural → Direct Object: 2nd person plural	they → you (all)	igidíní → nahíní
+3Pl+2SgO	3rd person plural → DO: 2nd person singular	Subject: 3rd person plural → Direct Object: 2nd person singular	they → you (one)	igidíní → níní
+3Pl+3PlO	3rd person plural → DO: 3rd person plural	Subject: 3rd person plural → Direct Object: 3rd person plural	they → them	igidíní → igidíní
+3Pl+3SgO	3rd person plural → DO: 3rd person singular	Subject: 3rd person plural → Direct Object: 3rd person singular	they → him/her/it	igidíní → idíní
+3Pl+4PlO	3rd person plural → DO: 4th person plural	Subject: 3rd person plural → Direct Object: 4th person plural	they → some people	igidíní → ?
+3Pl+4SgO	3rd person plural → DO: 4th person singular	Subject: 3rd person plural → Direct Object: 4th person singular	they → someone	igidíní → gúní
+3Pl+Distr+1PlO	Distributive 3rd person plural → DO: 1st person plural	Subject: distributive 3rd person plural → Direct Object: 1st person plural	each and every one of them → us	igidíní (tłaát'áa) → niihíní
+3Pl+Distr+1SgO	Distributive 3rd person plural → DO: 1st person singular	Subject: distributive 3rd person plural → Direct Object: 1st person singular	each and every one of them → me	igidíní (tłaát'áa) → síní
+3Pl+Distr+2PlO	Distributive 3rd person plural → DO: 2nd person plural	Subject: distributive 3rd person plural → Direct Object: 2nd person plural	each and every one of them → you (all)	igidíní (tłaát'áa) → nahíní
+3Pl+Distr+2SgO	Distributive 3rd person plural → DO: 2nd person singular	Subject: distributive 3rd person plural → Direct Object: 2nd person singular	each and every one of them → you (one)	igidíní (tłaát'áa) → níní
+3Pl+Distr+3PlO	Distributive 3rd person plural → DO: 3rd person plural	Subject: distributive 3rd person plural → Direct Object: 3rd person plural	each and every one of them → them	igidíní (tłaát'áa) → igidíní
+3Pl+Distr+3SgO	Distributive 3rd person plural → DO: 3rd person singular	Subject: distributive 3rd person plural → Direct Object: 3rd person singular	each and every one of them → him/her/it	igidíní (tłaát'áa) → idíní
+3Pl+Distr+4PlO	Distributive 3rd person plural → DO: 4th person plural	Subject: distributive 3rd person plural → Direct Object: 4th person plural	each and every one of them → some people	igidíní (tłaát'áa) → ?
+3Pl+Distr+4SgO	Distributive 3rd person plural → DO: 4th person singular	Subject: distributive 3rd person plural → Direct Object: 4th person singular	each and every one of them → someone	igidíní (tłaát'áa) → gúní
+3Sg+1PlO	3rd person singular → DO: 1st person plural	Subject: 3rd person singular → Direct Object: 1st person plural	he/she/it → us	idíní → niihíní
+3Sg+1SgO	3rd person singular → DO: 1st person singular	Subject: 3rd person singular → Direct Object: 1st person singular	he/she/it → me	idíní → síní
+3Sg+2PlO	3rd person singular → DO: 2nd person plural	Subject: 3rd person singular → Direct Object: 2nd person plural	he/she/it → you (all)	idíní → nahíní
+3Sg+2SgO	3rd person singular → DO: 2nd person singular	Subject: 3rd person singular → Direct Object: 2nd person singular	he/she/it → you (one)	idíní → níní
+3Sg+3PlO	3rd person singular → DO: 3rd person plural	Subject: 3rd person singular → Direct Object: 3rd person plural	he/she/it → them	idíní → igidíní
+3Sg+3SgO	3rd person singular → DO: 3rd person singular	Subject: 3rd person singular → Direct Object: 3rd person singular	he/she/it → him/her/it	idíní → idíní
+3Sg+4PlO	3rd person singular → DO: 4th person plural	Subject: 3rd person singular → Direct Object: 4th person plural	he/she/it → some people	idíní → ?
+3Sg+4SgO	3rd person singular → DO: 4th person singular	Subject: 3rd person singular → Direct Object: 4th person singular	he/she/it → someone	idíní → gúní
+4Sg+1PlO	4th person singular → DO: 1st person plural	Subject: 4th person singular → Direct Object: 1st person plural	someone (unspec./holy) → us	gúní → niihíní
+4Sg+1SgO	4th person singular → DO: 1st person singular	Subject: 4th person singular → Direct Object: 1st person singular	someone (unspec./holy) → me	gúní → síní
+4Sg+2PlO	4th person singular → DO: 2nd person plural	Subject: 4th person singular → Direct Object: 2nd person plural	someone (unspec./holy) → you (all)	gúní → nahíní
+4Sg+2SgO	4th person singular → DO: 2nd person singular	Subject: 4th person singular → Direct Object: 2nd person singular	someone (unspec./holy) → you (one)	gúní → níní
+4Sg+3PlO	4th person singular → DO: 3rd person plural	Subject: 4th person singular → Direct Object: 3rd person plural	someone (unspec./holy) → them	gúní → igidíní
+4Sg+3SgO	4th person singular → DO: 3rd person singular	Subject: 4th person singular → Direct Object: 3rd person singular	someone (unspec./holy) → him/her/it	gúní → idíní
+4Sg+4PlO	4th person singular → DO: 4th person plural	Subject: 4th person singular → Direct Object: 4th person plural	someone (unspec./holy) → some people	gúní → ?
+4Sg+4SgO	4th person singular → DO: 4th person singular	Subject: 4th person singular → Direct Object: 4th person singular	someone (unspec./holy) → someone	gúní → gúní
+4Sg+Distr+1PlO	Distributive 4th person singular → DO: 1st person plural	Subject: distributive 4th person plural → Direct Object: 1st person plural	each and every one of some people → us	gúní (tłaát'áa) → niihíní
+4Sg+Distr+1SgO	Distributive 4th person singular → DO: 1st person singular	Subject: distributive 4th person plural → Direct Object: 1st person singular	each and every one of some people → me	gúní (tłaát'áa) → síní
+4Sg+Distr+2PlO	Distributive 4th person singular → DO: 2nd person plural	Subject: distributive 4th person plural → Direct Object: 2nd person plural	each and every one of some people → you (all)	gúní (tłaát'áa) → nahíní
+4Sg+Distr+2SgO	Distributive 4th person singular → DO: 2nd person singular	Subject: distributive 4th person plural → Direct Object: 2nd person singular	each and every one of some people → you (one)	gúní (tłaát'áa) → níní
+4Sg+Distr+3PlO	Distributive 4th person singular → DO: 3rd person plural	Subject: distributive 4th person plural → Direct Object: 3rd person plural	each and every one of some people → them	gúní (tłaát'áa) → igidíní
+4Sg+Distr+3SgO	Distributive 4th person singular → DO: 3rd person singular	Subject: distributive 4th person plural → Direct Object: 3rd person singular	each and every one of some people → him/her/it	gúní (tłaát'áa) → idíní
+4Sg+Distr+4PlO	Distributive 4th person singular → DO: 4th person plural	Subject: distributive 4th person plural → Direct Object: 4th person plural	each and every one of some people → some people	gúní (tłaát'áa) → ?
+4Sg+Distr+4SgO	Distributive 4th person singular → DO: 4th person singular	Subject: distributive 4th person plural → Direct Object: 4th person singular	each and every one of some people → someone	gúní (tłaát'áa) → gúní

--- a/src/srseng/resources/layouts/VT.tsv
+++ b/src/srseng/resources/layouts/VT.tsv
@@ -1,4 +1,4 @@
-		| Ipfv	| Pfv
+	| Ipfv	| Pfv
 _ 1Sg _ 1SgO	${lemma}+V+T+Ipfv+SbjSg1+DObjSg1	${lemma}+V+T+Ipfv+SbjSg1+DObjSg1
 _ 1Sg _ 2SgO	${lemma}+V+T+Ipfv+SbjSg1+DObjSg2	${lemma}+V+T+Ipfv+SbjSg1+DObjSg2
 _ 1Sg _ 3SgO	${lemma}+V+T+Ipfv+SbjSg1+DObjSg3	${lemma}+V+T+Ipfv+SbjSg1+DObjSg3
@@ -7,7 +7,7 @@ _ 1Sg _ 1PlO	${lemma}+V+T+Ipfv+SbjSg1+DObjPl1	${lemma}+V+T+Ipfv+SbjSg1+DObjPl1
 _ 1Sg _ 2PlO	${lemma}+V+T+Ipfv+SbjSg1+DObjPl2	${lemma}+V+T+Ipfv+SbjSg1+DObjPl2
 _ 1Sg _ 3PlO	${lemma}+V+T+Ipfv+SbjSg1+DObjPl3	${lemma}+V+T+Ipfv+SbjSg1+DObjPl3
 _ 1Sg _ 4PlO	${lemma}+V+T+Ipfv+SbjSg1+DObjPl4	${lemma}+V+T+Ipfv+SbjSg1+DObjPl4
-			
+
 _ 2Sg _ 1SgO	${lemma}+V+T+Ipfv+SbjSg2+DObjSg1	${lemma}+V+T+Ipfv+SbjSg2+DObjSg1
 _ 2Sg _ 2SgO	${lemma}+V+T+Ipfv+SbjSg2+DObjSg2	${lemma}+V+T+Ipfv+SbjSg2+DObjSg2
 _ 2Sg _ 3SgO	${lemma}+V+T+Ipfv+SbjSg2+DObjSg3	${lemma}+V+T+Ipfv+SbjSg2+DObjSg3
@@ -16,7 +16,7 @@ _ 2Sg _ 1PlO	${lemma}+V+T+Ipfv+SbjSg2+DObjPl1	${lemma}+V+T+Ipfv+SbjSg2+DObjPl1
 _ 2Sg _ 2PlO	${lemma}+V+T+Ipfv+SbjSg2+DObjPl2	${lemma}+V+T+Ipfv+SbjSg2+DObjPl2
 _ 2Sg _ 3PlO	${lemma}+V+T+Ipfv+SbjSg2+DObjPl3	${lemma}+V+T+Ipfv+SbjSg2+DObjPl3
 _ 2Sg _ 4PlO	${lemma}+V+T+Ipfv+SbjSg2+DObjPl4	${lemma}+V+T+Ipfv+SbjSg2+DObjPl4
-			
+
 _ 3Sg _ 1SgO	${lemma}+V+T+Ipfv+SbjSg3+DObjSg1	${lemma}+V+T+Ipfv+SbjSg3+DObjSg1
 _ 3Sg _ 2SgO	${lemma}+V+T+Ipfv+SbjSg3+DObjSg2	${lemma}+V+T+Ipfv+SbjSg3+DObjSg2
 _ 3Sg _ 3SgO	${lemma}+V+T+Ipfv+SbjSg3+DObjSg3	${lemma}+V+T+Ipfv+SbjSg3+DObjSg3
@@ -25,7 +25,7 @@ _ 3Sg _ 1PlO	${lemma}+V+T+Ipfv+SbjSg3+DObjPl1	${lemma}+V+T+Ipfv+SbjSg3+DObjPl1
 _ 3Sg _ 2PlO	${lemma}+V+T+Ipfv+SbjSg3+DObjPl2	${lemma}+V+T+Ipfv+SbjSg3+DObjPl2
 _ 3Sg _ 3PlO	${lemma}+V+T+Ipfv+SbjSg3+DObjPl3	${lemma}+V+T+Ipfv+SbjSg3+DObjPl3
 _ 3Sg _ 4PlO	${lemma}+V+T+Ipfv+SbjSg3+DObjPl4	${lemma}+V+T+Ipfv+SbjSg3+DObjPl4
-			
+
 _ 1Pl _ 1SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg1	${lemma}+V+T+Ipfv+SbjPl1+DObjSg1
 _ 1Pl _ 2SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg2	${lemma}+V+T+Ipfv+SbjPl1+DObjSg2
 _ 1Pl _ 3SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg3	${lemma}+V+T+Ipfv+SbjPl1+DObjSg3
@@ -34,7 +34,7 @@ _ 1Pl _ 1PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl1	${lemma}+V+T+Ipfv+SbjPl1+DObjPl1
 _ 1Pl _ 2PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl2	${lemma}+V+T+Ipfv+SbjPl1+DObjPl2
 _ 1Pl _ 3PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl3	${lemma}+V+T+Ipfv+SbjPl1+DObjPl3
 _ 1Pl _ 4PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl4	${lemma}+V+T+Ipfv+SbjPl1+DObjPl4
-			
+
 _ 2Pl _ 1SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg1	${lemma}+V+T+Ipfv+SbjPl2+DObjSg1
 _ 2Pl _ 2SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg2	${lemma}+V+T+Ipfv+SbjPl2+DObjSg2
 _ 2Pl _ 3SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg3	${lemma}+V+T+Ipfv+SbjPl2+DObjSg3
@@ -43,7 +43,7 @@ _ 2Pl _ 1PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl1	${lemma}+V+T+Ipfv+SbjPl2+DObjPl1
 _ 2Pl _ 2PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl2	${lemma}+V+T+Ipfv+SbjPl2+DObjPl2
 _ 2Pl _ 3PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl3	${lemma}+V+T+Ipfv+SbjPl2+DObjPl3
 _ 2Pl _ 4PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl4	${lemma}+V+T+Ipfv+SbjPl2+DObjPl4
-			
+
 _ 3Pl _ 1SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg1	${lemma}+V+T+Ipfv+SbjPl3+DObjSg1
 _ 3Pl _ 2SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg2	${lemma}+V+T+Ipfv+SbjPl3+DObjSg2
 _ 3Pl _ 3SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg3	${lemma}+V+T+Ipfv+SbjPl3+DObjSg3
@@ -52,7 +52,7 @@ _ 3Pl _ 1PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl1	${lemma}+V+T+Ipfv+SbjPl3+DObjPl1
 _ 3Pl _ 2PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl2	${lemma}+V+T+Ipfv+SbjPl3+DObjPl2
 _ 3Pl _ 3PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl3	${lemma}+V+T+Ipfv+SbjPl3+DObjPl3
 _ 3Pl _ 4PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl4	${lemma}+V+T+Ipfv+SbjPl3+DObjPl4
-			
+
 _ 4Sg _ 1SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg1	${lemma}+V+T+Ipfv+SbjSg4+DObjSg1
 _ 4Sg _ 2SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg2	${lemma}+V+T+Ipfv+SbjSg4+DObjSg2
 _ 4Sg _ 3SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg3	${lemma}+V+T+Ipfv+SbjSg4+DObjSg3
@@ -61,7 +61,7 @@ _ 4Sg _ 1PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl1	${lemma}+V+T+Ipfv+SbjSg4+DObjPl1
 _ 4Sg _ 2PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl2	${lemma}+V+T+Ipfv+SbjSg4+DObjPl2
 _ 4Sg _ 3PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl3	${lemma}+V+T+Ipfv+SbjSg4+DObjPl3
 _ 4Sg _ 4PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl4	${lemma}+V+T+Ipfv+SbjSg4+DObjPl4
-			
+
 _ 1Pl _ Distr _ 1SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg1+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjSg1+Distr
 _ 1Pl _ Distr _ 2SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg2+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjSg2+Distr
 _ 1Pl _ Distr _ 3SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg3+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjSg3+Distr
@@ -70,7 +70,7 @@ _ 1Pl _ Distr _ 1PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl1+Distr	${lemma}+V+T+Ipfv+Sb
 _ 1Pl _ Distr _ 2PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl2+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjPl2+Distr
 _ 1Pl _ Distr _ 3PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl3+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjPl3+Distr
 _ 1Pl _ Distr _ 4PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl4+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjPl4+Distr
-			
+
 _ 2Pl _ Distr _ 1SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg1+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjSg1+Distr
 _ 2Pl _ Distr _ 2SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg2+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjSg2+Distr
 _ 2Pl _ Distr _ 3SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg3+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjSg3+Distr
@@ -79,7 +79,7 @@ _ 2Pl _ Distr _ 1PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl1+Distr	${lemma}+V+T+Ipfv+Sb
 _ 2Pl _ Distr _ 2PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl2+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjPl2+Distr
 _ 2Pl _ Distr _ 3PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl3+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjPl3+Distr
 _ 2Pl _ Distr _ 4PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl4+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjPl4+Distr
-			
+
 _ 3Pl _ Distr _ 1SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg1+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjSg1+Distr
 _ 3Pl _ Distr _ 2SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg2+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjSg2+Distr
 _ 3Pl _ Distr _ 3SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg3+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjSg3+Distr
@@ -88,7 +88,7 @@ _ 3Pl _ Distr _ 1PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl1+Distr	${lemma}+V+T+Ipfv+Sb
 _ 3Pl _ Distr _ 2PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl2+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjPl2+Distr
 _ 3Pl _ Distr _ 3PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl3+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjPl3+Distr
 _ 3Pl _ Distr _ 4PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl4+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjPl4+Distr
-			
+
 _ 4Sg _ Distr _ 1SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg1+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjSg1+Distr
 _ 4Sg _ Distr _ 2SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg2+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjSg2+Distr
 _ 4Sg _ Distr _ 3SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg3+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjSg3+Distr
@@ -97,9 +97,8 @@ _ 4Sg _ Distr _ 1PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl1+Distr	${lemma}+V+T+Ipfv+Sb
 _ 4Sg _ Distr _ 2PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl2+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjPl2+Distr
 _ 4Sg _ Distr _ 3PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl3+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjPl3+Distr
 _ 4Sg _ Distr _ 4PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl4+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjPl4+Distr
-			
-			
-		| Prog	
+
+	| Prog	
 _ 1Sg _ 1SgO	${lemma}+V+T+Prog+SbjSg1+DObjSg1	
 _ 1Sg _ 2SgO	${lemma}+V+T+Prog+SbjSg1+DObjSg2	
 _ 1Sg _ 3SgO	${lemma}+V+T+Prog+SbjSg1+DObjSg3	
@@ -108,7 +107,7 @@ _ 1Sg _ 1PlO	${lemma}+V+T+Prog+SbjSg1+DObjPl1
 _ 1Sg _ 2PlO	${lemma}+V+T+Prog+SbjSg1+DObjPl2	
 _ 1Sg _ 3PlO	${lemma}+V+T+Prog+SbjSg1+DObjPl3	
 _ 1Sg _ 4PlO	${lemma}+V+T+Prog+SbjSg1+DObjPl4	
-			
+
 _ 2Sg _ 1SgO	${lemma}+V+T+Prog+SbjSg2+DObjSg1	
 _ 2Sg _ 2SgO	${lemma}+V+T+Prog+SbjSg2+DObjSg2	
 _ 2Sg _ 3SgO	${lemma}+V+T+Prog+SbjSg2+DObjSg3	
@@ -117,7 +116,7 @@ _ 2Sg _ 1PlO	${lemma}+V+T+Prog+SbjSg2+DObjPl1
 _ 2Sg _ 2PlO	${lemma}+V+T+Prog+SbjSg2+DObjPl2	
 _ 2Sg _ 3PlO	${lemma}+V+T+Prog+SbjSg2+DObjPl3	
 _ 2Sg _ 4PlO	${lemma}+V+T+Prog+SbjSg2+DObjPl4	
-			
+
 _ 3Sg _ 1SgO	${lemma}+V+T+Prog+SbjSg3+DObjSg1	
 _ 3Sg _ 2SgO	${lemma}+V+T+Prog+SbjSg3+DObjSg2	
 _ 3Sg _ 3SgO	${lemma}+V+T+Prog+SbjSg3+DObjSg3	
@@ -126,7 +125,7 @@ _ 3Sg _ 1PlO	${lemma}+V+T+Prog+SbjSg3+DObjPl1
 _ 3Sg _ 2PlO	${lemma}+V+T+Prog+SbjSg3+DObjPl2	
 _ 3Sg _ 3PlO	${lemma}+V+T+Prog+SbjSg3+DObjPl3	
 _ 3Sg _ 4PlO	${lemma}+V+T+Prog+SbjSg3+DObjPl4	
-			
+
 _ 1Pl _ 1SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg1	
 _ 1Pl _ 2SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg2	
 _ 1Pl _ 3SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg3	
@@ -135,7 +134,7 @@ _ 1Pl _ 1PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl1
 _ 1Pl _ 2PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl2	
 _ 1Pl _ 3PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl3	
 _ 1Pl _ 4PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl4	
-			
+
 _ 2Pl _ 1SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg1	
 _ 2Pl _ 2SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg2	
 _ 2Pl _ 3SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg3	
@@ -144,7 +143,7 @@ _ 2Pl _ 1PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl1
 _ 2Pl _ 2PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl2	
 _ 2Pl _ 3PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl3	
 _ 2Pl _ 4PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl4	
-			
+
 _ 3Pl _ 1SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg1	
 _ 3Pl _ 2SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg2	
 _ 3Pl _ 3SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg3	
@@ -153,7 +152,7 @@ _ 3Pl _ 1PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl1
 _ 3Pl _ 2PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl2	
 _ 3Pl _ 3PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl3	
 _ 3Pl _ 4PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl4	
-			
+
 _ 4Sg _ 1SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg1	
 _ 4Sg _ 2SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg2	
 _ 4Sg _ 3SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg3	
@@ -162,7 +161,7 @@ _ 4Sg _ 1PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl1
 _ 4Sg _ 2PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl2	
 _ 4Sg _ 3PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl3	
 _ 4Sg _ 4PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl4	
-			
+
 _ 1Pl _ Distr _ 1SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg1+Distr	
 _ 1Pl _ Distr _ 2SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg2+Distr	
 _ 1Pl _ Distr _ 3SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg3+Distr	
@@ -171,7 +170,7 @@ _ 1Pl _ Distr _ 1PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl1+Distr
 _ 1Pl _ Distr _ 2PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl2+Distr	
 _ 1Pl _ Distr _ 3PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl3+Distr	
 _ 1Pl _ Distr _ 4PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl4+Distr	
-			
+
 _ 2Pl _ Distr _ 1SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg1+Distr	
 _ 2Pl _ Distr _ 2SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg2+Distr	
 _ 2Pl _ Distr _ 3SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg3+Distr	
@@ -180,7 +179,7 @@ _ 2Pl _ Distr _ 1PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl1+Distr
 _ 2Pl _ Distr _ 2PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl2+Distr	
 _ 2Pl _ Distr _ 3PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl3+Distr	
 _ 2Pl _ Distr _ 4PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl4+Distr	
-			
+
 _ 3Pl _ Distr _ 1SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg1+Distr	
 _ 3Pl _ Distr _ 2SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg2+Distr	
 _ 3Pl _ Distr _ 3SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg3+Distr	
@@ -189,7 +188,7 @@ _ 3Pl _ Distr _ 1PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl1+Distr
 _ 3Pl _ Distr _ 2PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl2+Distr	
 _ 3Pl _ Distr _ 3PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl3+Distr	
 _ 3Pl _ Distr _ 4PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl4+Distr	
-			
+
 _ 4Sg _ Distr _ 1SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg1+Distr	
 _ 4Sg _ Distr _ 2SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg2+Distr	
 _ 4Sg _ Distr _ 3SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg3+Distr	
@@ -197,10 +196,9 @@ _ 4Sg _ Distr _ 4SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg4+Distr
 _ 4Sg _ Distr _ 1PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl1+Distr	
 _ 4Sg _ Distr _ 2PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl2+Distr	
 _ 4Sg _ Distr _ 3PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl3+Distr	
-_ 4Sg _ Distr _ 4PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl4+Distr	
-			
-			
-		| Ipfv | Rep	| Pfv | Rep
+_ 4Sg _ Distr _ 4PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl4+Distr
+
+	| Ipfv | Rep	| Pfv | Rep
 _ 1Sg _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg1
 _ 1Sg _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg2
 _ 1Sg _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg3
@@ -209,7 +207,7 @@ _ 1Sg _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjSg1+D
 _ 1Sg _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl2
 _ 1Sg _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl3
 _ 1Sg _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl4
-			
+
 _ 2Sg _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg1
 _ 2Sg _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg2
 _ 2Sg _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg3
@@ -218,7 +216,7 @@ _ 2Sg _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjSg2+D
 _ 2Sg _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl2
 _ 2Sg _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl3
 _ 2Sg _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl4
-			
+
 _ 3Sg _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg1
 _ 3Sg _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg2
 _ 3Sg _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg3
@@ -227,7 +225,7 @@ _ 3Sg _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjSg3+D
 _ 3Sg _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl2
 _ 3Sg _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl3
 _ 3Sg _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl4
-			
+
 _ 1Pl _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg1
 _ 1Pl _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg2
 _ 1Pl _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg3
@@ -236,7 +234,7 @@ _ 1Pl _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjPl1+D
 _ 1Pl _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl2
 _ 1Pl _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl3
 _ 1Pl _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl4
-			
+
 _ 2Pl _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg1
 _ 2Pl _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg2
 _ 2Pl _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg3
@@ -245,7 +243,7 @@ _ 2Pl _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjPl2+D
 _ 2Pl _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl2
 _ 2Pl _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl3
 _ 2Pl _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl4
-			
+
 _ 3Pl _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg1
 _ 3Pl _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg2
 _ 3Pl _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg3
@@ -254,7 +252,7 @@ _ 3Pl _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjPl3+D
 _ 3Pl _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl2
 _ 3Pl _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl3
 _ 3Pl _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl4
-			
+
 _ 4Sg _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg1
 _ 4Sg _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg2
 _ 4Sg _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg3
@@ -263,7 +261,7 @@ _ 4Sg _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjSg4+D
 _ 4Sg _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl2
 _ 4Sg _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl3
 _ 4Sg _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl4
-			
+
 _ 1Pl _ Distr _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg1+Distr
 _ 1Pl _ Distr _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg2+Distr
 _ 1Pl _ Distr _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg3+Distr
@@ -272,7 +270,7 @@ _ 1Pl _ Distr _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl1+Distr	${lemma}+V+T+Ipf
 _ 1Pl _ Distr _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl2+Distr
 _ 1Pl _ Distr _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl3+Distr
 _ 1Pl _ Distr _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl4+Distr
-			
+
 _ 2Pl _ Distr _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg1+Distr
 _ 2Pl _ Distr _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg2+Distr
 _ 2Pl _ Distr _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg3+Distr
@@ -281,7 +279,7 @@ _ 2Pl _ Distr _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl1+Distr	${lemma}+V+T+Ipf
 _ 2Pl _ Distr _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl2+Distr
 _ 2Pl _ Distr _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl3+Distr
 _ 2Pl _ Distr _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl4+Distr
-			
+
 _ 3Pl _ Distr _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg1+Distr
 _ 3Pl _ Distr _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg2+Distr
 _ 3Pl _ Distr _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg3+Distr
@@ -290,7 +288,7 @@ _ 3Pl _ Distr _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl1+Distr	${lemma}+V+T+Ipf
 _ 3Pl _ Distr _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl2+Distr
 _ 3Pl _ Distr _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl3+Distr
 _ 3Pl _ Distr _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl4+Distr
-			
+
 _ 4Sg _ Distr _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg1+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg1+Distr
 _ 4Sg _ Distr _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg2+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg2+Distr
 _ 4Sg _ Distr _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg3+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg3+Distr
@@ -299,9 +297,8 @@ _ 4Sg _ Distr _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl1+Distr	${lemma}+V+T+Ipf
 _ 4Sg _ Distr _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl2+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl2+Distr
 _ 4Sg _ Distr _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl3+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl3+Distr
 _ 4Sg _ Distr _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl4+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl4+Distr
-			
-			
-		| Pot	
+
+	| Pot	
 _ 1Sg _ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjSg1	
 _ 1Sg _ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjSg2	
 _ 1Sg _ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjSg3	
@@ -310,7 +307,7 @@ _ 1Sg _ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjPl1
 _ 1Sg _ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjPl2	
 _ 1Sg _ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjPl3	
 _ 1Sg _ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjPl4	
-			
+
 _ 2Sg _ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjSg1	
 _ 2Sg _ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjSg2	
 _ 2Sg _ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjSg3	
@@ -319,7 +316,7 @@ _ 2Sg _ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjPl1
 _ 2Sg _ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjPl2	
 _ 2Sg _ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjPl3	
 _ 2Sg _ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjPl4	
-			
+
 _ 3Sg _ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjSg1	
 _ 3Sg _ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjSg2	
 _ 3Sg _ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjSg3	
@@ -328,7 +325,7 @@ _ 3Sg _ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjPl1
 _ 3Sg _ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjPl2	
 _ 3Sg _ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjPl3	
 _ 3Sg _ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjPl4	
-			
+
 _ 1Pl _ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg1	
 _ 1Pl _ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg2	
 _ 1Pl _ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg3	
@@ -337,7 +334,7 @@ _ 1Pl _ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl1
 _ 1Pl _ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl2	
 _ 1Pl _ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl3	
 _ 1Pl _ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl4	
-			
+
 _ 2Pl _ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg1	
 _ 2Pl _ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg2	
 _ 2Pl _ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg3	
@@ -346,7 +343,7 @@ _ 2Pl _ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl1
 _ 2Pl _ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl2	
 _ 2Pl _ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl3	
 _ 2Pl _ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl4	
-			
+
 _ 3Pl _ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg1	
 _ 3Pl _ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg2	
 _ 3Pl _ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg3	
@@ -355,7 +352,7 @@ _ 3Pl _ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl1
 _ 3Pl _ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl2	
 _ 3Pl _ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl3	
 _ 3Pl _ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl4	
-			
+
 _ 4Sg _ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg1	
 _ 4Sg _ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg2	
 _ 4Sg _ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg3	
@@ -364,7 +361,7 @@ _ 4Sg _ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl1
 _ 4Sg _ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl2	
 _ 4Sg _ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl3	
 _ 4Sg _ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl4	
-			
+
 _ 1Pl _ Distr _ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg1+Distr	
 _ 1Pl _ Distr _ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg2+Distr	
 _ 1Pl _ Distr _ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg3+Distr	
@@ -373,7 +370,7 @@ _ 1Pl _ Distr _ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl1+Distr
 _ 1Pl _ Distr _ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl2+Distr	
 _ 1Pl _ Distr _ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl3+Distr	
 _ 1Pl _ Distr _ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl4+Distr	
-			
+
 _ 2Pl _ Distr _ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg1+Distr	
 _ 2Pl _ Distr _ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg2+Distr	
 _ 2Pl _ Distr _ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg3+Distr	
@@ -382,7 +379,7 @@ _ 2Pl _ Distr _ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl1+Distr
 _ 2Pl _ Distr _ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl2+Distr	
 _ 2Pl _ Distr _ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl3+Distr	
 _ 2Pl _ Distr _ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl4+Distr	
-			
+
 _ 3Pl _ Distr _ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg1+Distr	
 _ 3Pl _ Distr _ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg2+Distr	
 _ 3Pl _ Distr _ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg3+Distr	
@@ -391,7 +388,7 @@ _ 3Pl _ Distr _ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl1+Distr
 _ 3Pl _ Distr _ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl2+Distr	
 _ 3Pl _ Distr _ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl3+Distr	
 _ 3Pl _ Distr _ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl4+Distr	
-			
+
 _ 4Sg _ Distr _ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg1+Distr	
 _ 4Sg _ Distr _ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg2+Distr	
 _ 4Sg _ Distr _ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg3+Distr	

--- a/src/srseng/resources/layouts/VT.tsv
+++ b/src/srseng/resources/layouts/VT.tsv
@@ -1,402 +1,402 @@
 		| Ipfv	| Pfv
-_ 1Sg 	_ 1SgO	${lemma}+V+T+Ipfv+SbjSg1+DObjSg1	${lemma}+V+T+Ipfv+SbjSg1+DObjSg1
-_ 1Sg 	_ 2SgO	${lemma}+V+T+Ipfv+SbjSg1+DObjSg2	${lemma}+V+T+Ipfv+SbjSg1+DObjSg2
-_ 1Sg 	_ 3SgO	${lemma}+V+T+Ipfv+SbjSg1+DObjSg3	${lemma}+V+T+Ipfv+SbjSg1+DObjSg3
-_ 1Sg 	_ 4SgO	${lemma}+V+T+Ipfv+SbjSg1+DObjSg4	${lemma}+V+T+Ipfv+SbjSg1+DObjSg4
-_ 1Sg 	_ 1PlO	${lemma}+V+T+Ipfv+SbjSg1+DObjPl1	${lemma}+V+T+Ipfv+SbjSg1+DObjPl1
-_ 1Sg 	_ 2PlO	${lemma}+V+T+Ipfv+SbjSg1+DObjPl2	${lemma}+V+T+Ipfv+SbjSg1+DObjPl2
-_ 1Sg 	_ 3PlO	${lemma}+V+T+Ipfv+SbjSg1+DObjPl3	${lemma}+V+T+Ipfv+SbjSg1+DObjPl3
-_ 1Sg 	_ 4PlO	${lemma}+V+T+Ipfv+SbjSg1+DObjPl4	${lemma}+V+T+Ipfv+SbjSg1+DObjPl4
+_ 1Sg _ 1SgO	${lemma}+V+T+Ipfv+SbjSg1+DObjSg1	${lemma}+V+T+Ipfv+SbjSg1+DObjSg1
+_ 1Sg _ 2SgO	${lemma}+V+T+Ipfv+SbjSg1+DObjSg2	${lemma}+V+T+Ipfv+SbjSg1+DObjSg2
+_ 1Sg _ 3SgO	${lemma}+V+T+Ipfv+SbjSg1+DObjSg3	${lemma}+V+T+Ipfv+SbjSg1+DObjSg3
+_ 1Sg _ 4SgO	${lemma}+V+T+Ipfv+SbjSg1+DObjSg4	${lemma}+V+T+Ipfv+SbjSg1+DObjSg4
+_ 1Sg _ 1PlO	${lemma}+V+T+Ipfv+SbjSg1+DObjPl1	${lemma}+V+T+Ipfv+SbjSg1+DObjPl1
+_ 1Sg _ 2PlO	${lemma}+V+T+Ipfv+SbjSg1+DObjPl2	${lemma}+V+T+Ipfv+SbjSg1+DObjPl2
+_ 1Sg _ 3PlO	${lemma}+V+T+Ipfv+SbjSg1+DObjPl3	${lemma}+V+T+Ipfv+SbjSg1+DObjPl3
+_ 1Sg _ 4PlO	${lemma}+V+T+Ipfv+SbjSg1+DObjPl4	${lemma}+V+T+Ipfv+SbjSg1+DObjPl4
 			
-_ 2Sg 	_ 1SgO	${lemma}+V+T+Ipfv+SbjSg2+DObjSg1	${lemma}+V+T+Ipfv+SbjSg2+DObjSg1
-_ 2Sg 	_ 2SgO	${lemma}+V+T+Ipfv+SbjSg2+DObjSg2	${lemma}+V+T+Ipfv+SbjSg2+DObjSg2
-_ 2Sg 	_ 3SgO	${lemma}+V+T+Ipfv+SbjSg2+DObjSg3	${lemma}+V+T+Ipfv+SbjSg2+DObjSg3
-_ 2Sg 	_ 4SgO	${lemma}+V+T+Ipfv+SbjSg2+DObjSg4	${lemma}+V+T+Ipfv+SbjSg2+DObjSg4
-_ 2Sg 	_ 1PlO	${lemma}+V+T+Ipfv+SbjSg2+DObjPl1	${lemma}+V+T+Ipfv+SbjSg2+DObjPl1
-_ 2Sg 	_ 2PlO	${lemma}+V+T+Ipfv+SbjSg2+DObjPl2	${lemma}+V+T+Ipfv+SbjSg2+DObjPl2
-_ 2Sg 	_ 3PlO	${lemma}+V+T+Ipfv+SbjSg2+DObjPl3	${lemma}+V+T+Ipfv+SbjSg2+DObjPl3
-_ 2Sg 	_ 4PlO	${lemma}+V+T+Ipfv+SbjSg2+DObjPl4	${lemma}+V+T+Ipfv+SbjSg2+DObjPl4
+_ 2Sg _ 1SgO	${lemma}+V+T+Ipfv+SbjSg2+DObjSg1	${lemma}+V+T+Ipfv+SbjSg2+DObjSg1
+_ 2Sg _ 2SgO	${lemma}+V+T+Ipfv+SbjSg2+DObjSg2	${lemma}+V+T+Ipfv+SbjSg2+DObjSg2
+_ 2Sg _ 3SgO	${lemma}+V+T+Ipfv+SbjSg2+DObjSg3	${lemma}+V+T+Ipfv+SbjSg2+DObjSg3
+_ 2Sg _ 4SgO	${lemma}+V+T+Ipfv+SbjSg2+DObjSg4	${lemma}+V+T+Ipfv+SbjSg2+DObjSg4
+_ 2Sg _ 1PlO	${lemma}+V+T+Ipfv+SbjSg2+DObjPl1	${lemma}+V+T+Ipfv+SbjSg2+DObjPl1
+_ 2Sg _ 2PlO	${lemma}+V+T+Ipfv+SbjSg2+DObjPl2	${lemma}+V+T+Ipfv+SbjSg2+DObjPl2
+_ 2Sg _ 3PlO	${lemma}+V+T+Ipfv+SbjSg2+DObjPl3	${lemma}+V+T+Ipfv+SbjSg2+DObjPl3
+_ 2Sg _ 4PlO	${lemma}+V+T+Ipfv+SbjSg2+DObjPl4	${lemma}+V+T+Ipfv+SbjSg2+DObjPl4
 			
-_ 3Sg 	_ 1SgO	${lemma}+V+T+Ipfv+SbjSg3+DObjSg1	${lemma}+V+T+Ipfv+SbjSg3+DObjSg1
-_ 3Sg 	_ 2SgO	${lemma}+V+T+Ipfv+SbjSg3+DObjSg2	${lemma}+V+T+Ipfv+SbjSg3+DObjSg2
-_ 3Sg 	_ 3SgO	${lemma}+V+T+Ipfv+SbjSg3+DObjSg3	${lemma}+V+T+Ipfv+SbjSg3+DObjSg3
-_ 3Sg 	_ 4SgO	${lemma}+V+T+Ipfv+SbjSg3+DObjSg4	${lemma}+V+T+Ipfv+SbjSg3+DObjSg4
-_ 3Sg 	_ 1PlO	${lemma}+V+T+Ipfv+SbjSg3+DObjPl1	${lemma}+V+T+Ipfv+SbjSg3+DObjPl1
-_ 3Sg 	_ 2PlO	${lemma}+V+T+Ipfv+SbjSg3+DObjPl2	${lemma}+V+T+Ipfv+SbjSg3+DObjPl2
-_ 3Sg 	_ 3PlO	${lemma}+V+T+Ipfv+SbjSg3+DObjPl3	${lemma}+V+T+Ipfv+SbjSg3+DObjPl3
-_ 3Sg 	_ 4PlO	${lemma}+V+T+Ipfv+SbjSg3+DObjPl4	${lemma}+V+T+Ipfv+SbjSg3+DObjPl4
+_ 3Sg _ 1SgO	${lemma}+V+T+Ipfv+SbjSg3+DObjSg1	${lemma}+V+T+Ipfv+SbjSg3+DObjSg1
+_ 3Sg _ 2SgO	${lemma}+V+T+Ipfv+SbjSg3+DObjSg2	${lemma}+V+T+Ipfv+SbjSg3+DObjSg2
+_ 3Sg _ 3SgO	${lemma}+V+T+Ipfv+SbjSg3+DObjSg3	${lemma}+V+T+Ipfv+SbjSg3+DObjSg3
+_ 3Sg _ 4SgO	${lemma}+V+T+Ipfv+SbjSg3+DObjSg4	${lemma}+V+T+Ipfv+SbjSg3+DObjSg4
+_ 3Sg _ 1PlO	${lemma}+V+T+Ipfv+SbjSg3+DObjPl1	${lemma}+V+T+Ipfv+SbjSg3+DObjPl1
+_ 3Sg _ 2PlO	${lemma}+V+T+Ipfv+SbjSg3+DObjPl2	${lemma}+V+T+Ipfv+SbjSg3+DObjPl2
+_ 3Sg _ 3PlO	${lemma}+V+T+Ipfv+SbjSg3+DObjPl3	${lemma}+V+T+Ipfv+SbjSg3+DObjPl3
+_ 3Sg _ 4PlO	${lemma}+V+T+Ipfv+SbjSg3+DObjPl4	${lemma}+V+T+Ipfv+SbjSg3+DObjPl4
 			
-_ 1Pl 	_ 1SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg1	${lemma}+V+T+Ipfv+SbjPl1+DObjSg1
-_ 1Pl 	_ 2SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg2	${lemma}+V+T+Ipfv+SbjPl1+DObjSg2
-_ 1Pl 	_ 3SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg3	${lemma}+V+T+Ipfv+SbjPl1+DObjSg3
-_ 1Pl 	_ 4SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg4	${lemma}+V+T+Ipfv+SbjPl1+DObjSg4
-_ 1Pl 	_ 1PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl1	${lemma}+V+T+Ipfv+SbjPl1+DObjPl1
-_ 1Pl 	_ 2PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl2	${lemma}+V+T+Ipfv+SbjPl1+DObjPl2
-_ 1Pl 	_ 3PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl3	${lemma}+V+T+Ipfv+SbjPl1+DObjPl3
-_ 1Pl 	_ 4PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl4	${lemma}+V+T+Ipfv+SbjPl1+DObjPl4
+_ 1Pl _ 1SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg1	${lemma}+V+T+Ipfv+SbjPl1+DObjSg1
+_ 1Pl _ 2SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg2	${lemma}+V+T+Ipfv+SbjPl1+DObjSg2
+_ 1Pl _ 3SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg3	${lemma}+V+T+Ipfv+SbjPl1+DObjSg3
+_ 1Pl _ 4SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg4	${lemma}+V+T+Ipfv+SbjPl1+DObjSg4
+_ 1Pl _ 1PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl1	${lemma}+V+T+Ipfv+SbjPl1+DObjPl1
+_ 1Pl _ 2PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl2	${lemma}+V+T+Ipfv+SbjPl1+DObjPl2
+_ 1Pl _ 3PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl3	${lemma}+V+T+Ipfv+SbjPl1+DObjPl3
+_ 1Pl _ 4PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl4	${lemma}+V+T+Ipfv+SbjPl1+DObjPl4
 			
-_ 2Pl 	_ 1SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg1	${lemma}+V+T+Ipfv+SbjPl2+DObjSg1
-_ 2Pl 	_ 2SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg2	${lemma}+V+T+Ipfv+SbjPl2+DObjSg2
-_ 2Pl 	_ 3SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg3	${lemma}+V+T+Ipfv+SbjPl2+DObjSg3
-_ 2Pl 	_ 4SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg4	${lemma}+V+T+Ipfv+SbjPl2+DObjSg4
-_ 2Pl 	_ 1PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl1	${lemma}+V+T+Ipfv+SbjPl2+DObjPl1
-_ 2Pl 	_ 2PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl2	${lemma}+V+T+Ipfv+SbjPl2+DObjPl2
-_ 2Pl 	_ 3PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl3	${lemma}+V+T+Ipfv+SbjPl2+DObjPl3
-_ 2Pl 	_ 4PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl4	${lemma}+V+T+Ipfv+SbjPl2+DObjPl4
+_ 2Pl _ 1SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg1	${lemma}+V+T+Ipfv+SbjPl2+DObjSg1
+_ 2Pl _ 2SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg2	${lemma}+V+T+Ipfv+SbjPl2+DObjSg2
+_ 2Pl _ 3SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg3	${lemma}+V+T+Ipfv+SbjPl2+DObjSg3
+_ 2Pl _ 4SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg4	${lemma}+V+T+Ipfv+SbjPl2+DObjSg4
+_ 2Pl _ 1PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl1	${lemma}+V+T+Ipfv+SbjPl2+DObjPl1
+_ 2Pl _ 2PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl2	${lemma}+V+T+Ipfv+SbjPl2+DObjPl2
+_ 2Pl _ 3PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl3	${lemma}+V+T+Ipfv+SbjPl2+DObjPl3
+_ 2Pl _ 4PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl4	${lemma}+V+T+Ipfv+SbjPl2+DObjPl4
 			
-_ 3Pl 	_ 1SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg1	${lemma}+V+T+Ipfv+SbjPl3+DObjSg1
-_ 3Pl 	_ 2SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg2	${lemma}+V+T+Ipfv+SbjPl3+DObjSg2
-_ 3Pl 	_ 3SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg3	${lemma}+V+T+Ipfv+SbjPl3+DObjSg3
-_ 3Pl 	_ 4SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg4	${lemma}+V+T+Ipfv+SbjPl3+DObjSg4
-_ 3Pl 	_ 1PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl1	${lemma}+V+T+Ipfv+SbjPl3+DObjPl1
-_ 3Pl 	_ 2PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl2	${lemma}+V+T+Ipfv+SbjPl3+DObjPl2
-_ 3Pl 	_ 3PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl3	${lemma}+V+T+Ipfv+SbjPl3+DObjPl3
-_ 3Pl 	_ 4PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl4	${lemma}+V+T+Ipfv+SbjPl3+DObjPl4
+_ 3Pl _ 1SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg1	${lemma}+V+T+Ipfv+SbjPl3+DObjSg1
+_ 3Pl _ 2SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg2	${lemma}+V+T+Ipfv+SbjPl3+DObjSg2
+_ 3Pl _ 3SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg3	${lemma}+V+T+Ipfv+SbjPl3+DObjSg3
+_ 3Pl _ 4SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg4	${lemma}+V+T+Ipfv+SbjPl3+DObjSg4
+_ 3Pl _ 1PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl1	${lemma}+V+T+Ipfv+SbjPl3+DObjPl1
+_ 3Pl _ 2PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl2	${lemma}+V+T+Ipfv+SbjPl3+DObjPl2
+_ 3Pl _ 3PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl3	${lemma}+V+T+Ipfv+SbjPl3+DObjPl3
+_ 3Pl _ 4PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl4	${lemma}+V+T+Ipfv+SbjPl3+DObjPl4
 			
-_ 4Sg 	_ 1SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg1	${lemma}+V+T+Ipfv+SbjSg4+DObjSg1
-_ 4Sg 	_ 2SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg2	${lemma}+V+T+Ipfv+SbjSg4+DObjSg2
-_ 4Sg 	_ 3SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg3	${lemma}+V+T+Ipfv+SbjSg4+DObjSg3
-_ 4Sg 	_ 4SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg4	${lemma}+V+T+Ipfv+SbjSg4+DObjSg4
-_ 4Sg 	_ 1PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl1	${lemma}+V+T+Ipfv+SbjSg4+DObjPl1
-_ 4Sg 	_ 2PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl2	${lemma}+V+T+Ipfv+SbjSg4+DObjPl2
-_ 4Sg 	_ 3PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl3	${lemma}+V+T+Ipfv+SbjSg4+DObjPl3
-_ 4Sg 	_ 4PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl4	${lemma}+V+T+Ipfv+SbjSg4+DObjPl4
+_ 4Sg _ 1SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg1	${lemma}+V+T+Ipfv+SbjSg4+DObjSg1
+_ 4Sg _ 2SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg2	${lemma}+V+T+Ipfv+SbjSg4+DObjSg2
+_ 4Sg _ 3SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg3	${lemma}+V+T+Ipfv+SbjSg4+DObjSg3
+_ 4Sg _ 4SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg4	${lemma}+V+T+Ipfv+SbjSg4+DObjSg4
+_ 4Sg _ 1PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl1	${lemma}+V+T+Ipfv+SbjSg4+DObjPl1
+_ 4Sg _ 2PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl2	${lemma}+V+T+Ipfv+SbjSg4+DObjPl2
+_ 4Sg _ 3PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl3	${lemma}+V+T+Ipfv+SbjSg4+DObjPl3
+_ 4Sg _ 4PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl4	${lemma}+V+T+Ipfv+SbjSg4+DObjPl4
 			
-_ 1Pl _ Distr 	_ 1SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg1+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjSg1+Distr
-_ 1Pl _ Distr 	_ 2SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg2+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjSg2+Distr
-_ 1Pl _ Distr 	_ 3SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg3+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjSg3+Distr
-_ 1Pl _ Distr 	_ 4SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg4+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjSg4+Distr
-_ 1Pl _ Distr 	_ 1PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl1+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjPl1+Distr
-_ 1Pl _ Distr 	_ 2PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl2+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjPl2+Distr
-_ 1Pl _ Distr 	_ 3PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl3+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjPl3+Distr
-_ 1Pl _ Distr 	_ 4PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl4+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjPl4+Distr
+_ 1Pl _ Distr _ 1SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg1+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjSg1+Distr
+_ 1Pl _ Distr _ 2SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg2+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjSg2+Distr
+_ 1Pl _ Distr _ 3SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg3+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjSg3+Distr
+_ 1Pl _ Distr _ 4SgO	${lemma}+V+T+Ipfv+SbjPl1+DObjSg4+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjSg4+Distr
+_ 1Pl _ Distr _ 1PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl1+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjPl1+Distr
+_ 1Pl _ Distr _ 2PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl2+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjPl2+Distr
+_ 1Pl _ Distr _ 3PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl3+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjPl3+Distr
+_ 1Pl _ Distr _ 4PlO	${lemma}+V+T+Ipfv+SbjPl1+DObjPl4+Distr	${lemma}+V+T+Ipfv+SbjPl1+DObjPl4+Distr
 			
-_ 2Pl _ Distr 	_ 1SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg1+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjSg1+Distr
-_ 2Pl _ Distr 	_ 2SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg2+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjSg2+Distr
-_ 2Pl _ Distr 	_ 3SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg3+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjSg3+Distr
-_ 2Pl _ Distr 	_ 4SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg4+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjSg4+Distr
-_ 2Pl _ Distr 	_ 1PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl1+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjPl1+Distr
-_ 2Pl _ Distr 	_ 2PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl2+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjPl2+Distr
-_ 2Pl _ Distr 	_ 3PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl3+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjPl3+Distr
-_ 2Pl _ Distr 	_ 4PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl4+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjPl4+Distr
+_ 2Pl _ Distr _ 1SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg1+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjSg1+Distr
+_ 2Pl _ Distr _ 2SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg2+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjSg2+Distr
+_ 2Pl _ Distr _ 3SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg3+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjSg3+Distr
+_ 2Pl _ Distr _ 4SgO	${lemma}+V+T+Ipfv+SbjPl2+DObjSg4+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjSg4+Distr
+_ 2Pl _ Distr _ 1PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl1+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjPl1+Distr
+_ 2Pl _ Distr _ 2PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl2+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjPl2+Distr
+_ 2Pl _ Distr _ 3PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl3+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjPl3+Distr
+_ 2Pl _ Distr _ 4PlO	${lemma}+V+T+Ipfv+SbjPl2+DObjPl4+Distr	${lemma}+V+T+Ipfv+SbjPl2+DObjPl4+Distr
 			
-_ 3Pl _ Distr 	_ 1SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg1+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjSg1+Distr
-_ 3Pl _ Distr 	_ 2SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg2+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjSg2+Distr
-_ 3Pl _ Distr 	_ 3SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg3+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjSg3+Distr
-_ 3Pl _ Distr 	_ 4SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg4+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjSg4+Distr
-_ 3Pl _ Distr 	_ 1PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl1+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjPl1+Distr
-_ 3Pl _ Distr 	_ 2PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl2+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjPl2+Distr
-_ 3Pl _ Distr 	_ 3PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl3+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjPl3+Distr
-_ 3Pl _ Distr 	_ 4PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl4+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjPl4+Distr
+_ 3Pl _ Distr _ 1SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg1+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjSg1+Distr
+_ 3Pl _ Distr _ 2SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg2+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjSg2+Distr
+_ 3Pl _ Distr _ 3SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg3+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjSg3+Distr
+_ 3Pl _ Distr _ 4SgO	${lemma}+V+T+Ipfv+SbjPl3+DObjSg4+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjSg4+Distr
+_ 3Pl _ Distr _ 1PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl1+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjPl1+Distr
+_ 3Pl _ Distr _ 2PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl2+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjPl2+Distr
+_ 3Pl _ Distr _ 3PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl3+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjPl3+Distr
+_ 3Pl _ Distr _ 4PlO	${lemma}+V+T+Ipfv+SbjPl3+DObjPl4+Distr	${lemma}+V+T+Ipfv+SbjPl3+DObjPl4+Distr
 			
-_ 4Sg _ Distr 	_ 1SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg1+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjSg1+Distr
-_ 4Sg _ Distr 	_ 2SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg2+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjSg2+Distr
-_ 4Sg _ Distr 	_ 3SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg3+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjSg3+Distr
-_ 4Sg _ Distr 	_ 4SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg4+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjSg4+Distr
-_ 4Sg _ Distr 	_ 1PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl1+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjPl1+Distr
-_ 4Sg _ Distr 	_ 2PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl2+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjPl2+Distr
-_ 4Sg _ Distr 	_ 3PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl3+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjPl3+Distr
-_ 4Sg _ Distr 	_ 4PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl4+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjPl4+Distr
+_ 4Sg _ Distr _ 1SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg1+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjSg1+Distr
+_ 4Sg _ Distr _ 2SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg2+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjSg2+Distr
+_ 4Sg _ Distr _ 3SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg3+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjSg3+Distr
+_ 4Sg _ Distr _ 4SgO	${lemma}+V+T+Ipfv+SbjSg4+DObjSg4+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjSg4+Distr
+_ 4Sg _ Distr _ 1PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl1+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjPl1+Distr
+_ 4Sg _ Distr _ 2PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl2+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjPl2+Distr
+_ 4Sg _ Distr _ 3PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl3+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjPl3+Distr
+_ 4Sg _ Distr _ 4PlO	${lemma}+V+T+Ipfv+SbjSg4+DObjPl4+Distr	${lemma}+V+T+Ipfv+SbjSg4+DObjPl4+Distr
 			
 			
 		| Prog	
-_ 1Sg 	_ 1SgO	${lemma}+V+T+Prog+SbjSg1+DObjSg1	
-_ 1Sg 	_ 2SgO	${lemma}+V+T+Prog+SbjSg1+DObjSg2	
-_ 1Sg 	_ 3SgO	${lemma}+V+T+Prog+SbjSg1+DObjSg3	
-_ 1Sg 	_ 4SgO	${lemma}+V+T+Prog+SbjSg1+DObjSg4	
-_ 1Sg 	_ 1PlO	${lemma}+V+T+Prog+SbjSg1+DObjPl1	
-_ 1Sg 	_ 2PlO	${lemma}+V+T+Prog+SbjSg1+DObjPl2	
-_ 1Sg 	_ 3PlO	${lemma}+V+T+Prog+SbjSg1+DObjPl3	
-_ 1Sg 	_ 4PlO	${lemma}+V+T+Prog+SbjSg1+DObjPl4	
+_ 1Sg _ 1SgO	${lemma}+V+T+Prog+SbjSg1+DObjSg1	
+_ 1Sg _ 2SgO	${lemma}+V+T+Prog+SbjSg1+DObjSg2	
+_ 1Sg _ 3SgO	${lemma}+V+T+Prog+SbjSg1+DObjSg3	
+_ 1Sg _ 4SgO	${lemma}+V+T+Prog+SbjSg1+DObjSg4	
+_ 1Sg _ 1PlO	${lemma}+V+T+Prog+SbjSg1+DObjPl1	
+_ 1Sg _ 2PlO	${lemma}+V+T+Prog+SbjSg1+DObjPl2	
+_ 1Sg _ 3PlO	${lemma}+V+T+Prog+SbjSg1+DObjPl3	
+_ 1Sg _ 4PlO	${lemma}+V+T+Prog+SbjSg1+DObjPl4	
 			
-_ 2Sg 	_ 1SgO	${lemma}+V+T+Prog+SbjSg2+DObjSg1	
-_ 2Sg 	_ 2SgO	${lemma}+V+T+Prog+SbjSg2+DObjSg2	
-_ 2Sg 	_ 3SgO	${lemma}+V+T+Prog+SbjSg2+DObjSg3	
-_ 2Sg 	_ 4SgO	${lemma}+V+T+Prog+SbjSg2+DObjSg4	
-_ 2Sg 	_ 1PlO	${lemma}+V+T+Prog+SbjSg2+DObjPl1	
-_ 2Sg 	_ 2PlO	${lemma}+V+T+Prog+SbjSg2+DObjPl2	
-_ 2Sg 	_ 3PlO	${lemma}+V+T+Prog+SbjSg2+DObjPl3	
-_ 2Sg 	_ 4PlO	${lemma}+V+T+Prog+SbjSg2+DObjPl4	
+_ 2Sg _ 1SgO	${lemma}+V+T+Prog+SbjSg2+DObjSg1	
+_ 2Sg _ 2SgO	${lemma}+V+T+Prog+SbjSg2+DObjSg2	
+_ 2Sg _ 3SgO	${lemma}+V+T+Prog+SbjSg2+DObjSg3	
+_ 2Sg _ 4SgO	${lemma}+V+T+Prog+SbjSg2+DObjSg4	
+_ 2Sg _ 1PlO	${lemma}+V+T+Prog+SbjSg2+DObjPl1	
+_ 2Sg _ 2PlO	${lemma}+V+T+Prog+SbjSg2+DObjPl2	
+_ 2Sg _ 3PlO	${lemma}+V+T+Prog+SbjSg2+DObjPl3	
+_ 2Sg _ 4PlO	${lemma}+V+T+Prog+SbjSg2+DObjPl4	
 			
-_ 3Sg 	_ 1SgO	${lemma}+V+T+Prog+SbjSg3+DObjSg1	
-_ 3Sg 	_ 2SgO	${lemma}+V+T+Prog+SbjSg3+DObjSg2	
-_ 3Sg 	_ 3SgO	${lemma}+V+T+Prog+SbjSg3+DObjSg3	
-_ 3Sg 	_ 4SgO	${lemma}+V+T+Prog+SbjSg3+DObjSg4	
-_ 3Sg 	_ 1PlO	${lemma}+V+T+Prog+SbjSg3+DObjPl1	
-_ 3Sg 	_ 2PlO	${lemma}+V+T+Prog+SbjSg3+DObjPl2	
-_ 3Sg 	_ 3PlO	${lemma}+V+T+Prog+SbjSg3+DObjPl3	
-_ 3Sg 	_ 4PlO	${lemma}+V+T+Prog+SbjSg3+DObjPl4	
+_ 3Sg _ 1SgO	${lemma}+V+T+Prog+SbjSg3+DObjSg1	
+_ 3Sg _ 2SgO	${lemma}+V+T+Prog+SbjSg3+DObjSg2	
+_ 3Sg _ 3SgO	${lemma}+V+T+Prog+SbjSg3+DObjSg3	
+_ 3Sg _ 4SgO	${lemma}+V+T+Prog+SbjSg3+DObjSg4	
+_ 3Sg _ 1PlO	${lemma}+V+T+Prog+SbjSg3+DObjPl1	
+_ 3Sg _ 2PlO	${lemma}+V+T+Prog+SbjSg3+DObjPl2	
+_ 3Sg _ 3PlO	${lemma}+V+T+Prog+SbjSg3+DObjPl3	
+_ 3Sg _ 4PlO	${lemma}+V+T+Prog+SbjSg3+DObjPl4	
 			
-_ 1Pl 	_ 1SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg1	
-_ 1Pl 	_ 2SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg2	
-_ 1Pl 	_ 3SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg3	
-_ 1Pl 	_ 4SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg4	
-_ 1Pl 	_ 1PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl1	
-_ 1Pl 	_ 2PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl2	
-_ 1Pl 	_ 3PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl3	
-_ 1Pl 	_ 4PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl4	
+_ 1Pl _ 1SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg1	
+_ 1Pl _ 2SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg2	
+_ 1Pl _ 3SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg3	
+_ 1Pl _ 4SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg4	
+_ 1Pl _ 1PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl1	
+_ 1Pl _ 2PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl2	
+_ 1Pl _ 3PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl3	
+_ 1Pl _ 4PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl4	
 			
-_ 2Pl 	_ 1SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg1	
-_ 2Pl 	_ 2SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg2	
-_ 2Pl 	_ 3SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg3	
-_ 2Pl 	_ 4SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg4	
-_ 2Pl 	_ 1PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl1	
-_ 2Pl 	_ 2PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl2	
-_ 2Pl 	_ 3PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl3	
-_ 2Pl 	_ 4PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl4	
+_ 2Pl _ 1SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg1	
+_ 2Pl _ 2SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg2	
+_ 2Pl _ 3SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg3	
+_ 2Pl _ 4SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg4	
+_ 2Pl _ 1PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl1	
+_ 2Pl _ 2PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl2	
+_ 2Pl _ 3PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl3	
+_ 2Pl _ 4PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl4	
 			
-_ 3Pl 	_ 1SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg1	
-_ 3Pl 	_ 2SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg2	
-_ 3Pl 	_ 3SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg3	
-_ 3Pl 	_ 4SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg4	
-_ 3Pl 	_ 1PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl1	
-_ 3Pl 	_ 2PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl2	
-_ 3Pl 	_ 3PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl3	
-_ 3Pl 	_ 4PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl4	
+_ 3Pl _ 1SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg1	
+_ 3Pl _ 2SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg2	
+_ 3Pl _ 3SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg3	
+_ 3Pl _ 4SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg4	
+_ 3Pl _ 1PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl1	
+_ 3Pl _ 2PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl2	
+_ 3Pl _ 3PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl3	
+_ 3Pl _ 4PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl4	
 			
-_ 4Sg 	_ 1SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg1	
-_ 4Sg 	_ 2SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg2	
-_ 4Sg 	_ 3SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg3	
-_ 4Sg 	_ 4SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg4	
-_ 4Sg 	_ 1PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl1	
-_ 4Sg 	_ 2PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl2	
-_ 4Sg 	_ 3PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl3	
-_ 4Sg 	_ 4PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl4	
+_ 4Sg _ 1SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg1	
+_ 4Sg _ 2SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg2	
+_ 4Sg _ 3SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg3	
+_ 4Sg _ 4SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg4	
+_ 4Sg _ 1PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl1	
+_ 4Sg _ 2PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl2	
+_ 4Sg _ 3PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl3	
+_ 4Sg _ 4PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl4	
 			
-_ 1Pl _ Distr 	_ 1SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg1+Distr	
-_ 1Pl _ Distr 	_ 2SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg2+Distr	
-_ 1Pl _ Distr 	_ 3SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg3+Distr	
-_ 1Pl _ Distr 	_ 4SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg4+Distr	
-_ 1Pl _ Distr 	_ 1PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl1+Distr	
-_ 1Pl _ Distr 	_ 2PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl2+Distr	
-_ 1Pl _ Distr 	_ 3PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl3+Distr	
-_ 1Pl _ Distr 	_ 4PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl4+Distr	
+_ 1Pl _ Distr _ 1SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg1+Distr	
+_ 1Pl _ Distr _ 2SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg2+Distr	
+_ 1Pl _ Distr _ 3SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg3+Distr	
+_ 1Pl _ Distr _ 4SgO	${lemma}+V+T+Prog+SbjPl1+DObjSg4+Distr	
+_ 1Pl _ Distr _ 1PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl1+Distr	
+_ 1Pl _ Distr _ 2PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl2+Distr	
+_ 1Pl _ Distr _ 3PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl3+Distr	
+_ 1Pl _ Distr _ 4PlO	${lemma}+V+T+Prog+SbjPl1+DObjPl4+Distr	
 			
-_ 2Pl _ Distr 	_ 1SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg1+Distr	
-_ 2Pl _ Distr 	_ 2SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg2+Distr	
-_ 2Pl _ Distr 	_ 3SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg3+Distr	
-_ 2Pl _ Distr 	_ 4SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg4+Distr	
-_ 2Pl _ Distr 	_ 1PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl1+Distr	
-_ 2Pl _ Distr 	_ 2PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl2+Distr	
-_ 2Pl _ Distr 	_ 3PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl3+Distr	
-_ 2Pl _ Distr 	_ 4PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl4+Distr	
+_ 2Pl _ Distr _ 1SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg1+Distr	
+_ 2Pl _ Distr _ 2SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg2+Distr	
+_ 2Pl _ Distr _ 3SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg3+Distr	
+_ 2Pl _ Distr _ 4SgO	${lemma}+V+T+Prog+SbjPl2+DObjSg4+Distr	
+_ 2Pl _ Distr _ 1PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl1+Distr	
+_ 2Pl _ Distr _ 2PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl2+Distr	
+_ 2Pl _ Distr _ 3PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl3+Distr	
+_ 2Pl _ Distr _ 4PlO	${lemma}+V+T+Prog+SbjPl2+DObjPl4+Distr	
 			
-_ 3Pl _ Distr 	_ 1SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg1+Distr	
-_ 3Pl _ Distr 	_ 2SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg2+Distr	
-_ 3Pl _ Distr 	_ 3SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg3+Distr	
-_ 3Pl _ Distr 	_ 4SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg4+Distr	
-_ 3Pl _ Distr 	_ 1PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl1+Distr	
-_ 3Pl _ Distr 	_ 2PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl2+Distr	
-_ 3Pl _ Distr 	_ 3PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl3+Distr	
-_ 3Pl _ Distr 	_ 4PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl4+Distr	
+_ 3Pl _ Distr _ 1SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg1+Distr	
+_ 3Pl _ Distr _ 2SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg2+Distr	
+_ 3Pl _ Distr _ 3SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg3+Distr	
+_ 3Pl _ Distr _ 4SgO	${lemma}+V+T+Prog+SbjPl3+DObjSg4+Distr	
+_ 3Pl _ Distr _ 1PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl1+Distr	
+_ 3Pl _ Distr _ 2PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl2+Distr	
+_ 3Pl _ Distr _ 3PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl3+Distr	
+_ 3Pl _ Distr _ 4PlO	${lemma}+V+T+Prog+SbjPl3+DObjPl4+Distr	
 			
-_ 4Sg _ Distr 	_ 1SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg1+Distr	
-_ 4Sg _ Distr 	_ 2SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg2+Distr	
-_ 4Sg _ Distr 	_ 3SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg3+Distr	
-_ 4Sg _ Distr 	_ 4SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg4+Distr	
-_ 4Sg _ Distr 	_ 1PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl1+Distr	
-_ 4Sg _ Distr 	_ 2PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl2+Distr	
-_ 4Sg _ Distr 	_ 3PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl3+Distr	
-_ 4Sg _ Distr 	_ 4PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl4+Distr	
+_ 4Sg _ Distr _ 1SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg1+Distr	
+_ 4Sg _ Distr _ 2SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg2+Distr	
+_ 4Sg _ Distr _ 3SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg3+Distr	
+_ 4Sg _ Distr _ 4SgO	${lemma}+V+T+Prog+SbjSg4+DObjSg4+Distr	
+_ 4Sg _ Distr _ 1PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl1+Distr	
+_ 4Sg _ Distr _ 2PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl2+Distr	
+_ 4Sg _ Distr _ 3PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl3+Distr	
+_ 4Sg _ Distr _ 4PlO	${lemma}+V+T+Prog+SbjSg4+DObjPl4+Distr	
 			
 			
 		| Ipfv | Rep	| Pfv | Rep
-_ 1Sg 	_ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg1
-_ 1Sg 	_ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg2
-_ 1Sg 	_ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg3
-_ 1Sg 	_ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg4
-_ 1Sg 	_ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl1
-_ 1Sg 	_ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl2
-_ 1Sg 	_ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl3
-_ 1Sg 	_ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl4
+_ 1Sg _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg1
+_ 1Sg _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg2
+_ 1Sg _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg3
+_ 1Sg _ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjSg4
+_ 1Sg _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl1
+_ 1Sg _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl2
+_ 1Sg _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl3
+_ 1Sg _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjSg1+DObjPl4
 			
-_ 2Sg 	_ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg1
-_ 2Sg 	_ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg2
-_ 2Sg 	_ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg3
-_ 2Sg 	_ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg4
-_ 2Sg 	_ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl1
-_ 2Sg 	_ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl2
-_ 2Sg 	_ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl3
-_ 2Sg 	_ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl4
+_ 2Sg _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg1
+_ 2Sg _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg2
+_ 2Sg _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg3
+_ 2Sg _ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjSg4
+_ 2Sg _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl1
+_ 2Sg _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl2
+_ 2Sg _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl3
+_ 2Sg _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjSg2+DObjPl4
 			
-_ 3Sg 	_ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg1
-_ 3Sg 	_ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg2
-_ 3Sg 	_ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg3
-_ 3Sg 	_ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg4
-_ 3Sg 	_ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl1
-_ 3Sg 	_ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl2
-_ 3Sg 	_ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl3
-_ 3Sg 	_ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl4
+_ 3Sg _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg1
+_ 3Sg _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg2
+_ 3Sg _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg3
+_ 3Sg _ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjSg4
+_ 3Sg _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl1
+_ 3Sg _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl2
+_ 3Sg _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl3
+_ 3Sg _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjSg3+DObjPl4
 			
-_ 1Pl 	_ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg1
-_ 1Pl 	_ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg2
-_ 1Pl 	_ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg3
-_ 1Pl 	_ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg4
-_ 1Pl 	_ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl1
-_ 1Pl 	_ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl2
-_ 1Pl 	_ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl3
-_ 1Pl 	_ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl4
+_ 1Pl _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg1
+_ 1Pl _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg2
+_ 1Pl _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg3
+_ 1Pl _ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg4
+_ 1Pl _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl1
+_ 1Pl _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl2
+_ 1Pl _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl3
+_ 1Pl _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl4
 			
-_ 2Pl 	_ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg1
-_ 2Pl 	_ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg2
-_ 2Pl 	_ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg3
-_ 2Pl 	_ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg4
-_ 2Pl 	_ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl1
-_ 2Pl 	_ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl2
-_ 2Pl 	_ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl3
-_ 2Pl 	_ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl4
+_ 2Pl _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg1
+_ 2Pl _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg2
+_ 2Pl _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg3
+_ 2Pl _ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg4
+_ 2Pl _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl1
+_ 2Pl _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl2
+_ 2Pl _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl3
+_ 2Pl _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl4
 			
-_ 3Pl 	_ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg1
-_ 3Pl 	_ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg2
-_ 3Pl 	_ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg3
-_ 3Pl 	_ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg4
-_ 3Pl 	_ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl1
-_ 3Pl 	_ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl2
-_ 3Pl 	_ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl3
-_ 3Pl 	_ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl4
+_ 3Pl _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg1
+_ 3Pl _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg2
+_ 3Pl _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg3
+_ 3Pl _ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg4
+_ 3Pl _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl1
+_ 3Pl _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl2
+_ 3Pl _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl3
+_ 3Pl _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl4
 			
-_ 4Sg 	_ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg1
-_ 4Sg 	_ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg2
-_ 4Sg 	_ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg3
-_ 4Sg 	_ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg4
-_ 4Sg 	_ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl1
-_ 4Sg 	_ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl2
-_ 4Sg 	_ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl3
-_ 4Sg 	_ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl4
+_ 4Sg _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg1	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg1
+_ 4Sg _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg2	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg2
+_ 4Sg _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg3	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg3
+_ 4Sg _ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg4	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg4
+_ 4Sg _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl1	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl1
+_ 4Sg _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl2	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl2
+_ 4Sg _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl3	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl3
+_ 4Sg _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl4	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl4
 			
-_ 1Pl _ Distr 	_ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg1+Distr
-_ 1Pl _ Distr 	_ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg2+Distr
-_ 1Pl _ Distr 	_ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg3+Distr
-_ 1Pl _ Distr 	_ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg4+Distr
-_ 1Pl _ Distr 	_ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl1+Distr
-_ 1Pl _ Distr 	_ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl2+Distr
-_ 1Pl _ Distr 	_ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl3+Distr
-_ 1Pl _ Distr 	_ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl4+Distr
+_ 1Pl _ Distr _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg1+Distr
+_ 1Pl _ Distr _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg2+Distr
+_ 1Pl _ Distr _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg3+Distr
+_ 1Pl _ Distr _ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjSg4+Distr
+_ 1Pl _ Distr _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl1+Distr
+_ 1Pl _ Distr _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl2+Distr
+_ 1Pl _ Distr _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl3+Distr
+_ 1Pl _ Distr _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl1+DObjPl4+Distr
 			
-_ 2Pl _ Distr 	_ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg1+Distr
-_ 2Pl _ Distr 	_ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg2+Distr
-_ 2Pl _ Distr 	_ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg3+Distr
-_ 2Pl _ Distr 	_ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg4+Distr
-_ 2Pl _ Distr 	_ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl1+Distr
-_ 2Pl _ Distr 	_ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl2+Distr
-_ 2Pl _ Distr 	_ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl3+Distr
-_ 2Pl _ Distr 	_ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl4+Distr
+_ 2Pl _ Distr _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg1+Distr
+_ 2Pl _ Distr _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg2+Distr
+_ 2Pl _ Distr _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg3+Distr
+_ 2Pl _ Distr _ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjSg4+Distr
+_ 2Pl _ Distr _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl1+Distr
+_ 2Pl _ Distr _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl2+Distr
+_ 2Pl _ Distr _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl3+Distr
+_ 2Pl _ Distr _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl2+DObjPl4+Distr
 			
-_ 3Pl _ Distr 	_ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg1+Distr
-_ 3Pl _ Distr 	_ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg2+Distr
-_ 3Pl _ Distr 	_ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg3+Distr
-_ 3Pl _ Distr 	_ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg4+Distr
-_ 3Pl _ Distr 	_ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl1+Distr
-_ 3Pl _ Distr 	_ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl2+Distr
-_ 3Pl _ Distr 	_ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl3+Distr
-_ 3Pl _ Distr 	_ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl4+Distr
+_ 3Pl _ Distr _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg1+Distr
+_ 3Pl _ Distr _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg2+Distr
+_ 3Pl _ Distr _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg3+Distr
+_ 3Pl _ Distr _ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjSg4+Distr
+_ 3Pl _ Distr _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl1+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl1+Distr
+_ 3Pl _ Distr _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl2+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl2+Distr
+_ 3Pl _ Distr _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl3+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl3+Distr
+_ 3Pl _ Distr _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl4+Distr	${lemma}+V+T+Ipfv+Rep+SbjPl3+DObjPl4+Distr
 			
-_ 4Sg _ Distr 	_ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg1+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg1+Distr
-_ 4Sg _ Distr 	_ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg2+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg2+Distr
-_ 4Sg _ Distr 	_ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg3+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg3+Distr
-_ 4Sg _ Distr 	_ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg4+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg4+Distr
-_ 4Sg _ Distr 	_ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl1+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl1+Distr
-_ 4Sg _ Distr 	_ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl2+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl2+Distr
-_ 4Sg _ Distr 	_ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl3+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl3+Distr
-_ 4Sg _ Distr 	_ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl4+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl4+Distr
+_ 4Sg _ Distr _ 1SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg1+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg1+Distr
+_ 4Sg _ Distr _ 2SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg2+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg2+Distr
+_ 4Sg _ Distr _ 3SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg3+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg3+Distr
+_ 4Sg _ Distr _ 4SgO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg4+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjSg4+Distr
+_ 4Sg _ Distr _ 1PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl1+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl1+Distr
+_ 4Sg _ Distr _ 2PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl2+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl2+Distr
+_ 4Sg _ Distr _ 3PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl3+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl3+Distr
+_ 4Sg _ Distr _ 4PlO	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl4+Distr	${lemma}+V+T+Ipfv+Rep+SbjSg4+DObjPl4+Distr
 			
 			
 		| Pot	
-_ 1Sg 	_ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjSg1	
-_ 1Sg 	_ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjSg2	
-_ 1Sg 	_ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjSg3	
-_ 1Sg 	_ 4SgO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjSg4	
-_ 1Sg 	_ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjPl1	
-_ 1Sg 	_ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjPl2	
-_ 1Sg 	_ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjPl3	
-_ 1Sg 	_ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjPl4	
+_ 1Sg _ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjSg1	
+_ 1Sg _ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjSg2	
+_ 1Sg _ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjSg3	
+_ 1Sg _ 4SgO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjSg4	
+_ 1Sg _ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjPl1	
+_ 1Sg _ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjPl2	
+_ 1Sg _ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjPl3	
+_ 1Sg _ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg1+DObjPl4	
 			
-_ 2Sg 	_ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjSg1	
-_ 2Sg 	_ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjSg2	
-_ 2Sg 	_ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjSg3	
-_ 2Sg 	_ 4SgO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjSg4	
-_ 2Sg 	_ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjPl1	
-_ 2Sg 	_ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjPl2	
-_ 2Sg 	_ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjPl3	
-_ 2Sg 	_ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjPl4	
+_ 2Sg _ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjSg1	
+_ 2Sg _ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjSg2	
+_ 2Sg _ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjSg3	
+_ 2Sg _ 4SgO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjSg4	
+_ 2Sg _ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjPl1	
+_ 2Sg _ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjPl2	
+_ 2Sg _ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjPl3	
+_ 2Sg _ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg2+DObjPl4	
 			
-_ 3Sg 	_ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjSg1	
-_ 3Sg 	_ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjSg2	
-_ 3Sg 	_ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjSg3	
-_ 3Sg 	_ 4SgO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjSg4	
-_ 3Sg 	_ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjPl1	
-_ 3Sg 	_ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjPl2	
-_ 3Sg 	_ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjPl3	
-_ 3Sg 	_ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjPl4	
+_ 3Sg _ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjSg1	
+_ 3Sg _ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjSg2	
+_ 3Sg _ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjSg3	
+_ 3Sg _ 4SgO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjSg4	
+_ 3Sg _ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjPl1	
+_ 3Sg _ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjPl2	
+_ 3Sg _ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjPl3	
+_ 3Sg _ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg3+DObjPl4	
 			
-_ 1Pl 	_ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg1	
-_ 1Pl 	_ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg2	
-_ 1Pl 	_ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg3	
-_ 1Pl 	_ 4SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg4	
-_ 1Pl 	_ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl1	
-_ 1Pl 	_ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl2	
-_ 1Pl 	_ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl3	
-_ 1Pl 	_ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl4	
+_ 1Pl _ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg1	
+_ 1Pl _ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg2	
+_ 1Pl _ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg3	
+_ 1Pl _ 4SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg4	
+_ 1Pl _ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl1	
+_ 1Pl _ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl2	
+_ 1Pl _ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl3	
+_ 1Pl _ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl4	
 			
-_ 2Pl 	_ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg1	
-_ 2Pl 	_ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg2	
-_ 2Pl 	_ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg3	
-_ 2Pl 	_ 4SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg4	
-_ 2Pl 	_ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl1	
-_ 2Pl 	_ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl2	
-_ 2Pl 	_ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl3	
-_ 2Pl 	_ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl4	
+_ 2Pl _ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg1	
+_ 2Pl _ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg2	
+_ 2Pl _ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg3	
+_ 2Pl _ 4SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg4	
+_ 2Pl _ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl1	
+_ 2Pl _ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl2	
+_ 2Pl _ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl3	
+_ 2Pl _ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl4	
 			
-_ 3Pl 	_ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg1	
-_ 3Pl 	_ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg2	
-_ 3Pl 	_ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg3	
-_ 3Pl 	_ 4SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg4	
-_ 3Pl 	_ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl1	
-_ 3Pl 	_ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl2	
-_ 3Pl 	_ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl3	
-_ 3Pl 	_ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl4	
+_ 3Pl _ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg1	
+_ 3Pl _ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg2	
+_ 3Pl _ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg3	
+_ 3Pl _ 4SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg4	
+_ 3Pl _ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl1	
+_ 3Pl _ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl2	
+_ 3Pl _ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl3	
+_ 3Pl _ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl4	
 			
-_ 4Sg 	_ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg1	
-_ 4Sg 	_ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg2	
-_ 4Sg 	_ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg3	
-_ 4Sg 	_ 4SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg4	
-_ 4Sg 	_ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl1	
-_ 4Sg 	_ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl2	
-_ 4Sg 	_ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl3	
-_ 4Sg 	_ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl4	
+_ 4Sg _ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg1	
+_ 4Sg _ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg2	
+_ 4Sg _ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg3	
+_ 4Sg _ 4SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg4	
+_ 4Sg _ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl1	
+_ 4Sg _ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl2	
+_ 4Sg _ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl3	
+_ 4Sg _ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl4	
 			
-_ 1Pl _ Distr 	_ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg1+Distr	
-_ 1Pl _ Distr 	_ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg2+Distr	
-_ 1Pl _ Distr 	_ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg3+Distr	
-_ 1Pl _ Distr 	_ 4SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg4+Distr	
-_ 1Pl _ Distr 	_ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl1+Distr	
-_ 1Pl _ Distr 	_ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl2+Distr	
-_ 1Pl _ Distr 	_ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl3+Distr	
-_ 1Pl _ Distr 	_ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl4+Distr	
+_ 1Pl _ Distr _ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg1+Distr	
+_ 1Pl _ Distr _ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg2+Distr	
+_ 1Pl _ Distr _ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg3+Distr	
+_ 1Pl _ Distr _ 4SgO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjSg4+Distr	
+_ 1Pl _ Distr _ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl1+Distr	
+_ 1Pl _ Distr _ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl2+Distr	
+_ 1Pl _ Distr _ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl3+Distr	
+_ 1Pl _ Distr _ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl1+DObjPl4+Distr	
 			
-_ 2Pl _ Distr 	_ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg1+Distr	
-_ 2Pl _ Distr 	_ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg2+Distr	
-_ 2Pl _ Distr 	_ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg3+Distr	
-_ 2Pl _ Distr 	_ 4SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg4+Distr	
-_ 2Pl _ Distr 	_ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl1+Distr	
-_ 2Pl _ Distr 	_ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl2+Distr	
-_ 2Pl _ Distr 	_ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl3+Distr	
-_ 2Pl _ Distr 	_ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl4+Distr	
+_ 2Pl _ Distr _ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg1+Distr	
+_ 2Pl _ Distr _ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg2+Distr	
+_ 2Pl _ Distr _ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg3+Distr	
+_ 2Pl _ Distr _ 4SgO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjSg4+Distr	
+_ 2Pl _ Distr _ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl1+Distr	
+_ 2Pl _ Distr _ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl2+Distr	
+_ 2Pl _ Distr _ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl3+Distr	
+_ 2Pl _ Distr _ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl2+DObjPl4+Distr	
 			
-_ 3Pl _ Distr 	_ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg1+Distr	
-_ 3Pl _ Distr 	_ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg2+Distr	
-_ 3Pl _ Distr 	_ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg3+Distr	
-_ 3Pl _ Distr 	_ 4SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg4+Distr	
-_ 3Pl _ Distr 	_ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl1+Distr	
-_ 3Pl _ Distr 	_ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl2+Distr	
-_ 3Pl _ Distr 	_ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl3+Distr	
-_ 3Pl _ Distr 	_ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl4+Distr	
+_ 3Pl _ Distr _ 1SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg1+Distr	
+_ 3Pl _ Distr _ 2SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg2+Distr	
+_ 3Pl _ Distr _ 3SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg3+Distr	
+_ 3Pl _ Distr _ 4SgO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjSg4+Distr	
+_ 3Pl _ Distr _ 1PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl1+Distr	
+_ 3Pl _ Distr _ 2PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl2+Distr	
+_ 3Pl _ Distr _ 3PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl3+Distr	
+_ 3Pl _ Distr _ 4PlO	${lemma}+V+T+Pot+Rep+SbjPl3+DObjPl4+Distr	
 			
-_ 4Sg _ Distr 	_ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg1+Distr	
-_ 4Sg _ Distr 	_ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg2+Distr	
-_ 4Sg _ Distr 	_ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg3+Distr	
-_ 4Sg _ Distr 	_ 4SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg4+Distr	
-_ 4Sg _ Distr 	_ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl1+Distr	
-_ 4Sg _ Distr 	_ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl2+Distr	
-_ 4Sg _ Distr 	_ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl3+Distr	
-_ 4Sg _ Distr 	_ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl4+Distr	
+_ 4Sg _ Distr _ 1SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg1+Distr	
+_ 4Sg _ Distr _ 2SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg2+Distr	
+_ 4Sg _ Distr _ 3SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg3+Distr	
+_ 4Sg _ Distr _ 4SgO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjSg4+Distr	
+_ 4Sg _ Distr _ 1PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl1+Distr	
+_ 4Sg _ Distr _ 2PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl2+Distr	
+_ 4Sg _ Distr _ 3PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl3+Distr	
+_ 4Sg _ Distr _ 4PlO	${lemma}+V+T+Pot+Rep+SbjSg4+DObjPl4+Distr	


### PR DESCRIPTION
Implements the following for transitive verb paradigms (VT.tsv):

1. Combines subject and object row names columns into a single column in `VT.tsv`, for more visually pleasing output.
2. Includes relabelings for the resultant tag combinations in `altlabel.tsv`

The aggregate relabeling is based on individual tag relabelings, with the following GAWK script:

```
cat rc/srseng/resources/layouts/VT.tsv | gawk -F"\t" 'BEGIN { while((getline < "src/srseng/resources/altlabel.tsv")!=0) { lings[$1]=$2; lingl[$1]=$3; eng[$1]=$4; srs[$1]=$5; } } $1!="" { sub("^_ ","",$1); sub("^_ ","",$2); str=$1 " " $2; sub(" _ ", "+", str); split(str,tags," "); print tags[1] "+" tags[2] "\t" lings[tags[1]] " → " lings[tags[2]] "\t" lingl[tags[1]] " → " lingl[tags[2]] "\t" eng[tags[1]] " " eng[tags[2]] "\t" srs[tags[1]] " " srs[tags[2]]; }' | sort -u | less
```
This could always be done differently/more elegantly.